### PR TITLE
Void-Rückgabewert für cdef-Funktionen verwenden

### DIFF
--- a/python/boomer/algorithm/_example_wise_losses.pxd
+++ b/python/boomer/algorithm/_example_wise_losses.pxd
@@ -32,17 +32,17 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
     cdef Prediction evaluate_label_dependent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)

--- a/python/boomer/algorithm/_example_wise_losses.pyx
+++ b/python/boomer/algorithm/_example_wise_losses.pyx
@@ -161,7 +161,7 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
 
         return scores
 
-    cdef begin_instance_sub_sampling(self):
+    cdef void begin_instance_sub_sampling(self):
         # Class members
         cdef float64[::1] total_sums_of_gradients = self.total_sums_of_gradients
         cdef float64[::1] total_sums_of_hessians = self.total_sums_of_hessians
@@ -169,7 +169,7 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
         total_sums_of_gradients[:] = 0
         total_sums_of_hessians[:] = 0
 
-    cdef update_sub_sample(self, intp example_index):
+    cdef void update_sub_sample(self, intp example_index):
         # Class members
         cdef float64[::1, :] gradients = self.gradients
         cdef float64[::1] total_sums_of_gradients = self.total_sums_of_gradients
@@ -190,7 +190,7 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
         for c in range(num_elements):
             total_sums_of_hessians[c] += hessians[example_index, c]
 
-    cdef begin_search(self, intp[::1] label_indices):
+    cdef void begin_search(self, intp[::1] label_indices):
         # Determine the number of gradients and hessians to be considered by the upcoming search...
         cdef float64[::1, :] gradients
         cdef intp num_gradients
@@ -224,7 +224,7 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
         # Store the given label indices...
         self.label_indices = label_indices
 
-    cdef update_search(self, intp example_index, uint32 weight):
+    cdef void update_search(self, intp example_index, uint32 weight):
         # Class members
         cdef float64[::1, :] gradients = self.gradients
         cdef float64[::1] sums_of_gradients = self.sums_of_gradients
@@ -362,8 +362,8 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableLoss):
 
         return prediction
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores):
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores):
         # Class members
         cdef float64[::1, :] expected_scores = self.expected_scores
         cdef float64[::1, :] current_scores = self.current_scores

--- a/python/boomer/algorithm/_label_wise_averaging.pxd
+++ b/python/boomer/algorithm/_label_wise_averaging.pxd
@@ -28,18 +28,18 @@ cdef class LabelWiseAveraging(DecomposableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
     cdef Prediction evaluate_label_dependent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)
 

--- a/python/boomer/algorithm/_label_wise_averaging.pyx
+++ b/python/boomer/algorithm/_label_wise_averaging.pyx
@@ -65,11 +65,11 @@ cdef class LabelWiseAveraging(DecomposableLoss):
 
         return default_rule
 
-    cdef begin_instance_sub_sampling(self):
+    cdef void begin_instance_sub_sampling(self):
         cdef float64[::1, :] confusion_matrices_default = self.confusion_matrices_default
         confusion_matrices_default[:, :] = 0
 
-    cdef update_sub_sample(self, intp example_index):
+    cdef void update_sub_sample(self, intp example_index):
         cdef float64[::1, :] uncovered_labels = self.uncovered_labels
         cdef uint8[::1, :] true_labels = self.true_labels
         cdef uint8[::1] minority_labels = self.minority_labels
@@ -94,7 +94,7 @@ cdef class LabelWiseAveraging(DecomposableLoss):
                     elif predicted_label == 1:
                         confusion_matrices_default[c, _RP] += 1
 
-    cdef begin_search(self, intp[::1] label_indices):
+    cdef void begin_search(self, intp[::1] label_indices):
         cdef LabelIndependentPrediction prediction = self.prediction
         cdef float64[::1] predicted_scores
         cdef float64[::1] quality_scores
@@ -117,7 +117,7 @@ cdef class LabelWiseAveraging(DecomposableLoss):
         confusion_matrices_covered[:, :] = 0
         self.label_indices = label_indices
 
