### PR TITLE
Nach stdout anstatt von sterr loggen

### DIFF
--- a/python/runnables.py
+++ b/python/runnables.py
@@ -18,7 +18,7 @@ from boomer.printing import RulePrinter, ModelPrinterLogOutput, ModelPrinterTxtO
 from boomer.training import DataSet
 
 LOG_FORMAT = '%(asctime)s %(levelname)s %(message)s'
-DATE_FORMAT = '%d.%m.%Y %H:%M:%S'
+DATE_FORMAT = '%d.%m.%y %H:%M:%S'
 
 
 class Runnable(ABC):


### PR DESCRIPTION
Standardmäßig loggt der 'root' Logger alle logging Einträge nach stderr wenn kein anderer Handler hinzugefügt wurde. Dieser Pull-Request fügt einen Handler hinzu, der nach stdout loggt. Außerdem passt er das Logging-Format an.
```
INFO:root:Starting experiment
INFO:root:Successfully loaded model
```
=>
```
04.08.20 13:58:07 INFO Starting experiment
04.08.20 13:58:07 INFO Successfully loaded model
```
Um Fehler trotzdem nach stderr zu loggen, könnte man noch einen weiteren Handler hinzufügen:
```
err_handler = log.StreamHandler(sys.stderr)
err_handler.setLevel(log.ERROR)
err_handler.setFormatter(formatter)
root.addHandler(err_handler)
```
Allerdings müsste man dann noch einen Filter hinzufügen, falls man verhindern will, dass Fehler zweimal geloggt werden.

Ich habe diese Änderungen in seco-experiments gemergt, aber falls du sie auch in den development branch übernehmen willst, kannst du diesen Pull-Request mergen.