### PR TITLE
Wert für Kommandozeilenargument umbenennen

### DIFF
--- a/python/boomer/algorithm/rule_learners.py
+++ b/python/boomer/algorithm/rule_learners.py
@@ -43,7 +43,7 @@ LOSS_LABEL_WISE_SQUARED_ERROR = 'label-wise-squared-error-loss'
 
 LOSS_EXAMPLE_WISE_LOGISTIC = 'example-wise-logistic-loss'
 
-MEASURE_LABEL_WISE = 'label-wise-measure'
+AVERAGING_LABEL_WISE = 'label-wise-averaging'
 
 HEURISTIC_PRECISION = 'precision'
 
@@ -339,7 +339,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
     """
 
     def __init__(self, model_dir: str = None, max_rules: int = 500, time_limit: int = -1, head_refinement: str = None,
-                 loss: str = MEASURE_LABEL_WISE, heuristic: str = HEURISTIC_PRECISION, label_sub_sampling: int = -1,
+                 loss: str = AVERAGING_LABEL_WISE, heuristic: str = HEURISTIC_PRECISION, label_sub_sampling: int = -1,
                  instance_sub_sampling: str = None, feature_sub_sampling: str = None, pruning: str = None):
         """
         :param max_rules:                   The maximum number of rules to be induced (including the default rule)
@@ -347,7 +347,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
                                             canceled
         :param head_refinement:             The strategy that is used to find the heads of rules. Must be
                                             `single-label` or None, if the default strategy should be used
-        :param loss:                        The loss function to be minimized. Must be `label-wise-measure`
+        :param loss:                        The loss function to be minimized. Must be `label-wise-averaging`
         :param heuristic:                   The heuristic to be minimized. Must be `precision` or `hamming-loss`
         :param label_sub_sampling:          The number of samples to be used for sub-sampling the labels each time a new
                                             classification rule is learned. Must be at least 1 or -1, if no sub-sampling
@@ -432,7 +432,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner):
     def __create_loss(self, heuristic: Heuristic) -> CoverageLoss:
         loss = self.loss
 
-        if loss == MEASURE_LABEL_WISE:
+        if loss == AVERAGING_LABEL_WISE:
             return LabelWiseAveraging(heuristic)
         raise ValueError('Invalid value given for parameter \'loss\': ' + str(loss))
 

--- a/python/main_seco.py
+++ b/python/main_seco.py
@@ -5,7 +5,7 @@ import logging as log
 
 from args import current_fold_string
 from args import optional_string, log_level, boolean_string
-from boomer.algorithm.rule_learners import MEASURE_LABEL_WISE, HEURISTIC_PRECISION
+from boomer.algorithm.rule_learners import AVERAGING_LABEL_WISE, HEURISTIC_PRECISION
 from boomer.algorithm.rule_learners import SeparateAndConquerRuleLearner
 from boomer.evaluation import ClassificationEvaluation, EvaluationLogOutput, EvaluationCsvOutput
 from boomer.experiments import Experiment
@@ -38,8 +38,7 @@ def configure_argument_parser(p: argparse.ArgumentParser):
                    help='The name of the strategy to be used for feature sub-sampling or None')
     p.add_argument('--pruning', type=optional_string, default=None,
                    help='The name of the strategy to be used for pruning or None')
-    p.add_argument('--loss', type=str, default=MEASURE_LABEL_WISE,
-                   help='The name of the loss function to be used')
+    p.add_argument('--loss', type=str, default=AVERAGING_LABEL_WISE, help='The name of the loss function to be used')
     p.add_argument('--heuristic', type=str, default=HEURISTIC_PRECISION, help='The name of the heuristic to be used')
     p.add_argument('--head-refinement', type=optional_string, default=None,
                    help='The name of the strategy to be used for finding the heads of rules')


### PR DESCRIPTION
Nur eine Kleinigkeit: Mir ist aufgefallen, dass, obwohl wir die Klasse `LabelWiseMeasure` irgendwann umbenannt hatten in `LabelWiseAveraging`, der entsprechende Wert für das dazugehörige Kommandozeilenargument immer noch "label-wise-measure" heißt. Aus Gründen der Konsistenz habe ich das mal zu "label-wise-averaging" umbenannt.