-    cdef update_search(self, intp example_index, uint32 weight):
+    cdef void update_search(self, intp example_index, uint32 weight):
         cdef float64[::1, :] uncovered_labels = self.uncovered_labels
         cdef uint8[::1] minority_labels = self.minority_labels
         cdef uint8[::1, :] true_labels = self.true_labels
@@ -189,8 +189,8 @@ cdef class LabelWiseAveraging(DecomposableLoss):
 
         return prediction
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores):
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores):
         cdef float64[::1, :] uncovered_labels = self.uncovered_labels
         cdef intp l, i
 

--- a/python/boomer/algorithm/_label_wise_losses.pxd
+++ b/python/boomer/algorithm/_label_wise_losses.pxd
@@ -36,18 +36,18 @@ cdef class LabelWiseLoss(DecomposableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)
 
 
 cdef class LabelWiseSquaredErrorLoss(LabelWiseLoss):
@@ -60,18 +60,18 @@ cdef class LabelWiseSquaredErrorLoss(LabelWiseLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)
 
 
 cdef class LabelWiseLogisticLoss(LabelWiseLoss):
@@ -84,15 +84,15 @@ cdef class LabelWiseLogisticLoss(LabelWiseLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)

--- a/python/boomer/algorithm/_label_wise_losses.pyx
+++ b/python/boomer/algorithm/_label_wise_losses.pyx
@@ -128,7 +128,7 @@ cdef class LabelWiseLoss(DecomposableLoss):
 
         return scores
 
-    cdef begin_instance_sub_sampling(self):
+    cdef void begin_instance_sub_sampling(self):
         # Class members
         cdef float64[::1] total_sums_of_gradients = self.total_sums_of_gradients
         cdef float64[::1] total_sums_of_hessians = self.total_sums_of_hessians
@@ -142,7 +142,7 @@ cdef class LabelWiseLoss(DecomposableLoss):
             total_sums_of_gradients[c] = 0
             total_sums_of_hessians[c] = 0
 
-    cdef update_sub_sample(self, intp example_index):
+    cdef void update_sub_sample(self, intp example_index):
         # Class members
         cdef float64[::1, :] gradients = self.gradients
         cdef float64[::1] total_sums_of_gradients = self.total_sums_of_gradients
@@ -159,7 +159,7 @@ cdef class LabelWiseLoss(DecomposableLoss):
             total_sums_of_gradients[c] += gradients[example_index, c]
             total_sums_of_hessians[c] += hessians[example_index, c]
 
-    cdef begin_search(self, intp[::1] label_indices):
+    cdef void begin_search(self, intp[::1] label_indices):
         # Determine the number of labels to be considered by the upcoming search...
         cdef float64[::1] total_sums_of_gradients
         cdef intp num_labels, c
@@ -201,7 +201,7 @@ cdef class LabelWiseLoss(DecomposableLoss):
         # Store the given label indices...
         self.label_indices = label_indices
 
-    cdef update_search(self, intp example_index, uint32 weight):
+    cdef void update_search(self, intp example_index, uint32 weight):
         # Class members
         cdef float64[::1, :] gradients = self.gradients
         cdef float64[::1] sums_of_gradients = self.sums_of_gradients
@@ -269,7 +269,7 @@ cdef class LabelWiseLoss(DecomposableLoss):
 
         return prediction
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
                            float64[::1] predicted_scores):
         # Class members
         cdef float64[::1, :] gradients = self.gradients

--- a/python/boomer/algorithm/_losses.pxd
+++ b/python/boomer/algorithm/_losses.pxd
@@ -23,20 +23,20 @@ cdef class Loss:
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
     cdef Prediction evaluate_label_dependent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)
 
 
 cdef class DecomposableLoss(Loss):
@@ -45,20 +45,20 @@ cdef class DecomposableLoss(Loss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
     cdef Prediction evaluate_label_dependent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)
 
 
 cdef class NonDecomposableLoss(Loss):
