### PR TITLE
Funktionsargumente der Klasse ModelBuilder anpassen

### DIFF
--- a/python/boomer/boosting/differentiable_losses.pxd
+++ b/python/boomer/boosting/differentiable_losses.pxd
@@ -2,6 +2,7 @@ from boomer.common._arrays cimport uint32, intp, float64
 from boomer.common.losses cimport LabelMatrix
 from boomer.common.losses cimport Loss, RefinementSearch
 from boomer.common.losses cimport DefaultPrediction, Prediction, LabelWisePrediction
+from boomer.common.head_refinement cimport HeadCandidate
 
 from libc.math cimport pow
 
@@ -20,7 +21,7 @@ cdef class DifferentiableLoss(Loss):
 
     cdef RefinementSearch begin_search(self, intp[::1] label_indices)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores)
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head)
 
 
 cdef inline float64 _l2_norm_pow(float64* a, intp n):

--- a/python/boomer/boosting/differentiable_losses.pyx
+++ b/python/boomer/boosting/differentiable_losses.pyx
@@ -28,5 +28,5 @@ cdef class DifferentiableLoss(Loss):
     cdef RefinementSearch begin_search(self, intp[::1] label_indices):
         pass
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores):
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head):
         pass

--- a/python/boomer/boosting/example_wise_losses.pxd
+++ b/python/boomer/boosting/example_wise_losses.pxd
@@ -2,6 +2,7 @@ from boomer.common._arrays cimport uint32, intp, float64
 from boomer.common.losses cimport LabelMatrix
 from boomer.common.losses cimport RefinementSearch, NonDecomposableRefinementSearch
 from boomer.common.losses cimport DefaultPrediction, Prediction, LabelWisePrediction
+from boomer.common.head_refinement cimport HeadCandidate
 from boomer.boosting.differentiable_losses cimport DifferentiableLoss
 
 
@@ -90,4 +91,4 @@ cdef class ExampleWiseLoss(DifferentiableLoss):
 
     cdef RefinementSearch begin_search(self, intp[::1] label_indices)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores)
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head)

--- a/python/boomer/boosting/example_wise_losses.pyx
+++ b/python/boomer/boosting/example_wise_losses.pyx
@@ -442,7 +442,7 @@ cdef class ExampleWiseLoss(DifferentiableLoss):
         return ExampleWiseRefinementSearch.__new__(ExampleWiseRefinementSearch, l2_regularization_weight, label_indices,
                                                    gradients, total_sums_of_gradients, hessians, total_sums_of_hessians)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores):
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head):
         # Class members
         cdef ExampleWiseLossFunction loss_function = self.loss_function
         cdef LabelMatrix label_matrix = self.label_matrix
@@ -450,13 +450,15 @@ cdef class ExampleWiseLoss(DifferentiableLoss):
         cdef float64[:, ::1] gradients = self.gradients
         cdef float64[:, ::1] hessians = self.hessians
         # The number of predicted labels
-        cdef intp num_predicted_labels = predicted_scores.shape[0]
+        cdef intp num_predictions = head.numPredictions_
+        # The predicted scores
+        cdef float64* predicted_scores = head.predictedScores_
         # Temporary variables
         cdef intp c, l
 
         # Traverse the labels for which the new rule predicts to update the scores that are currently predicted for the
         # example at the given index...
-        for c in range(num_predicted_labels):
+        for c in range(num_predictions):
             l = get_index(c, label_indices)
             current_scores[example_index, l] += predicted_scores[c]
 

--- a/python/boomer/boosting/label_wise_losses.pxd
+++ b/python/boomer/boosting/label_wise_losses.pxd
@@ -2,6 +2,7 @@ from boomer.common._arrays cimport uint32, intp, float64
 from boomer.common.losses cimport LabelMatrix
 from boomer.common.losses cimport RefinementSearch, DecomposableRefinementSearch
 from boomer.common.losses cimport DefaultPrediction, Prediction, LabelWisePrediction
