### PR TITLE
Separates Argument für überschreibbares HeadCandidate-Objekt zu Funktion "find_head" hinzufügen

### DIFF
--- a/python/boomer/boosting/head_refinement.pxd
+++ b/python/boomer/boosting/head_refinement.pxd
@@ -7,7 +7,8 @@ cdef class FullHeadRefinement(HeadRefinement):
 
     # Functions:
 
-    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, intp[::1] label_indices,
-                                  RefinementSearch refinement_search, bint uncovered, bint accumulated)
+    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
+                                  intp[::1] label_indices, RefinementSearch refinement_search, bint uncovered,
+                                  bint accumulated)
 
     cdef Prediction* calculate_prediction(self, RefinementSearch refinement_search, bint uncovered, bint accumulated)

--- a/python/boomer/boosting/head_refinement.pyx
+++ b/python/boomer/boosting/head_refinement.pyx
@@ -13,37 +13,36 @@ cdef class FullHeadRefinement(HeadRefinement):
     Allows to find the best multi-label head that predicts for all labels.
     """
 
-    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, intp[::1] label_indices,
-                                  RefinementSearch refinement_search, bint uncovered, bint accumulated):
+    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
+                                  intp[::1] label_indices, RefinementSearch refinement_search, bint uncovered,
+                                  bint accumulated):
         cdef Prediction* prediction = refinement_search.calculate_example_wise_prediction(uncovered, accumulated)
         cdef intp num_predictions = prediction.numPredictions_
         cdef float64* predicted_scores = prediction.predictedScores_
         cdef float64 overall_quality_score = prediction.overallQualityScore_
         cdef intp* candidate_label_indices = NULL
         cdef float64* candidate_predicted_scores
-        cdef HeadCandidate* candidate
         cdef intp c
 
-        if best_head == NULL:
-            # Create a new `HeadCandidate` and return it...
-            candidate_predicted_scores = <float64*>malloc(num_predictions * sizeof(float64))
-
-            for c in range(num_predictions):
-                candidate_predicted_scores[c] = predicted_scores[c]
-
-            if label_indices is not None:
-                candidate_label_indices = <intp*>malloc(num_predictions * sizeof(intp))
+        # The quality score must be better than that of `best_head`...
+        if best_head == NULL or overall_quality_score < best_head.qualityScore_:
+            if recyclable_head == NULL:
+                # Create a new `HeadCandidate` and return it...
+                candidate_predicted_scores = <float64*>malloc(num_predictions * sizeof(float64))
 
                 for c in range(num_predictions):
-                    candidate_label_indices[c] = label_indices[c]
+                    candidate_predicted_scores[c] = predicted_scores[c]
 
-            candidate = new HeadCandidate(num_predictions, candidate_label_indices, candidate_predicted_scores,
-                                          overall_quality_score)
-            return candidate
-        else:
-            # The quality score must be better than that of `best_head`...
-            if overall_quality_score < best_head.qualityScore_:
-                # Modify the `best_head` and return it...
+                if label_indices is not None:
+                    candidate_label_indices = <intp*>malloc(num_predictions * sizeof(intp))
+
+                    for c in range(num_predictions):
+                        candidate_label_indices[c] = label_indices[c]
+
+                return new HeadCandidate(num_predictions, candidate_label_indices, candidate_predicted_scores,
+                                         overall_quality_score)
+            else:
+                # Modify the `recyclable_head` and return it...
                 for c in range(num_predictions):
                     best_head.predictedScores_[c] = predicted_scores[c]
 

--- a/python/boomer/common/head_refinement.pxd
+++ b/python/boomer/common/head_refinement.pxd
@@ -25,8 +25,9 @@ cdef class HeadRefinement:
 
     # Functions:
 
-    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, intp[::1] label_indices,
-                                  RefinementSearch refinement_search, bint uncovered, bint accumulated)
+    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
+                                  intp[::1] label_indices, RefinementSearch refinement_search, bint uncovered,
+                                  bint accumulated)
 
     cdef Prediction* calculate_prediction(self, RefinementSearch refinement_search, bint uncovered, bint accumulated)
 
@@ -35,7 +36,8 @@ cdef class SingleLabelHeadRefinement(HeadRefinement):
 
     # Functions:
 
-    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, intp[::1] label_indices,
-                                  RefinementSearch refinement_search, bint uncovered, bint accumulated)
+    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
+                                  intp[::1] label_indices, RefinementSearch refinement_search, bint uncovered,
+                                  bint accumulated)
 
     cdef Prediction* calculate_prediction(self, RefinementSearch refinement_search, bint uncovered, bint accumulated)

--- a/python/boomer/common/rule_induction.pyx
+++ b/python/boomer/common/rule_induction.pyx
@@ -425,8 +425,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                                 if previous_threshold != current_threshold:
                                     # Find and evaluate the best head for the current refinement, if a condition that
                                     # uses the <= operator (or the == operator in case of a nominal feature) is used...
-                                    current_head = head_refinement.find_head(head, label_indices, refinement_search,
-                                                                             False, False)
+                                    current_head = head_refinement.find_head(head, head, label_indices,
+                                                                             refinement_search, False, False)
 
                                     # If the refinement is better than the current rule...
                                     if current_head != NULL:
@@ -450,8 +450,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
 
                                     # Find and evaluate the best head for the current refinement, if a condition that
                                     # uses the > operator (or the != operator in case of a nominal feature) is used...
-                                    current_head = head_refinement.find_head(head, label_indices, refinement_search,
-                                                                             True, False)
+                                    current_head = head_refinement.find_head(head, head, label_indices,
+                                                                             refinement_search, True, False)
 
                                     # If the refinement is better than the current rule...
                                     if current_head != NULL:
@@ -495,8 +495,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                                                                or accumulated_sum_of_weights < total_sum_of_weights):
                             # Find and evaluate the best head for the current refinement, if a condition that uses the
                             # == operator is used...
-                            current_head = head_refinement.find_head(head, label_indices, refinement_search, False,
-                                                                     False)
+                            current_head = head_refinement.find_head(head, head, label_indices, refinement_search,
+                                                                     False, False)
 
                             # If the refinement is better than the current rule...
                             if current_head != NULL:
@@ -515,7 +515,7 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
 
                             # Find and evaluate the best head for the current refinement, if a condition that uses the !=
                             # operator is used...
-                            current_head = head_refinement.find_head(head, label_indices, refinement_search, True,
+                            current_head = head_refinement.find_head(head, head, label_indices, refinement_search, True,
                                                                      False)
 
                             # If the refinement is better than the current rule...
@@ -574,8 +574,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                                 if previous_threshold != current_threshold:
                                     # Find and evaluate the best head for the current refinement, if a condition that
                                     # uses the > operator (or the == operator in case of a nominal feature) is used...
-                                    current_head = head_refinement.find_head(head, label_indices, refinement_search,
-                                                                             False, False)
+                                    current_head = head_refinement.find_head(head, head, label_indices,
+                                                                             refinement_search, False, False)
 
                                     # If the refinement is better than the current rule...
                                     if current_head != NULL:
@@ -599,8 +599,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
 
                                     # Find and evaluate the best head for the current refinement, if a condition that
                                     # uses the <= operator (or the != operator in case of a nominal feature) is used...
-                                    current_head = head_refinement.find_head(head, label_indices, refinement_search,
-                                                                             True, False)
+                                    current_head = head_refinement.find_head(head, head, label_indices,
+                                                                             refinement_search, True, False)
 
                                     # If the refinement is better than the current rule...
                                     if current_head != NULL:
@@ -643,7 +643,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                     if nominal and sum_of_weights > 0 and sum_of_weights < accumulated_sum_of_weights:
                         # Find and evaluate the best head for the current refinement, if a condition that uses the ==
                         # operator is used...
-                        current_head = head_refinement.find_head(head, label_indices, refinement_search, False, False)
+                        current_head = head_refinement.find_head(head, head, label_indices, refinement_search, False,
+                                                                 False)
 
                         # If the refinement is better than the current rule...
                         if current_head != NULL:
@@ -662,7 +663,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
 
                         # Find and evaluate the best head for the current refinement, if a condition that uses the !=
                         # operator is used...
-                        current_head = head_refinement.find_head(head, label_indices, refinement_search, True, False)
+                        current_head = head_refinement.find_head(head, head, label_indices, refinement_search, True,
+                                                                 False)
 
                         # If the refinement is better than the current rule...
                         if current_head != NULL:
@@ -696,7 +698,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                         # Find and evaluate the best head for the current refinement, if the condition
                         # `f > previous_threshold / 2` (or the condition `f != 0` in case of a nominal feature) is
                         # used...
-                        current_head = head_refinement.find_head(head, label_indices, refinement_search, False, nominal)
+                        current_head = head_refinement.find_head(head, head, label_indices, refinement_search, False,
+                                                                 nominal)
 
                         # If the refinement is better than the current rule...
                         if current_head != NULL:
@@ -723,7 +726,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
 
                         # Find and evaluate the best head for the current refinement, if the condition
                         # `f <= previous_threshold / 2` (or `f == 0` in case of a nominal feature) is used...
-                        current_head = head_refinement.find_head(head, label_indices, refinement_search, True, nominal)
+                        current_head = head_refinement.find_head(head, head, label_indices, refinement_search, True,
+                                                                 nominal)
 
                         # If the refinement is better than the current rule...
                         if current_head != NULL:
@@ -756,7 +760,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                     if not nominal and accumulated_sum_of_weights_negative > 0 and accumulated_sum_of_weights_negative < total_sum_of_weights:
                         # Find and evaluate the best head for the current refinement, if the condition that uses the <=
                         # operator is used...
-                        current_head = head_refinement.find_head(head, label_indices, refinement_search, False, True)
+                        current_head = head_refinement.find_head(head, head, label_indices, refinement_search, False,
+                                                                 True)
 
                         if current_head != NULL:
                             found_refinement = True
@@ -782,7 +787,8 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
 
                         # Find and evaluate the best head for the current refinement, if the condition that uses the >
                         # operator is used...
-                        current_head = head_refinement.find_head(head, label_indices, refinement_search, True, True)
+                        current_head = head_refinement.find_head(head, head, label_indices, refinement_search, True,
+                                                                 True)
 
                         if current_head != NULL:
                             found_refinement = True

--- a/python/boomer/seco/head_refinement.pxd
+++ b/python/boomer/seco/head_refinement.pxd
@@ -12,7 +12,8 @@ cdef class PartialHeadRefinement(HeadRefinement):
 
     # Functions:
 
-    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, intp[::1] label_indices,
-                                  RefinementSearch refinement_search, bint uncovered, bint accumulated)
+    cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
+                                  intp[::1] label_indices, RefinementSearch refinement_search, bint uncovered,
+                                  bint accumulated)
 
     cdef Prediction* calculate_prediction(self, RefinementSearch refinement_search, bint uncovered, bint accumulated)


### PR DESCRIPTION
Closes #166 

Fügt ein neues Argument `recyclable_head`, zusätzlich zu dem bestehenden Argument `best_head`, zu der Funktion `find_head` der Klasse `HeadRefinement` hinzu.