@@ -67,18 +67,18 @@ cdef class NonDecomposableLoss(Loss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef begin_instance_sub_sampling(self)
+    cdef void begin_instance_sub_sampling(self)
 
-    cdef update_sub_sample(self, intp example_index)
+    cdef void update_sub_sample(self, intp example_index)
 
-    cdef begin_search(self, intp[::1] label_indices)
+    cdef void begin_search(self, intp[::1] label_indices)
 
-    cdef update_search(self, intp example_index, uint32 weight)
+    cdef void update_search(self, intp example_index, uint32 weight)
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered)
 
     cdef Prediction evaluate_label_dependent_predictions(self, bint uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores)
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores)
 

--- a/python/boomer/algorithm/_losses.pyx
+++ b/python/boomer/algorithm/_losses.pyx
@@ -56,7 +56,7 @@ cdef class Loss:
         """
         pass
 
-    cdef begin_instance_sub_sampling(self):
+    cdef void begin_instance_sub_sampling(self):
         """
         Notifies the loss function that the examples, which should be considered in the following for learning a new
         rule or refining an existing one, have changed. The indices of the respective examples must be provided via
@@ -73,7 +73,7 @@ cdef class Loss:
         """
         pass
 
-    cdef update_sub_sample(self, intp example_index):
+    cdef void update_sub_sample(self, intp example_index):
         """
         Notifies the loss function about an example that should be considered in the following for learning a new rule
         or refining an existing one.
@@ -91,7 +91,7 @@ cdef class Loss:
         """
         pass
 
-    cdef begin_search(self, intp[::1] label_indices):
+    cdef void begin_search(self, intp[::1] label_indices):
         """
         Notifies the loss function that a new search for the best refinement of a rule, i.e., the best condition to be
         added to its body, should be started. The examples that are covered by such a condition must be provided via
@@ -114,7 +114,7 @@ cdef class Loss:
         """
         pass
 
-    cdef update_search(self, intp example_index, uint32 weight):
+    cdef void update_search(self, intp example_index, uint32 weight):
         """
         Notifies the loss function about an example that is covered by the condition that is currently considered for
         refining a rule.
@@ -177,8 +177,8 @@ cdef class Loss:
         """
         pass
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores):
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores):
         """
         Notifies the loss function that a new rule has been induced.
 
@@ -206,16 +206,16 @@ cdef class DecomposableLoss(Loss):
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y):
         pass
 
-    cdef begin_instance_sub_sampling(self):
+    cdef void begin_instance_sub_sampling(self):
         pass
 
-    cdef update_sub_sample(self, intp example_index):
+    cdef void update_sub_sample(self, intp example_index):
         pass
 
-    cdef begin_search(self, intp[::1] label_indices):
+    cdef void begin_search(self, intp[::1] label_indices):
         pass
 
-    cdef update_search(self, intp example_index, uint32 weight):
+    cdef void update_search(self, intp example_index, uint32 weight):
         pass
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered):
@@ -226,8 +226,8 @@ cdef class DecomposableLoss(Loss):
         # predictions...
         return self.evaluate_label_independent_predictions(uncovered)
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores):
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores):
         pass
 
 
@@ -239,16 +239,16 @@ cdef class NonDecomposableLoss(Loss):
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y):
         pass
 
-    cdef begin_instance_sub_sampling(self):
+    cdef void begin_instance_sub_sampling(self):
         pass
 
-    cdef update_sub_sample(self, intp example_index):
+    cdef void update_sub_sample(self, intp example_index):
         pass
 
-    cdef begin_search(self, intp[::1] label_indices):
+    cdef void begin_search(self, intp[::1] label_indices):
         pass
 
-    cdef update_search(self, intp example_index, uint32 weight):
+    cdef void update_search(self, intp example_index, uint32 weight):
         pass
 
     cdef LabelIndependentPrediction evaluate_label_independent_predictions(self, bint uncovered):
@@ -257,6 +257,6 @@ cdef class NonDecomposableLoss(Loss):
     cdef Prediction evaluate_label_dependent_predictions(self, bint uncovered):
         pass
 
-    cdef apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
-                           float64[::1] predicted_scores):
+    cdef void apply_predictions(self, intp[::1] covered_example_indices, intp[::1] label_indices,
+                                float64[::1] predicted_scores):
         pass

