### PR TITLE
Kleine Optimierungen in Klasse LabelWiseMeasure

### DIFF
--- a/python/boomer/algorithm/_label_wise_measure.pyx
+++ b/python/boomer/algorithm/_label_wise_measure.pyx
@@ -136,8 +136,9 @@ cdef class LabelWiseMeasure(DecomposableLoss):
         cdef float64[::1, :] confusion_matrices_covered = self.confusion_matrices_covered
         cdef intp[::1] label_indices = self.label_indices
         cdef intp num_labels = confusion_matrices_covered.shape[0]
+        cdef uint32 predicted_label
+        cdef uint8 true_label
         cdef intp c, l
-        cdef uint8 true_label, predicted_label
 
         for c in range(num_labels):
             l = get_index(c, label_indices)


### PR DESCRIPTION
Bei der Fehlersuche sind mir noch einige klitzekleine Kleinigkeiten in der Klasse `LabelWiseMeasure` aufgefallen, die hiermit behoben/verbessert werden. Nichts davon ist kritisch oder führt zu Problemen.

* Einige `cdef`-Definition fehlen oder haben den falschen Typ (wobei letzteres mein Fehler war)
* Einige Zeilen können weggelassen werden, da sie Variablen/Arrayeinträge initialisieren die anschließend sowieso wieder überschrieben werden
* An einer Stelle kann man auf einen unnötigen Zugriff auf eine Klassenvariable verzichten