### PR TITLE
[Test] Boolean-Arrays

### DIFF
--- a/python/boomer/algorithm/_arrays.pxd
+++ b/python/boomer/algorithm/_arrays.pxd
@@ -17,10 +17,12 @@ DEF MODE_C_CONTIGUOUS = 'c'
 DEF MODE_FORTRAN_CONTIGUOUS = 'fortran'
 
 IF UNAME_SYSNAME == 'Windows':
+    DEF FORMAT_UINT8 = '?'
     DEF FORMAT_UINT32 = 'I'
     DEF FORMAT_INTP = 'q'
     DEF FORMAT_FLOAT64 = 'd'
 ELSE:
+    DEF FORMAT_UINT8 = 'B'
     DEF FORMAT_UINT32 = 'I'
     DEF FORMAT_INTP = 'l'
     DEF FORMAT_FLOAT64 = 'd'
@@ -35,6 +37,18 @@ cdef inline cvarray array_intp(intp num_elements):
     cdef tuple shape = tuple([num_elements])
     cdef intp itemsize = sizeof(intp)
     cdef cvarray array = cvarray(shape, itemsize, FORMAT_INTP, MODE_C_CONTIGUOUS)
+    return array
+
+cdef inline cvarray array_uint8(intp num_elements):
+    """
+    Creates and returns a new C-contiguous array of dtype `uint8`, shape `(num_elements)`.
+
+    :param num_elements:    The number of elements in the array
+    :return:                The array that has been created
+    """
+    cdef tuple shape = tuple([num_elements])
+    cdef intp itemsize = sizeof(uint8)
+    cdef cvarray array = cvarray(shape, itemsize, FORMAT_UINT8, MODE_C_CONTIGUOUS)
     return array
 
 cdef inline cvarray array_uint32(intp num_elements):

--- a/python/boomer/algorithm/_label_wise_measure.pxd
+++ b/python/boomer/algorithm/_label_wise_measure.pxd
@@ -14,7 +14,7 @@ cdef class LabelWiseMeasure(DecomposableLoss):
 
     cdef readonly float64[::1, :] coverable_labels
 
-    cdef uint32[::1] minority_labels
+    cdef uint8[::1] minority_labels
 
     cdef uint8[::1, :] true_labels
 

--- a/python/boomer/algorithm/_label_wise_measure.pyx
+++ b/python/boomer/algorithm/_label_wise_measure.pyx
@@ -1,4 +1,5 @@
-from boomer.algorithm._arrays cimport uint8, uint32, intp, float64, array_float64, matrix_float64, array_uint32
+from boomer.algorithm._arrays cimport uint8, uint32, intp, float64
+from boomer.algorithm._arrays cimport array_uint8, array_uint32, array_float64, matrix_float64
 
 from boomer.algorithm._heuristics cimport Heuristic
 from boomer.algorithm._losses cimport LabelIndependentPrediction, DecomposableLoss
@@ -23,7 +24,7 @@ cdef class LabelWiseMeasure(DecomposableLoss):
         cdef intp num_examples = y.shape[0]
         cdef intp num_labels = y.shape[1]
         cdef float64[::1] default_rule = array_float64(num_labels)
-        cdef uint32[::1] minority_labels = array_uint32(num_labels)
+        cdef uint8[::1] minority_labels = array_uint8(num_labels)
         cdef float64[::1, :] uncovered_labels = matrix_float64(num_examples, num_labels)
         cdef float64[::1, :] coverable_labels = matrix_float64(num_examples, num_labels)
         cdef float64[::1, :] confusion_matrices_default = matrix_float64(num_labels, 4)
@@ -40,10 +41,12 @@ cdef class LabelWiseMeasure(DecomposableLoss):
 
             if default_rule[c] > threshold:
                 default_rule[c] = 1
-                minority_labels[c] = 0
+                minority_labels[c] = False
+                print('should be False, is ' + str(minority_labels[c]))
             else:
                 default_rule[c] = 0
-                minority_labels[c] = 1
+                minority_labels[c] = True
+                print('should be True, is ' + str(minority_labels[c]))
 
             for r in range(num_examples):
                 if default_rule[c] == y[r,c]:
@@ -72,7 +75,7 @@ cdef class LabelWiseMeasure(DecomposableLoss):
     cdef update_sub_sample(self, intp example_index):
         cdef float64[::1, :] uncovered_labels = self.uncovered_labels
         cdef uint8[::1, :] true_labels = self.true_labels
-        cdef uint32[::1] minority_labels = self.minority_labels
+        cdef uint8[::1] minority_labels = self.minority_labels
         cdef intp num_labels = minority_labels.shape[0]
         cdef float64[::1, :] confusion_matrices_default = self.confusion_matrices_default
         cdef intp c
@@ -84,14 +87,14 @@ cdef class LabelWiseMeasure(DecomposableLoss):
                 predicted_label = minority_labels[c]
 
                 if true_label == 0:
