### PR TITLE
C-Funktionen malloc, realloc und free verwenden

### DIFF
--- a/python/boomer/boosting/example_wise_losses.pyx
+++ b/python/boomer/boosting/example_wise_losses.pyx
@@ -7,8 +7,7 @@ from boomer.common._arrays cimport uint8, array_float64, c_matrix_float64, fortr
 from boomer.boosting.differentiable_losses cimport _l2_norm_pow
 
 from libc.math cimport pow, exp, fabs
-
-from cpython.mem cimport PyMem_Malloc as malloc, PyMem_Free as free
+from libc.stdlib cimport malloc, free
 
 from scipy.linalg.cython_blas cimport ddot, dspmv
 from scipy.linalg.cython_lapack cimport dsysv

--- a/python/boomer/common/rule_induction.pyx
+++ b/python/boomer/common/rule_induction.pyx
@@ -10,14 +10,12 @@ from boomer.common.head_refinement cimport HeadCandidate
 from boomer.common.losses cimport RefinementSearch, DefaultPrediction, Prediction
 
 from libc.math cimport fabs
-from libc.stdlib cimport abs, qsort
+from libc.stdlib cimport abs, qsort, malloc, realloc, free
 
 from libcpp.list cimport list as double_linked_list
 from libcpp.pair cimport pair
 
 from cython.operator cimport dereference, postincrement
-
-from cpython.mem cimport PyMem_Malloc as malloc, PyMem_Realloc as realloc, PyMem_Free as free
 
 
 cdef class FeatureMatrix:

--- a/python/boomer/seco/head_refinement.pyx
+++ b/python/boomer/seco/head_refinement.pyx
@@ -2,9 +2,7 @@ from boomer.common._arrays cimport float64, array_intp, array_float64, get_index
 from boomer.common._tuples cimport IndexedFloat64, compare_indexed_float64
 from boomer.common.losses cimport LabelWisePrediction
 
-from libc.stdlib cimport qsort
-
-from cpython.mem cimport PyMem_Malloc as malloc, PyMem_Free as free
+from libc.stdlib cimport qsort, malloc, free
 
 
 cdef class PartialHeadRefinement(HeadRefinement):


### PR DESCRIPTION
Ersetzt alle Aufrufe der Python-Funktionen `PyMem_Malloc`, `PyMem_Realloc` und `PyMem_Free` mit den entsprechenden Funktionen `malloc`, `realloc` und `free` aus `libc.stdlib`.