### PR TITLE
Berechnung des quality_score in PartialHeadRefinement

### DIFF
--- a/python/boomer/algorithm/head_refinement.pyx
+++ b/python/boomer/algorithm/head_refinement.pyx
@@ -157,9 +157,10 @@ cdef class PartialHeadRefinement(HeadRefinement):
             maximum_lift = lift.get_max_lift()
             for c in range(0, num_labels):
                 # select the top element of sorted_label_indices excluding labels already contained
-                total_quality_score += quality_scores[sorted_indices[c]]
+                total_quality_score += 1 - quality_scores[sorted_indices[c]]
 
-                quality_score = (1 - (1 - total_quality_score) * lift.eval(c + 1)) / (c + 1)
+                quality_score = 1 - (total_quality_score / (c + 1)) * lift.eval(c + 1)
+
 
                 if best_head_candidate_length == 0 or quality_score < best_quality_score:
                     best_head_candidate_length = c + 1
@@ -176,9 +177,9 @@ cdef class PartialHeadRefinement(HeadRefinement):
 
             for c in range(0, num_labels):
                 # select the top element of sorted_label_indices excluding labels already contained
-                total_quality_score += quality_scores[c]
+                total_quality_score += 1 - quality_scores[c]
 
-            best_quality_score = (1 - (1 - total_quality_score) * lift.eval(num_labels)) / num_labels
+            best_quality_score = 1 - (total_quality_score/num_labels) * lift.eval(num_labels)
 
             best_head_candidate_length = label_indices.shape[0]
 


### PR DESCRIPTION
Ich habe mir nochmal die Berechnung des quality scores in head_refinement angeguckt.

Momentan findet die Berechnung so statt:

```
for c in range(0, num_labels):
    total_quality_score += quality_scores[c]

best_quality_score =  (1 - (1 - total_quality_score) * lift.eval(num_labels)) / num_labels
```

Das lezte mal hatten wir in #85 darüber diskutiert, allerdings bist du bei dem Beispiel von nur einer Regel ausgegangen und ich habe das dann falsch übertragen auf die Berechnung des gesamten quality scores.

Müsste die Berechnung nicht folgendermaßen ablaufen?

```
for c in range(0, num_labels):
    total_quality_score += 1 - quality_scores[c]

best_quality_score = 1 - (total_quality_score/num_labels) * lift.eval(num_labels)
```

1. Durchschittlicher quality score wird gebildet (total_quality_score/num_labels) wobei 1 dem perfekten quality score entsprechen würde und 0 dem schlechtesten
2. Dieser quality score wird geliftet und umgekehrt