+from boomer.common.head_refinement cimport HeadCandidate
 from boomer.boosting.differentiable_losses cimport DifferentiableLoss
 
 from libcpp.pair cimport pair
@@ -100,4 +101,4 @@ cdef class LabelWiseDifferentiableLoss(DifferentiableLoss):
 
     cdef RefinementSearch begin_search(self, intp[::1] label_indices)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores)
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head)

--- a/python/boomer/boosting/label_wise_losses.pyx
+++ b/python/boomer/boosting/label_wise_losses.pyx
@@ -347,7 +347,7 @@ cdef class LabelWiseDifferentiableLoss(DifferentiableLoss):
         return LabelWiseRefinementSearch.__new__(LabelWiseRefinementSearch, l2_regularization_weight, label_indices,
                                                  gradients, total_sums_of_gradients, hessians, total_sums_of_hessians)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores):
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head):
         # Class members
         cdef LabelWiseLossFunction loss_function = self.loss_function
         cdef LabelMatrix label_matrix = self.label_matrix
@@ -355,14 +355,16 @@ cdef class LabelWiseDifferentiableLoss(DifferentiableLoss):
         cdef float64[:, ::1] gradients = self.gradients
         cdef float64[:, ::1] hessians = self.hessians
         # The number of predicted labels
-        cdef intp num_predicted_labels = predicted_scores.shape[0]
+        cdef intp num_predictions = head.numPredictions_
+        # The predicted scores
+        cdef float64* predicted_scores = head.predictedScores_
         # Temporary variables
         cdef pair[float64, float64] gradient_and_hessian
         cdef float64 predicted_score, current_score, gradient, hessian
         cdef intp c, l
 
         # Only the labels that are predicted by the new rule must be considered...
-        for c in range(num_predicted_labels):
+        for c in range(num_predictions):
             l = get_index(c, label_indices)
             predicted_score = predicted_scores[c]
 

--- a/python/boomer/common/losses.pxd
+++ b/python/boomer/common/losses.pxd
@@ -1,5 +1,6 @@
 from boomer.common._arrays cimport uint8, uint32, intp, float64
 from boomer.common._sparse cimport BinaryDokMatrix
+from boomer.common.head_refinement cimport HeadCandidate
 
 
 cdef extern from "cpp/losses.h" namespace "losses":
@@ -122,4 +123,4 @@ cdef class Loss:
 
     cdef RefinementSearch begin_search(self, intp[::1] label_indices)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores)
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head)

--- a/python/boomer/common/losses.pyx
+++ b/python/boomer/common/losses.pyx
@@ -332,7 +332,7 @@ cdef class Loss:
         """
         pass
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores):
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head):
         """
         Notifies the loss function about the predictions of a new rule that has been induced.
 
@@ -346,7 +346,7 @@ cdef class Loss:
         :param label_indices:       An array of dtype int, shape `(num_predicted_labels)`, representing the indices of
                                     the labels for which the newly induced rule predicts or None, if the rule predicts
                                     for all labels
