### PR TITLE
Konfiguration von Boomer und SeCo-Algorithmus vereinheitlichen

### DIFF
--- a/python/boomer/algorithm/rule_learners.py
+++ b/python/boomer/algorithm/rule_learners.py
@@ -94,14 +94,14 @@ def _create_pruning(pruning: str) -> Pruning:
     raise ValueError('Invalid value given for parameter \'pruning\': ' + str(pruning))
 
 
-def _create_stopping_criteria(num_rules: int, time_limit: int) -> List[StoppingCriterion]:
+def _create_stopping_criteria(max_rules: int, time_limit: int) -> List[StoppingCriterion]:
     stopping_criteria: List[StoppingCriterion] = []
 
-    if num_rules != -1:
-        if num_rules > 0:
-            stopping_criteria.append(SizeStoppingCriterion(num_rules))
+    if max_rules != -1:
+        if max_rules > 0:
+            stopping_criteria.append(SizeStoppingCriterion(max_rules))
         else:
-            raise ValueError('Invalid value given for parameter \'num_rules\': ' + str(num_rules))
+            raise ValueError('Invalid value given for parameter \'max_rules\': ' + str(max_rules))
 
     if time_limit != -1:
         if time_limit > 0:
@@ -177,13 +177,13 @@ class Boomer(MLRuleLearner):
     classification rules.
     """
 
-    def __init__(self, model_dir: str = None, num_rules: int = 1000, time_limit: int = -1, head_refinement: str = None,
+    def __init__(self, model_dir: str = None, max_rules: int = 1000, time_limit: int = -1, head_refinement: str = None,
                  loss: str = LOSS_LABEL_WISE_LOGISTIC, label_sub_sampling: int = -1,
                  instance_sub_sampling: str = INSTANCE_SUB_SAMPLING_BAGGING,
                  feature_sub_sampling: str = FEATURE_SUB_SAMPLING_RANDOM,
                  pruning: str = None, shrinkage: float = 0.3, l2_regularization_weight: float = 1.0):
         """
-        :param num_rules:                   The number of rules to be induced (including the default rule)
+        :param max_rules:                   The maximum number of rules to be induced (including the default rule)
         :param time_limit:                  The duration in seconds after which the induction of rules should be
                                             canceled
         :param head_refinement:             The strategy that is used to find the heads of rules. Must be
@@ -207,7 +207,7 @@ class Boomer(MLRuleLearner):
                                             scores that are predicted by rules. Must be at least 0
         """
         super().__init__(model_dir)
-        self.num_rules = num_rules
+        self.max_rules = max_rules
         self.time_limit = time_limit
         self.head_refinement = head_refinement
         self.loss = loss
@@ -222,7 +222,7 @@ class Boomer(MLRuleLearner):
         return 'boomer'
 
     def get_name(self) -> str:
-        name = 'num-rules=' + str(self.num_rules)
+        name = 'max-rules=' + str(self.max_rules)
         if self.head_refinement is not None:
             name += '_head-refinement=' + str(self.head_refinement)
         name += '_loss=' + str(self.loss)
@@ -243,7 +243,7 @@ class Boomer(MLRuleLearner):
     def get_params(self, deep=True):
         params = super().get_params()
         params.update({
-            'num_rules': self.num_rules,
+            'max_rules': self.max_rules,
             'time_limit': self.time_limit,
             'head_refinement': self.head_refinement,
             'loss': self.loss,
@@ -260,7 +260,7 @@ class Boomer(MLRuleLearner):
         return Sign(LinearCombination())
 
     def _create_rule_induction(self, stats: Stats) -> RuleInduction:
-        stopping_criteria = _create_stopping_criteria(int(self.num_rules), int(self.time_limit))
+        stopping_criteria = _create_stopping_criteria(int(self.max_rules), int(self.time_limit))
         l2_regularization_weight = self.__create_l2_regularization_weight()
         loss = self.__create_loss(l2_regularization_weight)
         head_refinement = self.__create_head_refinement(loss)
@@ -319,11 +319,11 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
     classification rules.
     """
 