-                    if predicted_label == 0:
-                        confusion_matrices_default[c, _IN] += 1
-                    elif predicted_label == 1:
+                    if predicted_label:
                         confusion_matrices_default[c, _IP] += 1
+                    else:
+                        confusion_matrices_default[c, _IN] += 1
                 elif true_label == 1:
-                    if predicted_label == 0:
+                    if predicted_label == False:
                         confusion_matrices_default[c, _RN] += 1
-                    elif predicted_label == 1:
+                    elif predicted_label == True:
                         confusion_matrices_default[c, _RP] += 1
 
     cdef begin_search(self, intp[::1] label_indices):
@@ -119,7 +122,7 @@ cdef class LabelWiseMeasure(DecomposableLoss):
 
     cdef update_search(self, intp example_index, uint32 weight):
         cdef float64[::1, :] uncovered_labels = self.uncovered_labels
-        cdef uint32[::1] minority_labels = self.minority_labels
+        cdef uint8[::1] minority_labels = self.minority_labels
         cdef uint8[::1, :] true_labels = self.true_labels
         cdef float64[::1, :] confusion_matrices_covered = self.confusion_matrices_covered
         cdef intp[::1] label_indices = self.label_indices
@@ -134,14 +137,14 @@ cdef class LabelWiseMeasure(DecomposableLoss):
                 predicted_label = minority_labels[l]
 
                 if true_label == 0:
-                    if predicted_label == 0:
+                    if predicted_label == False:
                         confusion_matrices_covered[c, _IN] += weight
-                    elif predicted_label == 1:
+                    elif predicted_label == True:
                         confusion_matrices_covered[c, _IP] += weight
                 elif true_label == 1:
-                    if predicted_label == 0:
+                    if predicted_label == False:
                         confusion_matrices_covered[c, _RN] += weight
-                    elif predicted_label == 1:
+                    elif predicted_label == True:
                         confusion_matrices_covered[c, _RP] += weight
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered):
@@ -149,7 +152,7 @@ cdef class LabelWiseMeasure(DecomposableLoss):
         cdef float64[::1] predicted_scores = prediction.predicted_scores
         cdef float64[::1] quality_scores = prediction.quality_scores
         cdef float64 overall_quality_score = 0
-        cdef uint32[::1] minority_labels = self.minority_labels
+        cdef uint8[::1] minority_labels = self.minority_labels
         cdef intp[::1] label_indices = self.label_indices
         cdef float64[::1, :] confusion_matrices_covered = self.confusion_matrices_covered
         cdef float64[::1, :] confusion_matrices_default = self.confusion_matrices_default
@@ -159,7 +162,7 @@ cdef class LabelWiseMeasure(DecomposableLoss):
 
         for c in range(num_labels):
             l = get_index(c, label_indices)
-            predicted_scores[c] = minority_labels[l]
+            predicted_scores[c] = <float64>minority_labels[l]
             if uncovered:
                 quality_scores[c] = heuristic.evaluate_confusion_matrix(
                     confusion_matrices_default[l, _IN] - confusion_matrices_covered[c, _IN],


### PR DESCRIPTION
Hi Jakob,

*Dieser Pull-Request ist nicht unbedingt dazu gedacht ihn zu mergen. Ich habe nur etwas ausprobiert, das ich dir nicht vorenthalten wollte.*

Wir hatten ja mal darüber geredet, dass wir in manchem Fällen Boolean-Arrays brauchen könnten, aber das die nicht zur Verfügung standen (Issue #21 hat sich darauf bezogen, wenn ich das richtig sehe). Als Datentyp für Boolean-Variablen verwenden wir jetzt schon den Typ `bint`, aber es gibt wohl keine Möglichkeit ein `bint`-Array zu erzeugen. Allerdings ist ein `bint` intern eigentlich sowieso ein Integer mit 8 Bit, der als Boolean interpretiert werden kann (False wenn der Wert 0 ist, anderenfalls True). Das entspricht dem Typ `uint8`, weshalb man also einfach diesen Typ für das Array benutzen kann.

Das habe ich hier einmal testweise ausprobiert und es scheint zu funktionieren. Man kann ein solches Array erzeugen mit
```
cdef uint8[::1] array = array_uint8(2)
```
und dann Boolean-Werte zuweisen mit
```
array[0] = True
array[1] = False
```
Beim Abfragen kann man die Array-Elemente auch wie "richtige" Booleans behandeln:
```
if array[0]:
    # mach was
```
oder
```
if array[0] == True:
    # mach was
```
Das könnte den Code eventuell etwas schöner machen. Da das aber nur Kosmetik ist, würde ich dem nicht die höchste Priorität einräumen und das auch nicht als Voraussetzung für das Mergen des seco-Branches sehen. Deine Meinung dazu würde mich interessieren.

Hier ein Stackoverflow-Artikel dazu: https://stackoverflow.com/questions/49058191/boolean-numpy-arrays-with-cython

Und hier wird der `bint`-Datentyp beschrieben: https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#types