### PR TITLE
Kleine Performanceverbesserungen in rule_induction.pyx

### DIFF
--- a/python/boomer/common/rule_induction.pyx
+++ b/python/boomer/common/rule_induction.pyx
@@ -945,16 +945,19 @@ cdef inline intp __adjust_split(IndexedArray* indexed_array, intp condition_end,
     cdef intp adjusted_position = condition_end
     cdef bint ascending = condition_end < condition_previous
     cdef intp direction = 1 if ascending else -1
+    cdef intp start = condition_end + direction
+    cdef intp num_steps = abs(start - condition_previous)
     cdef float32 feature_value
     cdef bint adjust
-    cdef intp r
+    cdef intp i, r
 
     # Traverse the examples in ascending (or descending) order until we encounter an example that is contained in the
     # current sub-sample...
-    for r in range(condition_end + direction, condition_previous, direction):
+    for i in range(num_steps):
         # Check if the current position should be adjusted, or not. This is the case, if the feature value of the
         # current example is smaller than or equal to the given `threshold` (or greater than the `threshold`, if we
         # traverse in descending direction).
+        r = start + (i * direction)
         feature_value = indexed_values[r].value
         adjust = (feature_value <= threshold if ascending else feature_value > threshold)
 
@@ -1009,10 +1012,11 @@ cdef inline uint32 __filter_current_indices(IndexedArray* indexed_array, Indexed
     cdef intp num_indexed_values = dereference(indexed_array).num_elements
     cdef bint descending = condition_end < condition_start
     cdef uint32 updated_target, weight
-    cdef intp start, end, direction, i, r, index
+    cdef intp start, end, direction, i, r, j, index, num_steps
 
     # Determine the number of elements in the filtered array...
-    cdef intp num_elements = abs(condition_start - condition_end)
+    cdef intp num_condition_steps = abs(condition_start - condition_end)
+    cdef intp num_elements = num_condition_steps
 
     if not covered:
         num_elements = num_indexed_values - num_elements
@@ -1037,7 +1041,9 @@ cdef inline uint32 __filter_current_indices(IndexedArray* indexed_array, Indexed
         # Retain the indices at positions [condition_start, condition_end) and set the corresponding values in
         # `covered_examples_mask` to `num_conditions`, which marks them as covered (because
         # `updated_target == num_conditions`)...
-        for r in range(condition_start, condition_end, direction):
+
+        for j in range(num_condition_steps):
+            r = condition_start + (j * direction)
             index = indexed_values[r].index
             covered_examples_mask[index] = num_conditions
             filtered_array[i].index = index
@@ -1059,7 +1065,10 @@ cdef inline uint32 __filter_current_indices(IndexedArray* indexed_array, Indexed
             # Retain the indices at positions [start, condition_start), while leaving the corresponding values in
             # `covered_examples_mask` untouched, such that all previously covered examples in said range are still
             # marked as covered, while previously uncovered examples are still marked as uncovered...
-            for r in range(start, condition_start, direction):
+            num_steps = abs(start - condition_start)
+
+            for j in range(num_steps):
+                r = start + (j * direction)
                 filtered_array[i].index = indexed_values[r].index
                 filtered_array[i].value = indexed_values[r].value
                 i += direction
@@ -1067,7 +1076,8 @@ cdef inline uint32 __filter_current_indices(IndexedArray* indexed_array, Indexed
         # Discard the indices at positions [condition_start, condition_end) and set the corresponding values in
         # `covered_examples_mask` to `num_conditions`, which marks them as uncovered (because
         # `updated_target != num_conditions`)...
-        for r in range(condition_start, condition_end, direction):
+        for j in range(num_condition_steps):
+            r = condition_start + (j * direction)
             index = indexed_values[r].index
             covered_examples_mask[index] = num_conditions
             weight = 1 if weights is None else weights[index]
@@ -1076,7 +1086,10 @@ cdef inline uint32 __filter_current_indices(IndexedArray* indexed_array, Indexed
         # Retain the indices at positions [condition_end, end), while leaving the corresponding values in
         # `covered_examples_mask` untouched, such that all previously covered examples in said range are still marked as
         # covered, while previously uncovered examples are still marked as uncovered...
-        for r in range(condition_end, end, direction):
+        num_steps = abs(condition_end - end)
+
+        for j in range(num_steps):
+            r = condition_end + (j * direction)
             filtered_array[i].index = indexed_values[r].index
             filtered_array[i].value = indexed_values[r].value
             i += direction


### PR DESCRIPTION
Ich habe festgestellt dass es einige Stellen in `rule_induction.pyx` gibt die vom Cython-Compiler nicht in effizient in C-Code umgewandet werden. Dieser Pull-Request behebt die beiden folgenden Problemfälle:

1. Es wird jetzt die Funktion `libc.math.fabs` verwendet um den absoluten Wert von Fließkommazahlen zu ermitteln und analog dazu `libc.stdlib.abs` für Integers. Für Letzteres wurde vom Compiler zuvor die Python-Function `abs` als Fallback verwendet.

2. Der Cython-Compiler kann wohl Schleifen wie `for i in range(start, stop, step)` nicht in effiziente C-Loops umwandeln wenn das Vorzeichen von `step` nicht zur Compile-Zeit feststeht (siehe https://github.com/cython/cython/issues/2519 und https://github.com/cython/cython/issues/532). Ich habe diese Schleifen mit Hilfe eines Workarounds (https://stackoverflow.com/questions/21382180/cython-pure-c-loop-optimization) so umgeschrieben dass sie in effizienten C-Code kompiliert werden können.

Nach meinen Tests liefert der geänderte Code die selben Ergebnisse bei minimaler Verbesserung der Laufzeit.