-        :param predicted_scores:    An array of dtype float, shape `(num_predicted_labels)`, representing the scores
-                                    that are predicted by the newly induced rule
+        :param head:                A pointer to an object of type `HeadCandidate`, representing the head of the newly
+                                    induced rule
         """
         pass

--- a/python/boomer/common/rule_induction.pyx
+++ b/python/boomer/common/rule_induction.pyx
@@ -851,7 +851,6 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
             else:
                 num_predictions = head.numPredictions_
                 label_indices = <intp[:num_predictions]>head.labelIndices_ if head.labelIndices_ != NULL else None
-                predicted_scores = <float64[:num_predictions]>head.predictedScores_
 
                 if weights is not None:
                     # Prune rule, if necessary (a rule can only be pruned if it contains more than one condition)...
@@ -873,19 +872,19 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                     prediction = head_refinement.calculate_prediction(refinement_search, False, False)
 
                     for c in range(num_predictions):
-                        predicted_scores[c] = prediction.predictedScores_[c]
+                        head.predictedScores_[c] = prediction.predictedScores_[c]
 
                 # Apply shrinkage, if necessary...
                 if shrinkage is not None:
-                    shrinkage.apply_shrinkage(predicted_scores)
+                    shrinkage.apply_shrinkage(head)
 
                 # Tell the loss function that a new rule has been induced...
                 for r in range(num_examples):
                     if covered_examples_mask[r] == covered_examples_target:
-                        loss.apply_prediction(r, label_indices, predicted_scores)
+                        loss.apply_prediction(r, label_indices, head)
 
                 # Add the induced rule to the model...
-                model_builder.add_rule(label_indices, predicted_scores, conditions, num_conditions_per_comparator)
+                model_builder.add_rule(label_indices, head, conditions, num_conditions_per_comparator)
                 return True
         finally:
             del head

--- a/python/boomer/common/rules.pxd
+++ b/python/boomer/common/rules.pxd
@@ -1,5 +1,6 @@
 from boomer.common._arrays cimport uint8, uint32, intp, float32, float64
 from boomer.common.losses cimport DefaultPrediction
+from boomer.common.head_refinement cimport HeadCandidate
 
 from libcpp.list cimport list as double_linked_list
 
@@ -156,7 +157,7 @@ cdef class ModelBuilder:
 
     cdef void set_default_rule(self, DefaultPrediction* default_prediction)
 
-    cdef void add_rule(self, intp[::1] label_indices, float64[::1] scores, double_linked_list[Condition] conditions,
+    cdef void add_rule(self, intp[::1] label_indices, HeadCandidate* head, double_linked_list[Condition] conditions,
                        intp[::1] num_conditions_per_comparator)
 
     cdef RuleModel build_model(self)
@@ -178,7 +179,7 @@ cdef class RuleListBuilder(ModelBuilder):
 
     cdef void set_default_rule(self, DefaultPrediction* default_prediction)
 
-    cdef void add_rule(self, intp[::1] label_indices, float64[::1] scores, double_linked_list[Condition] conditions,
+    cdef void add_rule(self, intp[::1] label_indices, HeadCandidate* head, double_linked_list[Condition] conditions,
                        intp[::1] num_conditions_per_comparator)
 
     cdef RuleModel build_model(self)

--- a/python/boomer/common/rules.pyx
+++ b/python/boomer/common/rules.pyx
@@ -578,7 +578,7 @@ cdef class ModelBuilder:
         """
         pass
 
