### PR TITLE
One-Hot-Encoding standardmäßig deaktivieren

### DIFF
--- a/python/main_boomer.py
+++ b/python/main_boomer.py
@@ -22,7 +22,7 @@ def configure_argument_parser(p: argparse.ArgumentParser):
     p.add_argument('--model-dir', type=optional_string, default=None,
                    help='The path of the directory where models should be saved')
     p.add_argument('--dataset', type=str, help='The name of the data set to be used')
-    p.add_argument('--one-hot-encoding', type=boolean_string, default=True,
+    p.add_argument('--one-hot-encoding', type=boolean_string, default=False,
                    help='True, if one-hot-encoding should be used, False otherwise')
     p.add_argument('--folds', type=int, default=1, help='Total number of folds to be used by cross validation')
     p.add_argument('--current-fold', type=current_fold_string, default=-1,

--- a/python/main_boomer_bbc_cv.py
+++ b/python/main_boomer_bbc_cv.py
@@ -255,7 +255,7 @@ if __name__ == '__main__':
     parser.add_argument('--random-state', type=int, default=1, help='The seed to be used by RNGs')
     parser.add_argument('--data-dir', type=str, help='The path of the directory where the data sets are located')
     parser.add_argument('--dataset', type=str, help='The name of the data set to be used')
-    parser.add_argument('--one-hot-encoding', type=boolean_string, default=True,
+    parser.add_argument('--one-hot-encoding', type=boolean_string, default=False,
                         help='True, if one-hot-encoding should be used, False otherwise')
     parser.add_argument('--folds', type=int, default=1, help='The total number of folds to be used by cross validation')
     parser.add_argument('--model-dir', type=str, help='The path of the directory where the models are stored')

--- a/python/main_seco.py
+++ b/python/main_seco.py
@@ -22,7 +22,7 @@ def configure_argument_parser(p: argparse.ArgumentParser):
     p.add_argument('--model-dir', type=optional_string, default=None,
                    help='The path of the directory where models should be saved')
     p.add_argument('--dataset', type=str, help='The name of the data set to be used')
-    p.add_argument('--one-hot-encoding', type=boolean_string, default=True,
+    p.add_argument('--one-hot-encoding', type=boolean_string, default=False,
                    help='True, if one-hot-encoding should be used, False otherwise')
     p.add_argument('--folds', type=int, default=1, help='Total number of folds to be used by cross validation')
     p.add_argument('--current-fold', type=current_fold_string, default=-1,


### PR DESCRIPTION
Da der Regellerner mittlerweile mit nominalen Attributen umgehen kann, sollte man eigentlich kein One-Hot-Encoding mehr verwenden. Längerfristig plane ich diese Funktion sogar komplett zu entfernen.