### PR TITLE
Fehler bei argsort von quality_scores

### DIFF
--- a/python/boomer/algorithm/head_refinement.pxd
+++ b/python/boomer/algorithm/head_refinement.pxd
@@ -3,6 +3,14 @@ from boomer.algorithm.lift_functions cimport LiftFunction
 from boomer.algorithm.losses cimport Loss, Prediction
 
 
+"""
+A struct that stores a value of type float64 and a corresponding index that refers to the (original) position of the
+value in an array.
+"""
+cdef struct IndexedValue:
+    intp index
+    float64 value
+
 
 cdef class HeadCandidate:
 

--- a/python/boomer/algorithm/head_refinement.pyx
+++ b/python/boomer/algorithm/head_refinement.pyx
@@ -3,14 +3,11 @@
 
 Provides classes that implement strategies for finding the heads of rules.
 """
-from boomer.algorithm._arrays cimport array_intp, array_float64, get_index, float32
+from boomer.algorithm._arrays cimport array_intp, array_float64, get_index
 from boomer.algorithm.losses cimport LabelIndependentPrediction
-from boomer.algorithm.lift_functions cimport LiftFunction
-from boomer.algorithm.rule_induction cimport IndexedValue
 
 from libc.stdlib cimport qsort
 from cpython.mem cimport PyMem_Malloc as malloc, PyMem_Free as free
-from boomer.algorithm.rule_induction cimport compare_indexed_value
 
 cdef class HeadCandidate:
     """
@@ -283,9 +280,9 @@ cdef inline intp[::1] __argsort(float64[::1] values):
     try:
         for i in range(num_values):
             tmp_array[i].index = i
-            tmp_array[i].value = <float32> values[i]
+            tmp_array[i].value = values[i]
 
-        qsort(tmp_array, num_values, sizeof(IndexedValue), &compare_indexed_value)
+        qsort(tmp_array, num_values, sizeof(IndexedValue), &__compare_indexed_value)
 
         for i in range(num_values):
             sorted_array[i] = tmp_array[i].index
@@ -293,3 +290,17 @@ cdef inline intp[::1] __argsort(float64[::1] values):
         free(tmp_array)
 
     return sorted_array
+
+
+cdef int __compare_indexed_value(const void* a, const void* b) nogil:
+    """
+    Compares the values of two structs of type `IndexedValue`.
+
+    :param a:   A pointer to the first struct
+    :param b:   A pointer to the second struct
+    :return:    -1 if the value of the first struct is smaller than the value of the second struct, 0 if both values are
+                equal, or 1 if the value of the first struct is greater than the value of the second struct
+    """
+    cdef float64 v1 = (<IndexedValue*>a).value
+    cdef float64 v2 = (<IndexedValue*>b).value
+    return -1 if v1 < v2 else (0 if v1 == v2 else 1)

--- a/python/boomer/algorithm/rule_induction.pxd
+++ b/python/boomer/algorithm/rule_induction.pxd
@@ -97,17 +97,3 @@ cdef inline bint test_condition(float32 threshold, Comparator comparator, float3
         return feature_value == threshold
     else:
         return feature_value != threshold
-
-
-cdef inline int compare_indexed_value(const void* a, const void* b) nogil:
-    """
-    Compares the values of two structs of type `IndexedValue`.
-
-    :param a:   A pointer to the first struct
-    :param b:   A pointer to the second struct
-    :return:    -1 if the value of the first struct is smaller than the value of the second struct, 0 if both values are
-                equal, or 1 if the value of the first struct is greater than the value of the second struct
-    """
-    cdef float32 v1 = (<IndexedValue*>a).value
-    cdef float32 v2 = (<IndexedValue*>b).value
-    return -1 if v1 < v2 else (0 if v1 == v2 else 1)

--- a/python/boomer/algorithm/rule_induction.pyx
+++ b/python/boomer/algorithm/rule_induction.pyx
@@ -479,7 +479,7 @@ cdef inline intp* __argsort_by_feature_values(float32[::1] feature_values):
             tmp_array[i].index = i
             tmp_array[i].value = feature_values[i]
 
-        qsort(tmp_array, num_values, sizeof(IndexedValue), &compare_indexed_value)
+        qsort(tmp_array, num_values, sizeof(IndexedValue), &__compare_indexed_value)
         sorted_array = <intp*>malloc(num_values * sizeof(intp))
 
         for i in range(num_values):
@@ -488,6 +488,20 @@ cdef inline intp* __argsort_by_feature_values(float32[::1] feature_values):
         return sorted_array
     finally:
         free(tmp_array)
+
+
+cdef int __compare_indexed_value(const void* a, const void* b) nogil:
+    """
+    Compares the values of two structs of type `IndexedValue`.
+
+    :param a:   A pointer to the first struct
+    :param b:   A pointer to the second struct
+    :return:    -1 if the value of the first struct is smaller than the value of the second struct, 0 if both values are
+                equal, or 1 if the value of the first struct is greater than the value of the second struct
+    """
+    cdef float32 v1 = (<IndexedValue*>a).value
+    cdef float32 v2 = (<IndexedValue*>b).value
+    return -1 if v1 < v2 else (0 if v1 == v2 else 1)
 
 
 cdef inline Condition __make_condition(intp feature_index, Comparator comparator, float32 threshold):


### PR DESCRIPTION
Seitdem rule_induction.compare_indexed_value() in head_refinement.__argsort() verwendet wird, werden bei dem Aufruf dort float64 Werte als float32 Werte behandelt, was zu fehlerhaften Ergebnissen führt. Dieser Pull-Request soll diesen Bug beheben.