### PR TITLE
Konfusionsmatrizen in C-contiguous Arrays speichern

### DIFF
--- a/python/boomer/seco/label_wise_rule_evaluation.pxd
+++ b/python/boomer/seco/label_wise_rule_evaluation.pxd
@@ -20,7 +20,7 @@ cdef class LabelWiseRuleEvaluation:
     # Functions:
 
     cdef void calculate_label_wise_prediction(self, const intp[::1] label_indices, const uint8[::1] minority_labels,
-                                              const float64[::1, :] confusion_matrices_total,
-                                              const float64[::1, :] confusion_matrices_subset,
-                                              float64[::1, :] confusion_matrices_covered, bint uncovered,
+                                              const float64[:, ::1] confusion_matrices_total,
+                                              const float64[:, ::1] confusion_matrices_subset,
+                                              float64[:, ::1] confusion_matrices_covered, bint uncovered,
                                               LabelWisePrediction* prediction) nogil

--- a/python/boomer/seco/label_wise_rule_evaluation.pyx
+++ b/python/boomer/seco/label_wise_rule_evaluation.pyx
@@ -57,9 +57,9 @@ cdef class LabelWiseRuleEvaluation:
         self.heuristic_function = heuristic.heuristic_function
 
     cdef void calculate_label_wise_prediction(self, const intp[::1] label_indices, const uint8[::1] minority_labels,
-                                              const float64[::1, :] confusion_matrices_total,
-                                              const float64[::1, :] confusion_matrices_subset,
-                                              float64[::1, :] confusion_matrices_covered, bint uncovered,
+                                              const float64[:, ::1] confusion_matrices_total,
+                                              const float64[:, ::1] confusion_matrices_subset,
+                                              float64[:, ::1] confusion_matrices_covered, bint uncovered,
                                               LabelWisePrediction* prediction) nogil:
         """
         Calculates the scores to be predicted by a rule, as well as corresponding quality scores, based on confusion

--- a/python/boomer/seco/label_wise_statistics.pxd
+++ b/python/boomer/seco/label_wise_statistics.pxd
@@ -20,13 +20,13 @@ cdef class LabelWiseRefinementSearch(DecomposableRefinementSearch):
 
     cdef const uint8[::1] minority_labels
 
-    cdef const float64[::1, :] confusion_matrices_total
+    cdef const float64[:, ::1] confusion_matrices_total
 
-    cdef const float64[::1, :] confusion_matrices_subset
+    cdef const float64[:, ::1] confusion_matrices_subset
 
-    cdef float64[::1, :] confusion_matrices_covered
+    cdef float64[:, ::1] confusion_matrices_covered
 
-    cdef float64[::1, :] accumulated_confusion_matrices_covered
+    cdef float64[:, ::1] accumulated_confusion_matrices_covered
 
     cdef LabelWisePrediction* prediction
 
@@ -53,9 +53,9 @@ cdef class LabelWiseStatistics(CoverageStatistics):
 
     cdef uint8[::1] minority_labels
 
-    cdef float64[::1, :] confusion_matrices_total
+    cdef float64[:, ::1] confusion_matrices_total
 
-    cdef float64[::1, :] confusion_matrices_subset
+    cdef float64[:, ::1] confusion_matrices_subset
 
     # Functions:
 


### PR DESCRIPTION
Ändert das Memory Layout aller Matrizen, die die Elemente von Konfusionsmatrizen speichern, von Fortran-contiguous zu C-contiguous.