--- a/python/boomer/algorithm/_math.pxd
+++ b/python/boomer/algorithm/_math.pxd
@@ -11,7 +11,7 @@ from libc.stdlib cimport malloc, free
 from libc.math cimport pow
 
 
-cdef inline divide_or_zero_float64(float64 a, float64 b):
+cdef inline float64 divide_or_zero_float64(float64 a, float64 b):
     """
     Divides a number of dtype `float64` by another one. The division by zero evaluates to 0 by definition.
 
@@ -35,7 +35,7 @@ cdef inline intp triangular_number(intp n):
     return (n * (n + 1)) // 2
 
 
-cdef inline l2_norm_pow(float64[::1] a):
+cdef inline float64 l2_norm_pow(float64[::1] a):
     """
     Computes and returns the square of the L2 norm of a specific vector, i.e. the sum of the squares of its elements. To 
     obtain the actual L2 norm, the square-root of the result provided by this function must be computed.

--- a/python/boomer/algorithm/_model.pxd
+++ b/python/boomer/algorithm/_model.pxd
@@ -44,7 +44,7 @@ cdef class Head:
 
     # Functions:
 
-    cdef predict(self, float64[:] predictions, intp[:] predicted=*)
+    cdef void predict(self, float64[:] predictions, intp[:] predicted=*)
 
 
 cdef class FullHead(Head):
@@ -55,7 +55,7 @@ cdef class FullHead(Head):
 
     # Functions:
 
-    cdef predict(self, float64[:] predictions, intp[:] predicted=*)
+    cdef void predict(self, float64[:] predictions, intp[:] predicted=*)
 
 
 cdef class PartialHead(Head):
@@ -68,7 +68,7 @@ cdef class PartialHead(Head):
 
     # Functions:
 
-    cdef predict(self, float64[:] predictions, intp[:] predicted=*)
+    cdef void predict(self, float64[:] predictions, intp[:] predicted=*)
 
 
 cdef class Rule:

--- a/python/boomer/algorithm/_model.pyx
+++ b/python/boomer/algorithm/_model.pyx
@@ -162,7 +162,7 @@ cdef class Head:
     def __setstate__(self, state):
         pass
 
-    cdef predict(self, float64[:] predictions, intp[:] predicted = None):
+    cdef void predict(self, float64[:] predictions, intp[:] predicted = None):
         """
         Applies the head's prediction to a given vector of predictions given that no prediction has yet been made.
 
@@ -192,7 +192,7 @@ cdef class FullHead(Head):
         scores = state
         self.scores = scores
 
-    cdef predict(self, float64[:] predictions, intp[:] predicted = None):
+    cdef void predict(self, float64[:] predictions, intp[:] predicted = None):
         cdef float64[::1] scores = self.scores
         cdef intp num_cols = predictions.shape[0]
         cdef intp c
@@ -229,7 +229,7 @@ cdef class PartialHead(Head):
         self.label_indices = label_indices
         self.scores = scores
 
-    cdef predict(self, float64[:] predictions, intp[:] predicted = None):
+    cdef void predict(self, float64[:] predictions, intp[:] predicted = None):
         cdef intp[::1] label_indices = self.label_indices
         cdef float64[::1] scores = self.scores
         cdef intp num_labels = label_indices.shape[0]

--- a/python/boomer/algorithm/_pruning.pxd
+++ b/python/boomer/algorithm/_pruning.pxd
@@ -11,8 +11,8 @@ cdef class Pruning:
 
     # Functions:
 
-    cdef begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
-                       intp[::1] covered_example_indices, intp[::1] label_indices)
+    cdef void begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
+                            intp[::1] covered_example_indices, intp[::1] label_indices)
 
     cdef intp[::1] prune(self, float32[::1, :] x, intp[::1, :] x_sorted_indices, list[Condition] conditions)
 
@@ -35,7 +35,7 @@ cdef class IREP(Pruning):
 
     # Functions:
 
-    cdef begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
-                       intp[::1] covered_example_indices, intp[::1] label_indices)
+    cdef void begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
+                            intp[::1] covered_example_indices, intp[::1] label_indices)
 
     cdef intp[::1] prune(self, float32[::1, :] x, intp[::1, :] x_sorted_indices, list[Condition] conditions)

--- a/python/boomer/algorithm/_pruning.pyx
+++ b/python/boomer/algorithm/_pruning.pyx
@@ -19,8 +19,8 @@ cdef class Pruning:
     to as the "grow set").
     """
 
