### PR TITLE
Change minority_labels to uint8 array

### DIFF
--- a/python/boomer/algorithm/_arrays.pxd
+++ b/python/boomer/algorithm/_arrays.pxd
@@ -17,11 +17,13 @@ DEF MODE_C_CONTIGUOUS = 'c'
 DEF MODE_FORTRAN_CONTIGUOUS = 'fortran'
 
 IF UNAME_SYSNAME == 'Windows':
+    DEF FORMAT_UINT8 = 'B'
     DEF FORMAT_UINT32 = 'I'
     DEF FORMAT_INTP = 'q'
     DEF FORMAT_FLOAT32 = 'f'
     DEF FORMAT_FLOAT64 = 'd'
 ELSE:
+    DEF FORMAT_UINT8 = 'B'
     DEF FORMAT_UINT32 = 'I'
     DEF FORMAT_INTP = 'l'
     DEF FORMAT_FLOAT32 = 'f'
@@ -37,6 +39,17 @@ cdef inline cvarray array_intp(intp num_elements):
     cdef tuple shape = tuple([num_elements])
     cdef intp itemsize = sizeof(intp)
     cdef cvarray array = cvarray(shape, itemsize, FORMAT_INTP, MODE_C_CONTIGUOUS)
+    return array
+
+cdef inline cvarray array_uint8(intp num_elements):
+    """
+    Creates and returns a new C-contiguous array of dtype `uint8`, shape `(num_elements)`.
+    :param num_elements:    The number of elements in the array
+    :return:                The array that has been created
+    """
+    cdef tuple shape = tuple([num_elements])
+    cdef intp itemsize = sizeof(uint8)
+    cdef cvarray array = cvarray(shape, itemsize, FORMAT_UINT8, MODE_C_CONTIGUOUS)
     return array
 
 cdef inline cvarray array_uint32(intp num_elements):

--- a/python/boomer/algorithm/_label_wise_averaging.pxd
+++ b/python/boomer/algorithm/_label_wise_averaging.pxd
@@ -14,7 +14,7 @@ cdef class LabelWiseAveraging(DecomposableLoss):
 
     cdef readonly float64[::1, :] coverable_labels
 
-    cdef uint32[::1] minority_labels
+    cdef uint8[::1] minority_labels
 
     cdef uint8[::1, :] true_labels
 


### PR DESCRIPTION
Was hältst du von dieser Anpassung? Im Array minority_labels sollen ja labels stehen und nicht wirklich ein Wahrheitswert. Vlt. wäre es daher eine gute Idee, den Typ zwar auf uint8 zu setzen, aber weiterhin 0 und 1 als Werte zu verwenden?