### PR TITLE
Cython-Klassen NonDecomposableRefinementSearch und DecomposableRefinementSearch entfernen

### DIFF
--- a/python/boomer/boosting/example_wise_statistics.pxd
+++ b/python/boomer/boosting/example_wise_statistics.pxd
@@ -1,6 +1,6 @@
 from boomer.common._arrays cimport uint32, intp, float64
 from boomer.common.input_data cimport LabelMatrix
-from boomer.common.statistics cimport RefinementSearch, NonDecomposableRefinementSearch, AbstractRefinementSearch
+from boomer.common.statistics cimport RefinementSearch, AbstractRefinementSearch
 from boomer.common.head_refinement cimport HeadCandidate
 from boomer.common.rule_evaluation cimport DefaultPrediction, Prediction, LabelWisePrediction
 from boomer.boosting.statistics cimport GradientStatistics
@@ -32,7 +32,7 @@ cdef extern from "cpp/example_wise_statistics.h" namespace "boosting":
         Prediction* calculateExampleWisePrediction(bool uncovered, bool accumulated) nogil except +
 
 
-cdef class ExampleWiseRefinementSearch(NonDecomposableRefinementSearch):
+cdef class ExampleWiseRefinementSearch(RefinementSearch):
 
     # Attributes:
 

--- a/python/boomer/boosting/example_wise_statistics.pyx
+++ b/python/boomer/boosting/example_wise_statistics.pyx
@@ -8,7 +8,7 @@ from boomer.common._arrays cimport array_float64, c_matrix_float64, get_index
 from boomer.boosting._math cimport triangular_number
 
 
-cdef class ExampleWiseRefinementSearch(NonDecomposableRefinementSearch):
+cdef class ExampleWiseRefinementSearch(RefinementSearch):
     """
     A wrapper for the C++ class `ExampleWiseRefinementSearchImpl`.
     """

--- a/python/boomer/boosting/label_wise_statistics.pxd
+++ b/python/boomer/boosting/label_wise_statistics.pxd
@@ -1,7 +1,6 @@
 from boomer.common._arrays cimport uint32, intp, float64
 from boomer.common.input_data cimport LabelMatrix
-from boomer.common.statistics cimport RefinementSearch, DecomposableRefinementSearch, AbstractRefinementSearch, \
-    AbstractDecomposableRefinementSearch
+from boomer.common.statistics cimport RefinementSearch, AbstractRefinementSearch, AbstractDecomposableRefinementSearch
 from boomer.common.head_refinement cimport HeadCandidate
 from boomer.common.rule_evaluation cimport DefaultPrediction, Prediction, LabelWisePrediction
 from boomer.boosting.statistics cimport GradientStatistics
@@ -33,7 +32,7 @@ cdef extern from "cpp/label_wise_statistics.h" namespace "boosting":
         Prediction* calculateExampleWisePrediction(bool uncovered, bool accumulated) nogil except +
 
 
-cdef class LabelWiseRefinementSearch(DecomposableRefinementSearch):
+cdef class LabelWiseRefinementSearch(RefinementSearch):
 
     # Attributes:
 

--- a/python/boomer/boosting/label_wise_statistics.pyx
+++ b/python/boomer/boosting/label_wise_statistics.pyx
@@ -9,7 +9,7 @@ from boomer.common._arrays cimport array_float64, c_matrix_float64, get_index
 from libcpp.pair cimport pair
 
 
-cdef class LabelWiseRefinementSearch(DecomposableRefinementSearch):
+cdef class LabelWiseRefinementSearch(RefinementSearch):
     """
     A wrapper for the C++ class `LabelWiseRefinementSearchImpl`.
     """
@@ -56,6 +56,10 @@ cdef class LabelWiseRefinementSearch(DecomposableRefinementSearch):
     cdef LabelWisePrediction* calculate_label_wise_prediction(self, bint uncovered, bint accumulated):
         cdef AbstractRefinementSearch* refinement_search = self.refinement_search
         return refinement_search.calculateLabelWisePrediction(uncovered, accumulated)
+
+    cdef Prediction* calculate_example_wise_prediction(self, bint uncovered, bint accumulated):
+        cdef AbstractRefinementSearch* refinement_search = self.refinement_search
+        return refinement_search.calculateExampleWisePrediction(uncovered, accumulated)
 
 
 cdef class LabelWiseStatistics(GradientStatistics):

--- a/python/boomer/common/statistics.pxd
+++ b/python/boomer/common/statistics.pxd
@@ -47,30 +47,6 @@ cdef class RefinementSearch:
     cdef Prediction* calculate_example_wise_prediction(self, bint uncovered, bint accumulated)
 
 
