### PR TITLE
Funktion "evaluate_confusion_matrix" mit nogil-Keyword versehen

### DIFF
--- a/python/boomer/seco/heuristics.pxd
+++ b/python/boomer/seco/heuristics.pxd
@@ -15,7 +15,7 @@ cdef class Heuristic:
     # Functions:
 
     cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp)
+                                           float64 uip, float64 urn, float64 urp) nogil
 
 
 cdef class HammingLoss(Heuristic):
@@ -23,7 +23,7 @@ cdef class HammingLoss(Heuristic):
     # Functions:
 
     cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp)
+                                           float64 uip, float64 urn, float64 urp) nogil
 
 
 cdef class Precision(Heuristic):
@@ -31,7 +31,7 @@ cdef class Precision(Heuristic):
     # Functions:
 
     cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp)
+                                           float64 uip, float64 urn, float64 urp) nogil
 
 
 cdef class Recall(Heuristic):
@@ -39,7 +39,7 @@ cdef class Recall(Heuristic):
     # Functions:
 
     cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp)
+                                           float64 uip, float64 urn, float64 urp) nogil
 
 
 cdef class WeightedRelativeAccuracy(Heuristic):
@@ -47,7 +47,7 @@ cdef class WeightedRelativeAccuracy(Heuristic):
     # Functions:
 
     cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp)
+                                           float64 uip, float64 urn, float64 urp) nogil
 
 
 cdef class FMeasure(Heuristic):
@@ -56,14 +56,10 @@ cdef class FMeasure(Heuristic):
 
     cdef readonly float64 beta
 
-    cdef Recall recall
-
-    cdef Precision precision
-
     # Functions:
 
     cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp)
+                                           float64 uip, float64 urn, float64 urp) nogil
 
 
 cdef class MEstimate(Heuristic):
@@ -72,11 +68,7 @@ cdef class MEstimate(Heuristic):
 
     cdef readonly float64 m
 
-    cdef WeightedRelativeAccuracy wra
-
-    cdef Precision precision
-
     # Functions:
 
     cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp)
+                                           float64 uip, float64 urn, float64 urp) nogil


### PR DESCRIPTION
Versieht die Funktion `evaluate_confusion_matrix` der Klasse `Heuristic` mit dem Keyword `nogil`.