### PR TITLE
Änderungen in API der Loss-Klasse - Teil 2

### DIFF
--- a/python/boomer/boosting/differentiable_losses.pxd
+++ b/python/boomer/boosting/differentiable_losses.pxd
@@ -10,9 +10,11 @@ cdef class DifferentiableLoss(Loss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 
@@ -35,9 +37,11 @@ cdef class DecomposableDifferentiableLoss(DifferentiableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 
@@ -60,9 +64,11 @@ cdef class NonDecomposableDifferentiableLoss(DifferentiableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 

--- a/python/boomer/boosting/differentiable_losses.pyx
+++ b/python/boomer/boosting/differentiable_losses.pyx
@@ -15,12 +15,16 @@ cdef class DifferentiableLoss(Loss):
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y):
         pass
 
-    cdef void reset_examples(self):
-        pass
+    cdef void reset_sampled_examples(self):
+        # This function is equivalent to the function `reset_covered_examples`...
+        self.reset_covered_examples()
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight):
         # This function is equivalent to the function `update_covered_example`...
         self.update_covered_example(example_index, weight, False)
+
+    cdef void reset_covered_examples(self):
+        pass
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove):
         pass
@@ -51,7 +55,7 @@ cdef class DecomposableDifferentiableLoss(DifferentiableLoss):
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y):
         pass
 
-    cdef void reset_examples(self):
+    cdef void reset_covered_examples(self):
         pass
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove):
@@ -86,7 +90,7 @@ cdef class NonDecomposableDifferentiableLoss(DifferentiableLoss):
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y):
         pass
 
-    cdef void reset_examples(self):
+    cdef void reset_covered_examples(self):
         pass
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove):

--- a/python/boomer/boosting/example_wise_losses.pxd
+++ b/python/boomer/boosting/example_wise_losses.pxd
@@ -37,9 +37,11 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableDifferentiableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 

--- a/python/boomer/boosting/example_wise_losses.pyx
+++ b/python/boomer/boosting/example_wise_losses.pyx
@@ -164,7 +164,7 @@ cdef class ExampleWiseLogisticLoss(NonDecomposableDifferentiableLoss):
 
         return scores
 
-    cdef void reset_examples(self):
+    cdef void reset_covered_examples(self):
         # Class members
         cdef float64[::1] total_sums_of_gradients = self.total_sums_of_gradients
         cdef float64[::1] total_sums_of_hessians = self.total_sums_of_hessians

