### PR TITLE
Fehlerhafte Imports

### DIFF
--- a/python/boomer/algorithm/rule_learners.py
+++ b/python/boomer/algorithm/rule_learners.py
@@ -13,8 +13,8 @@ import numpy as np
 from boomer.algorithm._example_wise_losses import ExampleWiseLogisticLoss
 from boomer.algorithm._head_refinement import HeadRefinement, SingleLabelHeadRefinement, FullHeadRefinement
 from boomer.algorithm._heuristics import Heuristic, HammingLoss, Precision
+from boomer.algorithm._label_wise_averaging import LabelWiseAveraging
 from boomer.algorithm._label_wise_losses import LabelWiseSquaredErrorLoss, LabelWiseLogisticLoss
-from boomer.algorithm._label_wise_measure import LabelWiseAveraging
 from boomer.algorithm._losses import Loss, DecomposableLoss
 from boomer.algorithm._pruning import Pruning, IREP
 from boomer.algorithm._shrinkage import Shrinkage, ConstantShrinkage

--- a/python/boomer/algorithm/stopping_criteria.py
+++ b/python/boomer/algorithm/stopping_criteria.py
@@ -10,7 +10,7 @@ from abc import abstractmethod, ABC
 from timeit import default_timer as timer
 
 import numpy as np
-from boomer.algorithm._label_wise_measure import LabelWiseAveraging
+from boomer.algorithm._label_wise_averaging import LabelWiseAveraging
 
 from boomer.algorithm.model import Theory
 


### PR DESCRIPTION
Nach der Umbenennung von `_label_wise_measure.pyx/.pxd` in `_label_wise_averaging.pyx/.pxd` stimmen ein paar Imports nicht mehr, was hierdurch behoben wird.