-    cdef begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
-                       intp[::1] covered_example_indices, intp[::1] label_indices):
+    cdef void begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
+                            intp[::1] covered_example_indices, intp[::1] label_indices):
         """
         Calculates the quality score of an existing rule, based on the examples that are contained in the prune set,
         i.e., based on all examples whose weight is 0.
@@ -71,8 +71,8 @@ cdef class IREP(Pruning):
     set).
     """
 
-    cdef begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
-                       intp[::1] covered_example_indices, intp[::1] label_indices):
+    cdef void begin_pruning(self, uint32[::1] weights, Loss loss, HeadRefinement head_refinement,
+                            intp[::1] covered_example_indices, intp[::1] label_indices):
         cdef uint32 weight
         cdef intp i
 

--- a/python/boomer/algorithm/_shrinkage.pxd
+++ b/python/boomer/algorithm/_shrinkage.pxd
@@ -5,7 +5,7 @@ cdef class Shrinkage:
 
     # Functions:
 
-    cdef apply_shrinkage(self, float64[::1] predicted_scores)
+    cdef void apply_shrinkage(self, float64[::1] predicted_scores)
 
 
 cdef class ConstantShrinkage(Shrinkage):
@@ -16,4 +16,4 @@ cdef class ConstantShrinkage(Shrinkage):
 
     # Functions:
 
-    cdef apply_shrinkage(self, float64[::1] predicted_scores)
+    cdef void apply_shrinkage(self, float64[::1] predicted_scores)

--- a/python/boomer/algorithm/_shrinkage.pyx
+++ b/python/boomer/algorithm/_shrinkage.pyx
@@ -12,7 +12,7 @@ cdef class Shrinkage:
     a.k.a. the learning rate, may e.g. be constant or a function depending on the number of rules learned so far.
     """
 
-    cdef apply_shrinkage(self, float64[::1] predicted_scores):
+    cdef void apply_shrinkage(self, float64[::1] predicted_scores):
         """
         Applies the shrinkage parameter to the scores that are predicted by a rule.
         
@@ -33,7 +33,7 @@ cdef class ConstantShrinkage(Shrinkage):
         """
         self.shrinkage = shrinkage
 
-    cdef apply_shrinkage(self, float64[::1] predicted_scores):
+    cdef void apply_shrinkage(self, float64[::1] predicted_scores):
         cdef float shrinkage = self.shrinkage
         cdef intp num_labels = predicted_scores.shape[0]
         cdef intp c


### PR DESCRIPTION
Ich habe wieder einmal tief in der Cython-Doku gewühlt und feststellen müssen, dass wir `cdef`-Funktionen ohne Rückgabewert nicht ganz optimal definieren. Dort heißt es

> The optional return type of a cdef function can be any static type [..]. We can also have a return type of void. If the return type is omitted, then it defaults to object.

Wenn eine Funktion nichts zurück gibt haben wir bisher immer darauf verzichtet einen Rückgabewert zu definieren, er war implizit also immer `object`. Das ist ein Python-Datentyp, weshalb beim Aufruf einer solchen Funktion der Rückgabewert (der den Wert `None` hat, weil nichts zurückgegeben wird) vom Python-Interpreter inspiziert werden muss, auch wenn die Funktion von einer anderen `cdef`-Funktion aufgerufen wurde.

Durch diesen Pull Request wird für alle betroffenen Funktionen `void` (ein C-Datentyp) als Rückgabetyp angegeben. Für `cpdef`-Funktionen funktioniert das nicht, weil diese auch aus Python-Code heraus aufgerufen werden können und deshalb der Rückgabetyp Python-kompatibel sein muss.