--- a/python/boomer/boosting/label_wise_losses.pxd
+++ b/python/boomer/boosting/label_wise_losses.pxd
@@ -41,9 +41,11 @@ cdef class LabelWiseDifferentiableLoss(DecomposableDifferentiableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 
@@ -68,9 +70,11 @@ cdef class LabelWiseSquaredErrorLoss(LabelWiseDifferentiableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 
@@ -95,9 +99,11 @@ cdef class LabelWiseLogisticLoss(LabelWiseDifferentiableLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 

--- a/python/boomer/boosting/label_wise_losses.pyx
+++ b/python/boomer/boosting/label_wise_losses.pyx
@@ -127,7 +127,7 @@ cdef class LabelWiseDifferentiableLoss(DecomposableDifferentiableLoss):
 
         return scores
 
-    cdef void reset_examples(self):
+    cdef void reset_covered_examples(self):
         # Class members
         cdef float64[::1] total_sums_of_gradients = self.total_sums_of_gradients
         cdef float64[::1] total_sums_of_hessians = self.total_sums_of_hessians

--- a/python/boomer/common/losses.pxd
+++ b/python/boomer/common/losses.pxd
@@ -23,9 +23,11 @@ cdef class Loss:
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 

--- a/python/boomer/common/losses.pyx
+++ b/python/boomer/common/losses.pyx
@@ -56,16 +56,13 @@ cdef class Loss:
         """
         pass
 
-    cdef void reset_examples(self):
+    cdef void reset_sampled_examples(self):
         """
         Notifies the loss function that the examples, which should be considered in the following for learning a new
-        rule or refining an existing one, have changed. The indices of the respective examples must be provided via
-        subsequent calls to the function `add_sampled_example` or `update_covered_example`.
+        rule have changed. The indices of the respective examples must be provided via subsequent calls to the function
+        `add_sampled_example`.
 
-        This function must be invoked before a new rule is learned from scratch (as each rule may be learned on a
-        different sub-sample of the training data), as well as each time an existing rule has been refined, i.e.
-        when a new condition has been added to its body (because this results in fewer examples being covered by the
-        refined rule).
+        This function must be invoked before a new rule is learned from scratch.
 
         This function is supposed to reset any non-global internal state that only holds for a certain set of examples
         and therefore becomes invalid when different examples are used, e.g. statistics about the ground truth labels of
@@ -88,6 +85,21 @@ cdef class Loss:
 
         :param example_index:   The index of an example that should be considered
         :param weight:          The weight of the example that should be considered
+        """
+        pass
+
+    cdef void reset_covered_examples(self):
+        """
+        Notifies the loss function that the examples, which should be considered in the following for refining an
+        existing rule, have changed. The indices of the respective examples must be provided via subsequent calls to the
+        function `update_covered_example`.
+
+        This function must be invoked each time an existing rule has been refined, i.e. when a new condition has been
+        added to its body, because this results in fewer examples being covered by the refined rule.
+
+        This function is supposed to reset any non-global internal state that only holds for a certain set of examples
+        and therefore becomes invalid when different examples are used, e.g. statistics about the ground truth labels of
+        particular examples.
         """
         pass
 

--- a/python/boomer/common/pruning.pyx
+++ b/python/boomer/common/pruning.pyx
@@ -79,7 +79,7 @@ cdef class IREP(Pruning):
         cdef bint uncovered
 
         # Tell the loss function to start a new search...
-        loss.reset_examples()
+        loss.reset_sampled_examples()
         loss.begin_search(label_indices)
 
         # Tell the loss function about all examples in the prune set that are covered by the existing rule...
@@ -170,7 +170,7 @@ cdef class IREP(Pruning):
             # the covered examples and notify the loss function about the updated sub-sample...
             if (n + 1) < num_conditions:
                 if not uncovered:
-                    loss.reset_examples()
+                    loss.reset_covered_examples()
                     current_covered_examples_target = n
 
                 for r in range(start, end):

--- a/python/boomer/common/rule_induction.pyx
+++ b/python/boomer/common/rule_induction.pyx
@@ -296,7 +296,7 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
             total_sum_of_weights = uint32_array_scalar_pair.second
 
         # Notify the loss function about the examples that are included in the sub-sample...
-        loss.reset_examples()
+        loss.reset_sampled_examples()
 
         for i in range(num_examples):
             weight = 1 if weights is None else weights[i]
@@ -1023,7 +1023,7 @@ cdef inline uint32 __filter_current_indices(IndexedArray* indexed_array, Indexed
 
     if covered:
         updated_target = num_conditions
-        loss.reset_examples()
+        loss.reset_covered_examples()
 
         # Retain the indices at positions [condition_start, condition_end) and set the corresponding values in
         # `covered_examples_mask` to `num_conditions`, which marks them as covered (because

--- a/python/boomer/seco/coverage_losses.pxd
+++ b/python/boomer/seco/coverage_losses.pxd
@@ -12,9 +12,11 @@ cdef class CoverageLoss(Loss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 
@@ -37,9 +39,11 @@ cdef class DecomposableCoverageLoss(CoverageLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 

--- a/python/boomer/seco/coverage_losses.pyx
+++ b/python/boomer/seco/coverage_losses.pyx
@@ -15,12 +15,16 @@ cdef class CoverageLoss(Loss):
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y):
         pass
 
-    cdef void reset_examples(self):
-        pass
+    cdef void reset_sampled_examples(self):
+        # This function is equivalent to the function `reset_covered_examples`...
+        self.reset_covered_examples()
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight):
         # This function is equivalent to the function `update_covered_example`...
         self.update_covered_example(example_index, weight, False)
+
+    cdef void reset_covered_examples(self):
+        pass
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove):
         pass
@@ -52,7 +56,7 @@ cdef class DecomposableCoverageLoss(CoverageLoss):
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y):
         pass
 
-    cdef void reset_examples(self):
+    cdef void reset_covered_examples(self):
         pass
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove):

--- a/python/boomer/seco/label_wise_averaging.pxd
+++ b/python/boomer/seco/label_wise_averaging.pxd
@@ -32,9 +32,11 @@ cdef class LabelWiseAveraging(DecomposableCoverageLoss):
 
     cdef float64[::1] calculate_default_scores(self, uint8[::1, :] y)
 
-    cdef void reset_examples(self)
+    cdef void reset_sampled_examples(self)
 
     cdef void add_sampled_example(self, intp example_index, uint32 weight)
+
+    cdef void reset_covered_examples(self)
 
     cdef void update_covered_example(self, intp example_index, uint32 weight, bint remove)
 

--- a/python/boomer/seco/label_wise_averaging.pyx
+++ b/python/boomer/seco/label_wise_averaging.pyx
@@ -60,7 +60,7 @@ cdef class LabelWiseAveraging(DecomposableCoverageLoss):
 
         return default_rule
 
-    cdef void reset_examples(self):
+    cdef void reset_covered_examples(self):
         cdef float64[::1, :] confusion_matrices_default = self.confusion_matrices_default
         cdef uint8[::1, :] true_labels = self.true_labels
         cdef intp num_examples = true_labels.shape[0]


### PR DESCRIPTION
Hier eine Ergänzung zu Pull-Request #144.

Ich habe gemerkt, dass nicht ausreicht zwischen den Funktionen `add_sampled_example` und `update_covered_example` zu unterscheiden um das Instance-Sub-Sampling mit dem SeCo-Algorithmus zum Laufen zu bringen. Analog dazu muss es auch möglich sein zu unterscheiden zu welchem Zweck die bisherige Funktion `reset_examples` aufgerufen wird. 

Aus diesem Grund habe ich diese Funktion durch zwei neue Funktionen `reset_sampled_examples` und `reset_covered_examples` ersetzt. Wie im vorherigen Pull-Request verweisen beide Funktion erst einmal auf die bestehende Implementierung. In `rule_induction.pyx` und `pruning.pyx` wird jetzt eine dieser beiden neuen Funktionen aufgerufen, je nachdem welcher Aufruf für die jeweilige Situation angebracht ist.