### PR TITLE
Refactoring der Klasse DefaultRuleEvaluation

### DIFF
--- a/python/boomer/boosting/example_wise_rule_evaluation.pxd
+++ b/python/boomer/boosting/example_wise_rule_evaluation.pxd
@@ -42,13 +42,9 @@ cdef extern from "cpp/example_wise_rule_evaluation.h" namespace "boosting":
 
 cdef class ExampleWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
 
-    # Attributes:
-
-    cdef AbstractDefaultRuleEvaluation* default_rule_evaluation
-
     # Functions:
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix)
+    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil
 
 
 cdef class ExampleWiseRuleEvaluation:

--- a/python/boomer/boosting/example_wise_rule_evaluation.pyx
+++ b/python/boomer/boosting/example_wise_rule_evaluation.pyx
@@ -27,10 +27,6 @@ cdef class ExampleWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
     def __dealloc__(self):
         del self.default_rule_evaluation
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix):
-        cdef AbstractDefaultRuleEvaluation* default_rule_evaluation = self.default_rule_evaluation
-        return default_rule_evaluation.calculateDefaultPrediction(label_matrix.label_matrix)
-
 
 cdef class ExampleWiseRuleEvaluation:
     """

--- a/python/boomer/boosting/label_wise_rule_evaluation.pxd
+++ b/python/boomer/boosting/label_wise_rule_evaluation.pxd
@@ -36,13 +36,9 @@ cdef extern from "cpp/label_wise_rule_evaluation.h" namespace "boosting":
 
 cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
 
-    # Attributes:
-
-    cdef AbstractDefaultRuleEvaluation* default_rule_evaluation
-
     # Functions:
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix)
+    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil
 
 
 cdef class LabelWiseRuleEvaluation:

--- a/python/boomer/boosting/label_wise_rule_evaluation.pyx
+++ b/python/boomer/boosting/label_wise_rule_evaluation.pyx
@@ -24,10 +24,6 @@ cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
     def __dealloc__(self):
         del self.default_rule_evaluation
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix):
-        cdef AbstractDefaultRuleEvaluation* default_rule_evaluation = self.default_rule_evaluation
-        return default_rule_evaluation.calculateDefaultPrediction(label_matrix.label_matrix)
-
 
 cdef class LabelWiseRuleEvaluation:
     """

--- a/python/boomer/common/rule_evaluation.pxd
+++ b/python/boomer/common/rule_evaluation.pxd
@@ -49,6 +49,10 @@ cdef extern from "cpp/rule_evaluation.h":
 
 cdef class DefaultRuleEvaluation:
 
+    # Attributes:
+
+    cdef AbstractDefaultRuleEvaluation* default_rule_evaluation
+
     # Functions:
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix)
+    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil

--- a/python/boomer/common/rule_evaluation.pyx
+++ b/python/boomer/common/rule_evaluation.pyx
@@ -10,7 +10,7 @@ cdef class DefaultRuleEvaluation:
     A base class for all classes that allow to calculate the predictions of a default rule.
     """
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix):
+    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil:
         """
         Calculates the scores to be predicted by a default rule based on the ground truth label matrix.
 
@@ -18,4 +18,5 @@ cdef class DefaultRuleEvaluation:
         :return:                A pointer to an object of type `DefaultPrediction`, representing the predictions of the
                                 default rule
         """
-        pass
+        cdef AbstractDefaultRuleEvaluation* default_rule_evaluation = self.default_rule_evaluation
+        return default_rule_evaluation.calculateDefaultPrediction(label_matrix.label_matrix)

--- a/python/boomer/seco/label_wise_rule_evaluation.pxd
+++ b/python/boomer/seco/label_wise_rule_evaluation.pxd
@@ -32,13 +32,9 @@ cdef extern from "cpp/label_wise_rule_evaluation.h" namespace "seco":
 
 cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
 
-    # Attributes:
-
-    cdef AbstractDefaultRuleEvaluation* default_rule_evaluation
-
     # Functions:
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix)
+    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil
 
 
 cdef class LabelWiseRuleEvaluation:

--- a/python/boomer/seco/label_wise_rule_evaluation.pyx
+++ b/python/boomer/seco/label_wise_rule_evaluation.pyx
@@ -17,10 +17,6 @@ cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
     def __dealloc__(self):
         del self.default_rule_evaluation
 
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix):
-        cdef AbstractDefaultRuleEvaluation* default_rule_evaluation = self.default_rule_evaluation
-        return default_rule_evaluation.calculateDefaultPrediction(label_matrix.label_matrix)
-
 
 cdef class LabelWiseRuleEvaluation:
     """


### PR DESCRIPTION
Enthält folgende Änderungen bezüglich der Klasse `DefaultRuleEvaluation` und ihrer Unterklassen:

* Die Funktion `calculate_default_prediction` wird jetzt einmalig in der Basisklasse implementiert
* Die Funktion `calculate_default_prediction` wurde mit dem `nogil`-Keyword versehen