-cdef class DecomposableRefinementSearch(RefinementSearch):
-
-    # Functions:
-
-    cdef void update_search(self, intp statistic_index, uint32 weight)
-
-    cdef void reset_search(self)
-
-    cdef LabelWisePrediction* calculate_label_wise_prediction(self, bint uncovered, bint accumulated)
-
-    cdef Prediction* calculate_example_wise_prediction(self, bint uncovered, bint accumulated)
-
-
-cdef class NonDecomposableRefinementSearch(RefinementSearch):
-
-    cdef void update_search(self, intp statistic_index, uint32 weight)
-
-    cdef void reset_search(self)
-
-    cdef LabelWisePrediction* calculate_label_wise_prediction(self, bint uncovered, bint accumulated)
-
-    cdef Prediction* calculate_example_wise_prediction(self, bint uncovered, bint accumulated)
-
-
 cdef class Statistics:
 
     # Functions:

--- a/python/boomer/common/statistics.pyx
+++ b/python/boomer/common/statistics.pyx
@@ -112,47 +112,6 @@ cdef class RefinementSearch:
         pass
 
 
-cdef class DecomposableRefinementSearch(RefinementSearch):
-    """
-    A base class for all classes that allow to search for the best refinement of a rule based on previously stored
-    statistics in the decomposable case, i.e., when the label-wise predictions are the same as the example-wise
-    predictions.
-    """
-
-    cdef void update_search(self, intp statistic_index, uint32 weight):
-        pass
-
-    cdef void reset_search(self):
-        pass
-
-    cdef LabelWisePrediction* calculate_label_wise_prediction(self, bint uncovered, bint accumulated):
-        pass
-
-    cdef Prediction* calculate_example_wise_prediction(self, bint uncovered, bint accumulated):
-        # In the decomposable case, the example-wise predictions are the same as the label-wise predictions...
-        return <Prediction*>self.calculate_label_wise_prediction(uncovered, accumulated)
-
-
-cdef class NonDecomposableRefinementSearch(RefinementSearch):
-    """
-    A base class for all classes that allow to search for the best refinement of a rule based on previously stored
-    statistics in the non-decomposable case, i.e., when the label-wise predictions are not the same as the example-wise
-    predictions.
-    """
-
-    cdef void update_search(self, intp statistic_index, uint32 weight):
-        pass
-
-    cdef void reset_search(self):
-        pass
-
-    cdef LabelWisePrediction* calculate_label_wise_prediction(self, bint uncovered, bint accumulated):
-        pass
-
-    cdef Prediction* calculate_example_wise_prediction(self, bint uncovered, bint accumulated):
-        pass
-
-
 cdef class Statistics:
     """
     A base class for all classes that store statistics about the labels of the training examples, which serve as the

--- a/python/boomer/seco/label_wise_statistics.pxd
+++ b/python/boomer/seco/label_wise_statistics.pxd
@@ -1,7 +1,6 @@
 from boomer.common._arrays cimport intp, uint8, uint32, float64
 from boomer.common.input_data cimport LabelMatrix, AbstractLabelMatrix
-from boomer.common.statistics cimport RefinementSearch, DecomposableRefinementSearch, AbstractRefinementSearch, \
-    AbstractDecomposableRefinementSearch
+from boomer.common.statistics cimport RefinementSearch, AbstractRefinementSearch, AbstractDecomposableRefinementSearch
 from boomer.common.head_refinement cimport HeadCandidate
 from boomer.common.rule_evaluation cimport DefaultPrediction, Prediction, LabelWisePrediction
 from boomer.seco.statistics cimport CoverageStatistics
@@ -33,7 +32,7 @@ cdef extern from "cpp/label_wise_statistics.h" namespace "seco":
         Prediction* calculateExampleWisePrediction(bool uncovered, bool accumulated) nogil except +
 
 
-cdef class LabelWiseRefinementSearch(DecomposableRefinementSearch):
+cdef class LabelWiseRefinementSearch(RefinementSearch):
 
     # Attributes:
 

--- a/python/boomer/seco/label_wise_statistics.pyx
+++ b/python/boomer/seco/label_wise_statistics.pyx
@@ -7,7 +7,7 @@ from boomer.common._arrays cimport array_uint8, c_matrix_float64, get_index
 from boomer.seco.heuristics cimport ConfusionMatrixElement
 
 
-cdef class LabelWiseRefinementSearch(DecomposableRefinementSearch):
+cdef class LabelWiseRefinementSearch(RefinementSearch):
     """
     A wrapper for the C++ class `LabelWiseRefinementSearchImpl`.
     """
@@ -55,6 +55,10 @@ cdef class LabelWiseRefinementSearch(DecomposableRefinementSearch):
     cdef LabelWisePrediction* calculate_label_wise_prediction(self, bint uncovered, bint accumulated):
         cdef AbstractRefinementSearch* refinement_search = self.refinement_search
         return refinement_search.calculateLabelWisePrediction(uncovered, accumulated)
+
+    cdef Prediction* calculate_example_wise_prediction(self, bint uncovered, bint accumulated):
+        cdef AbstractRefinementSearch* refinement_search = self.refinement_search
+        return refinement_search.calculateExampleWisePrediction(uncovered, accumulated)
 
 
 cdef class LabelWiseStatistics(CoverageStatistics):


### PR DESCRIPTION
Entfernt die Cython-Klassen `NonDecomposableRefinementSearch` und `DecomposableRefinementSearch`.