-    cdef void add_rule(self, intp[::1] label_indices, float64[::1] scores, double_linked_list[Condition] conditions,
+    cdef void add_rule(self, intp[::1] label_indices, HeadCandidate* head, double_linked_list[Condition] conditions,
                        intp[::1] num_conditions_per_comparator):
         """
         Adds a new rule to the model.
@@ -586,8 +586,8 @@ cdef class ModelBuilder:
         :param label_indices:                   An array of dtype int, shape `(num_predicted_labels)`, representing the
                                                 indices of the labels for which the rule predicts or None, if the rule
                                                 predicts for all labels
-        :param scores:                          An array of dtype float, shape `(num_predicted_labels)`, representing
-                                                the scores that are predicted by the rule
+        :param head:                            A pointer to an object of type `HeadCandidate`, representing the head of
+                                                the rule
         :param conditions:                      A list that contains the rule's conditions
         :param num_conditions_per_comparator:   An array of dtype int, shape `(4)`, representing the number of
                                                 conditions that use a specific operator
@@ -637,7 +637,7 @@ cdef class RuleListBuilder(ModelBuilder):
 
         self.rule_list = rule_list
 
-    cdef void add_rule(self, intp[::1] label_indices, float64[::1] scores, double_linked_list[Condition] conditions,
+    cdef void add_rule(self, intp[::1] label_indices, HeadCandidate* head, double_linked_list[Condition] conditions,
                        intp[::1] num_conditions_per_comparator):
         cdef intp num_conditions = num_conditions_per_comparator[<intp>Comparator.LEQ]
         cdef intp[::1] leq_feature_indices = array_intp(num_conditions) if num_conditions > 0 else None
@@ -682,24 +682,28 @@ cdef class RuleListBuilder(ModelBuilder):
 
             postincrement(iterator)
 
-        cdef ConjunctiveBody body = ConjunctiveBody.__new__(ConjunctiveBody, leq_feature_indices, leq_thresholds,
-                                                            gr_feature_indices, gr_thresholds, eq_feature_indices,
-                                                            eq_thresholds, neq_feature_indices, neq_thresholds)
+        cdef ConjunctiveBody rule_body = ConjunctiveBody.__new__(ConjunctiveBody, leq_feature_indices, leq_thresholds,
+                                                                 gr_feature_indices, gr_thresholds, eq_feature_indices,
+                                                                 eq_thresholds, neq_feature_indices, neq_thresholds)
 
-        cdef intp num_predictions = scores.shape[0]
+        cdef intp num_predictions = head.numPredictions_
+        cdef float64* predicted_scores = head.predictedScores_
         cdef float64[::1] head_scores = array_float64(num_predictions)
-        head_scores[:] = scores
         cdef intp[::1] head_label_indices
-        cdef Head head
+        cdef Head rule_head
+        cdef intp c
+
+        for c in range(num_predictions):
+            head_scores[c] = predicted_scores[c]
 
         if label_indices is None:
-            head = FullHead.__new__(FullHead, head_scores)
+            rule_head = FullHead.__new__(FullHead, head_scores)
         else:
             head_label_indices = array_intp(num_predictions)
             head_label_indices[:] = label_indices
-            head = PartialHead.__new__(PartialHead, head_label_indices, head_scores)
+            rule_head = PartialHead.__new__(PartialHead, head_label_indices, head_scores)
 
-        cdef rule = Rule.__new__(Rule, body, head)
+        cdef rule = Rule.__new__(Rule, rule_body, rule_head)
         cdef RuleList rule_list = self.rule_list
         rule_list.add_rule(rule)
 

--- a/python/boomer/common/shrinkage.pxd
+++ b/python/boomer/common/shrinkage.pxd
@@ -1,19 +1,20 @@
 from boomer.common._arrays cimport float64
+from boomer.common.head_refinement cimport HeadCandidate
 
 
 cdef class Shrinkage:
 
     # Functions:
 
-    cdef void apply_shrinkage(self, float64[::1] predicted_scores)
+    cdef void apply_shrinkage(self, HeadCandidate* head)
 
 
 cdef class ConstantShrinkage(Shrinkage):
 
     # Attributes:
 
-    cdef float shrinkage
+    cdef float64 shrinkage
 
     # Functions:
 
-    cdef void apply_shrinkage(self, float64[::1] predicted_scores)
+    cdef void apply_shrinkage(self, HeadCandidate* head)

--- a/python/boomer/common/shrinkage.pyx
+++ b/python/boomer/common/shrinkage.pyx
@@ -12,12 +12,11 @@ cdef class Shrinkage:
     a.k.a. the learning rate, may e.g. be constant or a function depending on the number of rules learned so far.
     """
 
-    cdef void apply_shrinkage(self, float64[::1] predicted_scores):
+    cdef void apply_shrinkage(self, HeadCandidate* head):
         """
         Applies the shrinkage parameter to the scores that are predicted by a rule.
         
-        :param predicted_scores: An array of dtype float, shape `(num_predicted_labels)`, representing the scores that 
-                                 are predicted by the rule
+        :param head: A pointer to an object of type `HeadCandidate`, representing the head of the rule
         """
         pass
 
@@ -27,16 +26,17 @@ cdef class ConstantShrinkage(Shrinkage):
     Shrinks the weights of rules by a constant factor.
     """
 
-    def __cinit__(self, float shrinkage = 1.0):
+    def __cinit__(self, float64 shrinkage = 1.0):
         """
         :param shrinkage: The constant factor to shrink the weights of rules. Must be in (0, 1]
         """
         self.shrinkage = shrinkage
 
-    cdef void apply_shrinkage(self, float64[::1] predicted_scores):
-        cdef float shrinkage = self.shrinkage
-        cdef intp num_labels = predicted_scores.shape[0]
+    cdef void apply_shrinkage(self, HeadCandidate* head):
+        cdef float64 shrinkage = self.shrinkage
+        cdef intp num_predictions = head.numPredictions_
+        cdef float64* predicted_scores = head.predictedScores_
         cdef intp c
 
-        for c in range(num_labels):
+        for c in range(num_predictions):
             predicted_scores[c] *= shrinkage

--- a/python/boomer/seco/coverage_losses.pxd
+++ b/python/boomer/seco/coverage_losses.pxd
@@ -2,6 +2,7 @@ from boomer.common._arrays cimport uint32, intp, float64
 from boomer.common.losses cimport LabelMatrix
 from boomer.common.losses cimport Loss, RefinementSearch
 from boomer.common.losses cimport DefaultPrediction, Prediction, LabelWisePrediction
+from boomer.common.head_refinement cimport HeadCandidate
 
 
 cdef class CoverageLoss(Loss):
@@ -22,4 +23,4 @@ cdef class CoverageLoss(Loss):
 
     cdef RefinementSearch begin_search(self, intp[::1] label_indices)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores)
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head)

--- a/python/boomer/seco/coverage_losses.pyx
+++ b/python/boomer/seco/coverage_losses.pyx
@@ -28,5 +28,5 @@ cdef class CoverageLoss(Loss):
     cdef RefinementSearch begin_search(self, intp[::1] label_indices):
         pass
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores):
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head):
         pass

--- a/python/boomer/seco/label_wise_averaging.pxd
+++ b/python/boomer/seco/label_wise_averaging.pxd
@@ -2,6 +2,7 @@ from boomer.common._arrays cimport uint8, uint32, intp, float64
 from boomer.common.losses cimport LabelMatrix
 from boomer.common.losses cimport RefinementSearch, DecomposableRefinementSearch
 from boomer.common.losses cimport DefaultPrediction, Prediction, LabelWisePrediction
+from boomer.common.head_refinement cimport HeadCandidate
 from boomer.seco.coverage_losses cimport CoverageLoss
 from boomer.seco.heuristics cimport Heuristic
 
@@ -69,4 +70,4 @@ cdef class LabelWiseAveraging(CoverageLoss):
 
     cdef RefinementSearch begin_search(self, intp[::1] label_indices)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores)
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head)

--- a/python/boomer/seco/label_wise_averaging.pyx
+++ b/python/boomer/seco/label_wise_averaging.pyx
@@ -285,16 +285,16 @@ cdef class LabelWiseAveraging(CoverageLoss):
                                                  uncovered_labels, minority_labels, confusion_matrices_default,
                                                  confusion_matrices_subsample_default)
 
-    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, float64[::1] predicted_scores):
+    cdef void apply_prediction(self, intp example_index, intp[::1] label_indices, HeadCandidate* head):
         cdef float64[::1, :] uncovered_labels = self.uncovered_labels
         cdef LabelMatrix label_matrix = self.label_matrix
         cdef uint8[::1] minority_labels = self.minority_labels
         cdef float64 sum_uncovered_labels = self.sum_uncovered_labels
-        cdef intp num_labels = predicted_scores.shape[0]
+        cdef intp num_predictions = head.numPredictions_
         cdef intp c, l
 
         # Only the labels that are predicted by the new rule must be considered
-        for c in range(num_labels):
+        for c in range(num_predictions):
             l = get_index(c, label_indices)
 
             if uncovered_labels[example_index, l] == 1:


### PR DESCRIPTION
Die Funktionen `set_default_rule`, bzw. `add_rule`, der Klasse `ModelBuilder` nehmen nun einen Pointer zu einem Objekt vom Typ `DefaultPrediction`, bzw. `HeadCandidate`, als Argument entgegen.

Außerdem nehmen die Funktionen `apply_shrinkage` der Klasse `Shrinkage`, sowie `apply_prediction` der Klasse `Loss`, einen Pointer zu einem Objekt vom Typ `HeadCandidate` entgegen.