### PR TITLE
Korrekter Default-Wert für Parameter "sample_size" - Teil 2

### DIFF
--- a/python/boomer/algorithm/rule_learners.py
+++ b/python/boomer/algorithm/rule_learners.py
@@ -108,7 +108,7 @@ def _create_instance_sub_sampling(instance_sub_sampling: str) -> InstanceSubSamp
             sample_size = _get_float_argument(args, ARGUMENT_SAMPLE_SIZE, 1.0, lambda x: 0 < x <= 1)
             return Bagging(sample_size)
         elif prefix == INSTANCE_SUB_SAMPLING_RANDOM:
-            sample_size = _get_float_argument(args, ARGUMENT_SAMPLE_SIZE, 0.0, lambda x: 0 < x < 1)
+            sample_size = _get_float_argument(args, ARGUMENT_SAMPLE_SIZE, 0.66, lambda x: 0 < x < 1)
             return RandomInstanceSubsetSelection(sample_size)
         raise ValueError('Invalid value given for parameter \'instance_sub_sampling\': ' + str(instance_sub_sampling))
 


### PR DESCRIPTION
In Pull-Request #107 hat sich noch ein weiterer kleiner Fehler eingeschlichen. Wenn RandomInstanceSelection verwendet wird, dann wurde standardmäßig eine "sample_size" von 0 statt 0.66 verwendet.