-    def __init__(self, model_dir: str = None, num_rules: int = 500, time_limit: int = -1, head_refinement: str = None,
+    def __init__(self, model_dir: str = None, max_rules: int = 500, time_limit: int = -1, head_refinement: str = None,
                  loss: str = MEASURE_LABEL_WISE, heuristic: str = HEURISTIC_PRECISION, label_sub_sampling: int = -1,
                  instance_sub_sampling: str = None, feature_sub_sampling: str = None, pruning: str = None):
         """
-        :param num_rules:                   The maximum number of rules to be induced (including the default rule)
+        :param max_rules:                   The maximum number of rules to be induced (including the default rule)
         :param time_limit:                  The duration in seconds after which the induction of rules should be
                                             canceled
         :param head_refinement:             The strategy that is used to find the heads of rules. Must be
@@ -343,7 +343,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
                                             pruning should be used
         """
         super().__init__(model_dir)
-        self.num_rules = num_rules
+        self.max_rules = max_rules
         self.time_limit = time_limit
         self.head_refinement = head_refinement
         self.loss = loss
@@ -357,7 +357,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
         return 'seco'
 
     def get_name(self) -> str:
-        name = 'num-rules=' + str(self.num_rules)
+        name = 'max-rules=' + str(self.max_rules)
         if self.head_refinement is not None:
             name += '_head-refinement=' + str(self.head_refinement)
         name += '_loss=' + str(self.loss)
@@ -375,7 +375,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
     def get_params(self, deep=True):
         params = super().get_params()
         params.update({
-            'num_rules': self.num_rules,
+            'max_rules': self.max_rules,
             'time_limit': self.time_limit,
             'head_refinement': self.head_refinement,
             'loss': self.loss,
@@ -395,7 +395,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
         instance_sub_sampling = _create_instance_sub_sampling(str(self.instance_sub_sampling))
         feature_sub_sampling = _create_feature_sub_sampling(str(self.feature_sub_sampling))
         pruning = _create_pruning(str(self.pruning))
-        stopping_criteria = _create_stopping_criteria(int(self.num_rules), int(self.time_limit))
+        stopping_criteria = _create_stopping_criteria(int(self.max_rules), int(self.time_limit))
         stopping_criteria.append(UncoveredLabelsCriterion(loss, 0))
         return SeparateAndConquer(head_refinement, loss, label_sub_sampling, instance_sub_sampling,
                                   feature_sub_sampling, pruning, *stopping_criteria)

--- a/python/boomer/algorithm/stopping_criteria.py
+++ b/python/boomer/algorithm/stopping_criteria.py
@@ -10,8 +10,8 @@ from abc import abstractmethod, ABC
 from timeit import default_timer as timer
 
 import numpy as np
-
 from boomer.algorithm._label_wise_measure import LabelWiseMeasure
+
 from boomer.algorithm.model import Theory
 
 
@@ -37,14 +37,14 @@ class SizeStoppingCriterion(StoppingCriterion):
     A stopping criterion that ensures that the number of rules in a theory does not exceed a certain maximum.
     """
 
-    def __init__(self, num_rules: int):
+    def __init__(self, max_rules: int):
         """
-        :param num_rules: The maximum number of rules
+        :param max_rules: The maximum number of rules
         """
-        self.num_rules = num_rules
+        self.max_rules = max_rules
 
     def should_continue(self, theory: Theory) -> bool:
-        return len(theory) < self.num_rules
+        return len(theory) < self.max_rules
 
 
 class TimeStoppingCriterion(StoppingCriterion):

--- a/python/main_boomer.py
+++ b/python/main_boomer.py
@@ -23,7 +23,7 @@ def configure_argument_parser(p: argparse.ArgumentParser):
     p.add_argument('--folds', type=int, default=1, help='Total number of folds to be used by cross validation')
     p.add_argument('--current-fold', type=current_fold_string, default=-1,
                    help='The cross validation fold to be performed')
-    p.add_argument('--num-rules', type=int, default=1000, help='The number of rules to be induced or -1')
+    p.add_argument('--max-rules', type=int, default=500, help='The maximum number of rules to be induced or -1')
     p.add_argument('--time-limit', type=int, default=-1,
                    help='The duration in seconds after which the induction of rules should be canceled or -1')
     p.add_argument('--label-sub-sampling', type=int, default=-1,
@@ -44,7 +44,7 @@ def configure_argument_parser(p: argparse.ArgumentParser):
 
 
 def create_learner(params) -> Boomer:
-    return Boomer(model_dir=params.model_dir, num_rules=params.num_rules, time_limit=params.time_limit,
+    return Boomer(model_dir=params.model_dir, max_rules=params.max_rules, time_limit=params.time_limit,
                   loss=params.loss, pruning=params.pruning, label_sub_sampling=params.label_sub_sampling,
                   instance_sub_sampling=params.instance_sub_sampling, shrinkage=params.shrinkage,
                   feature_sub_sampling=params.feature_sub_sampling, head_refinement=params.head_refinement,

--- a/python/main_seco.py
+++ b/python/main_seco.py
@@ -23,7 +23,7 @@ def configure_argument_parser(p: argparse.ArgumentParser):
     p.add_argument('--folds', type=int, default=1, help='Total number of folds to be used by cross validation')
     p.add_argument('--current-fold', type=current_fold_string, default=-1,
                    help='The cross validation fold to be performed')
-    p.add_argument('--num-rules', type=int, default=500, help='The number of rules to be induced or -1')
+    p.add_argument('--max-rules', type=int, default=500, help='The maximum number of rules to be induced or -1')
     p.add_argument('--time-limit', type=int, default=-1,
                    help='The duration in seconds after which the induction of rules should be canceled or -1')
     p.add_argument('--label-sub-sampling', type=int, default=-1,
@@ -42,7 +42,7 @@ def configure_argument_parser(p: argparse.ArgumentParser):
 
 
 def create_learner(params) -> SeparateAndConquerRuleLearner:
-    return SeparateAndConquerRuleLearner(model_dir=params.model_dir, num_rules=params.num_rules,
+    return SeparateAndConquerRuleLearner(model_dir=params.model_dir, max_rules=params.max_rules,
                                          time_limit=params.time_limit, loss=params.loss, heuristic=params.heuristic,
                                          pruning=params.pruning, label_sub_sampling=params.label_sub_sampling,
                                          instance_sub_sampling=params.instance_sub_sampling,


### PR DESCRIPTION
In Pull Request #30 wurden Konstanten für die möglichen Parameterwerte des Boomer-Algorithmus eingeführt. Diese werden hierdurch auch für den Seco-Algorithmus verwendet. Für Hyperparameter, die für beide Algorithmen gleich sind, wurde außerdem der Code vereinheitlicht.

Außerdem sind folgende Änderungen enthalten:

* Kommandozeilenargument "--heuristic" in `main_seco.py` hinzugefügt.
* Der Parameter "max_rules" des SeCo-Algorithmus wurde in "num_rules" umbenannt, damit die Benennung für beide Algorithmen die selbe ist.
* Die Klassen `Boomer` und `SeparateAndConquerRuleLearner` überschreiben jetzt die Funktion `get_model_prefix` damit man unterscheiden kann ob ein als Datei abgespeichertes Modell mit dem einen oder dem anderen Algorithmus trainiert wurde.
* Die Klasse `SeparateAndConquerRuleLearner` implementiert jetzt die Funktion `get_params`. Das ist notwendig damit die Parametereinstellungen nicht auf den Standardwert zurückgesetzt werden wenn der Klassifizierer kopiert wird (passiert z.B. von Fold zu Fold bei einer Cross Validation)
* Die Funktion `get_name` in der Klasse `SeparateAndConquerRuleLearner` integriert jetzt die Parameterwerte im Namen. Das ist wichtig um nachvollziehen zu können mit welchen Einstellungen ein Modell trainiert wurde, wenn es in einer Datei abgespeichert wird.