### PR TITLE
Attribut "l2_regularization_weight" aus Loss-Klasse entfernen

### DIFF
--- a/python/boomer/algorithm/_example_wise_losses.pxd
+++ b/python/boomer/algorithm/_example_wise_losses.pxd
@@ -6,6 +6,8 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
 
     # Attributes:
 
+    cdef readonly float64 l2_regularization_weight
+
     cdef float64[::1, :] expected_scores
 
     cdef float64[::1, :] current_scores

--- a/python/boomer/algorithm/_label_wise_losses.pxd
+++ b/python/boomer/algorithm/_label_wise_losses.pxd
@@ -6,6 +6,8 @@ cdef class LabelWiseLoss(DecomposableLoss):
 
     # Attributes:
 
+    cdef readonly float64 l2_regularization_weight
+
     cdef float64[::1, :] expected_scores
 
     cdef float64[::1, :] current_scores

--- a/python/boomer/algorithm/_losses.pxd
+++ b/python/boomer/algorithm/_losses.pxd
@@ -19,10 +19,6 @@ cdef class LabelIndependentPrediction(Prediction):
 
 cdef class Loss:
 
-    # Attributes:
-
-    cdef readonly float64 l2_regularization_weight
-
     # Functions:
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)


### PR DESCRIPTION
Entfernt das Attribute `l2_regularization_weight` aus der Klasse `Loss`, da es nicht von allen Subklassen verwendet wird. Stattdessen wird es in den Klassen in denen es tatsächlich verwendet wird (`LabelWiseLoss` und `ExamleWiseLogisticLoss` deklariert).