### PR TITLE
Effiziente Instanziierung von Objekten

### DIFF
--- a/python/boomer/algorithm/_example_wise_losses.pyx
+++ b/python/boomer/algorithm/_example_wise_losses.pyx
@@ -27,7 +27,7 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
                                          more conservative, setting it to 0 turns of L2 regularization entirely
         """
         self.l2_regularization_weight = l2_regularization_weight
-        self.prediction = LabelIndependentPrediction()
+        self.prediction = LabelIndependentPrediction.__new__(LabelIndependentPrediction)
         self.sums_of_gradients = None
         self.sums_of_hessians = None
 

--- a/python/boomer/algorithm/_head_refinement.pyx
+++ b/python/boomer/algorithm/_head_refinement.pyx
@@ -99,7 +99,8 @@ cdef class FullHeadRefinement(HeadRefinement):
             for c in range(num_labels):
                 candidate_predicted_scores[c] = predicted_scores[c]
 
-            candidate = HeadCandidate(label_indices, candidate_predicted_scores, overall_quality_score)
+            candidate = HeadCandidate.__new__(HeadCandidate, label_indices, candidate_predicted_scores,
+                                              overall_quality_score)
             return candidate
         else:
             # The quality score must be better than that of `best_head`...
@@ -151,7 +152,8 @@ cdef class SingleLabelHeadRefinement(HeadRefinement):
             candidate_label_indices[0] = get_index(best_c, label_indices)
             candidate_predicted_scores = array_float64(1)
             candidate_predicted_scores[0] = predicted_scores[best_c]
-            candidate = HeadCandidate(candidate_label_indices, candidate_predicted_scores, best_quality_score)
+            candidate = HeadCandidate.__new__(HeadCandidate, candidate_label_indices, candidate_predicted_scores,
+                                              best_quality_score)
             return candidate
         else:
             # The quality score must be better than that of `best_head`...

--- a/python/boomer/algorithm/_label_wise_losses.pyx
+++ b/python/boomer/algorithm/_label_wise_losses.pyx
@@ -52,7 +52,7 @@ cdef class LabelWiseLoss(DecomposableLoss):
                                          more conservative, setting it to 0 turns of L2 regularization entirely
         """
         self.l2_regularization_weight = l2_regularization_weight
-        self.prediction = LabelIndependentPrediction()
+        self.prediction = LabelIndependentPrediction.__new__(LabelIndependentPrediction)
         self.sums_of_gradients = None
         self.sums_of_hessians = None
 

--- a/python/boomer/algorithm/_rule_induction.pyx
+++ b/python/boomer/algorithm/_rule_induction.pyx
@@ -35,8 +35,8 @@ cpdef Rule induce_default_rule(uint8[::1, :] y, Loss loss):
     :return:        The default rule that has been induced
     """
     cdef float64[::1] scores = loss.calculate_default_scores(y)
-    cdef FullHead head = FullHead(scores)
-    cdef EmptyBody body = EmptyBody()
+    cdef FullHead head = FullHead.__new__(FullHead, scores)
+    cdef EmptyBody body = EmptyBody.__new__(EmptyBody)
     cdef Rule rule = Rule(body, head)
     return rule
 
@@ -371,16 +371,16 @@ cdef Rule __build_rule(HeadCandidate head, list[s_condition] conditions,  intp n
 
         postincrement(iterator)
 
-    cdef ConjunctiveBody rule_body = ConjunctiveBody(leq_feature_indices, leq_thresholds, gr_feature_indices,
-                                                     gr_thresholds)
+    cdef ConjunctiveBody rule_body = ConjunctiveBody.__new__(ConjunctiveBody, leq_feature_indices, leq_thresholds,
+                                                             gr_feature_indices, gr_thresholds)
     cdef Head rule_head
 
     if head.label_indices is None:
-        rule_head = FullHead(head.predicted_scores)
+        rule_head = FullHead.__new__(FullHead, head.predicted_scores)
     else:
-        rule_head = PartialHead(head.label_indices, head.predicted_scores)
+        rule_head = PartialHead.__new__(PartialHead, head.label_indices, head.predicted_scores)
 
-    cdef Rule rule = Rule(rule_body, rule_head)
+    cdef Rule rule = Rule.__new__(Rule, rule_body, rule_head)
     return rule
 
 


### PR DESCRIPTION
Laut der [Cython-Dokumentation](https://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#fast-instantiation) sollte man Objekte mit 
```
Object.__new__(Object, params)
```
statt mit
```
Object(params)
```
instanziieren. Durch diesen Pull-Request wird für jede Objekt-Instanziierung im Cython-Code die empfohlene Methode verwendet.

Pull-Request #33 wendet die Änderung auch auf den "seco"-Branch an.