### PR TITLE
Unbenutzte Funktionen aus Cython-Wrapper-Klassen entfernen

### DIFF
--- a/python/boomer/seco/heuristics.pxd
+++ b/python/boomer/seco/heuristics.pxd
@@ -83,55 +83,26 @@ cdef class Heuristic:
 
     cdef AbstractHeuristic* heuristic
 
-    # Functions:
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil
-
 
 cdef class Precision(Heuristic):
-
-    # Functions:
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil
+    pass
 
 
 cdef class Recall(Heuristic):
-
-    # Functions:
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil
+    pass
 
 
 cdef class WRA(Heuristic):
-
-    # Functions:
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil
+    pass
 
 
 cdef class HammingLoss(Heuristic):
-
-    # Functions:
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil
+    pass
 
 
 cdef class FMeasure(Heuristic):
-
-    # Functions:
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil
+    pass
 
 
 cdef class MEstimate(Heuristic):
-
-    # Functions:
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil
+    pass

--- a/python/boomer/seco/heuristics.pyx
+++ b/python/boomer/seco/heuristics.pyx
@@ -15,12 +15,7 @@ cdef class Heuristic:
     """
     A wrapper for the abstract C++ class `AbstractHeuristic`.
     """
-
-    cdef float64 evaluate_confusion_matrix(self, float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                           float64 uip, float64 urn, float64 urp) nogil:
-        cdef AbstractHeuristic* heuristic = self.heuristic
-        cdef float64 quality_score = heuristic.evaluateConfusionMatrix(cin, cip, crn, crp, uin, uip, urn, urp)
-        return quality_score
+    pass
 
 
 cdef class Precision(Heuristic):


### PR DESCRIPTION
Entfernt unbenutzte Funktionen aus Cython-Wrapper-Klassen.