### PR TITLE
Funktionen zum Allokieren von Arrays entfernen

### DIFF
--- a/python/boomer/boosting/cpp/label_wise_rule_evaluation.cpp
+++ b/python/boomer/boosting/cpp/label_wise_rule_evaluation.cpp
@@ -25,7 +25,7 @@ DefaultPrediction* LabelWiseDefaultRuleEvaluationImpl::calculateDefaultPredictio
     // The number of labels
     intp numLabels = labelMatrix->numLabels_;
     // An array that stores the scores that are predicted by the default rule
-    float64* predictedScores = arrays::mallocFloat64(numLabels);
+    float64* predictedScores = (float64*) malloc(numLabels * sizeof(float64));
 
     for (intp c = 0; c < numLabels; c++) {
         float64 sumOfGradients = 0;

--- a/python/boomer/common/cpp/arrays.h
+++ b/python/boomer/common/cpp/arrays.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <cstdint>
-#include <stdlib.h>
 
 typedef uint8_t uint8;
 typedef uint32_t uint32;
@@ -16,27 +15,6 @@ typedef double float64;
 
 
 namespace arrays {
-
-    /**
-     * Allocates and returns a new C-contiguous array of type `float64`, shape `(numElements)`.
-     *
-     * @param numElements   The number of elements in the array
-     * @return              A pointer to the array that has been allocated
-     */
-    static inline float64* mallocFloat64(intp numElements) {
-        return (float64*) malloc(numElements * sizeof(float64));
-    }
-
-    /**
-     * Allocates and returns a new C-contiguous array of type `float64`, shape `(numRows, numCols)`.
-     *
-     * @param numRows   The number of rows in the array
-     * @param numCols   The number of columns in the array
-     * @return          A pointer to the array that has been allocated
-     */
-    static inline float64* mallocFloat64(intp numRows, intp numCols) {
-        return (float64*) malloc(numRows * numCols * sizeof(float64));
-    }
 
     /**
      * Sets all elements in an array to zero.

--- a/python/boomer/seco/cpp/label_wise_rule_evaluation.cpp
+++ b/python/boomer/seco/cpp/label_wise_rule_evaluation.cpp
@@ -1,5 +1,6 @@
 #include "label_wise_rule_evaluation.h"
 #include <cstddef>
+#include <stdlib.h>
 
 using namespace seco;
 
@@ -16,7 +17,7 @@ DefaultPrediction* LabelWiseDefaultRuleEvaluationImpl::calculateDefaultPredictio
     // The number of positive examples that must be exceeded for the default rule to predict a label as relevant
     float64 threshold = numExamples / 2.0;
     // An array that stores the scores that are predicted by the default rule
-    float64* predictedScores = arrays::mallocFloat64(numLabels);
+    float64* predictedScores = (float64*) malloc(numLabels * sizeof(float64));
 
     for (intp c = 0; c < numLabels; c++) {
         intp numPositiveLabels = 0;

--- a/python/boomer/seco/cpp/label_wise_statistics.cpp
+++ b/python/boomer/seco/cpp/label_wise_statistics.cpp
@@ -21,11 +21,11 @@ LabelWiseRefinementSearchImpl::LabelWiseRefinementSearchImpl(LabelWiseRuleEvalua
     minorityLabels_ = minorityLabels;
     confusionMatricesTotal_ = confusionMatricesTotal;
     confusionMatricesSubset_ = confusionMatricesSubset;
-    confusionMatricesCovered_ = arrays::mallocFloat64(numPredictions, 4);
+    confusionMatricesCovered_ = (float64*) malloc(numPredictions * 4 * sizeof(float64));
     arrays::setToZeros(confusionMatricesCovered_, numPredictions, 4);
     accumulatedConfusionMatricesCovered_ = NULL;
-    float64* predictedScores = arrays::mallocFloat64(numPredictions);
-    float64* qualityScores = arrays::mallocFloat64(numPredictions);
+    float64* predictedScores = (float64*) malloc(numPredictions * sizeof(float64));
+    float64* qualityScores = (float64*) malloc(numPredictions * sizeof(float64));
     prediction_ = new LabelWisePrediction(numPredictions, predictedScores, qualityScores, 0);
 }
 
@@ -56,7 +56,7 @@ void LabelWiseRefinementSearchImpl::updateSearch(intp statisticIndex, uint32 wei
 void LabelWiseRefinementSearchImpl::resetSearch() {
     // Allocate an array for storing the accumulated confusion matrices, if necessary...
     if (accumulatedConfusionMatricesCovered_ == NULL) {
-        accumulatedConfusionMatricesCovered_ = arrays::mallocFloat64(numPredictions_, 4);
+        accumulatedConfusionMatricesCovered_ = (float64*) malloc(numPredictions_ * 4 * sizeof(float64));
         arrays::setToZeros(accumulatedConfusionMatricesCovered_, numPredictions_, 4);
     }
 


### PR DESCRIPTION
Entfernt die `mallocFloat64`-Funktionen aus `arrays.h`.