### PR TITLE
Debug-/Annotate-Flags in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ from Cython.Build import cythonize
 from setuptools import setup, Extension
 
 # True, if annotated Cython source files that highlight Python interactions should be created
-ANNOTATE = False
+ANNOTATE = True
 
 # True, if all Cython compiler optimizations should be disabled
 DEBUG = False


### PR DESCRIPTION
Enthält folgende Änderungen in `setup.py`:

* Compiler-Direktive "initializedcheck" hinzugefügt (deaktiviert implizite Überprüfung darauf ob Memory-Views `None` sind).
* Alle Compiler-Optimierungen lassen sich über ein einziges Boolean-Flag an-/ausschalten
* Analog dazu gibt es jetzt ein Flag um die Code-Annotierung an-/auszuschalten