### PR TITLE
Smart Poiner für Referenzen auf Heuristiken verwenden

### DIFF
--- a/python/boomer/seco/cpp/label_wise_rule_evaluation.cpp
+++ b/python/boomer/seco/cpp/label_wise_rule_evaluation.cpp
@@ -36,8 +36,8 @@ DefaultPrediction* LabelWiseDefaultRuleEvaluationImpl::calculateDefaultPredictio
     return new DefaultPrediction(numLabels, predictedScores);
 }
 
-LabelWiseRuleEvaluationImpl::LabelWiseRuleEvaluationImpl(AbstractHeuristic* heuristic) {
-    heuristic_ = heuristic;
+LabelWiseRuleEvaluationImpl::LabelWiseRuleEvaluationImpl(std::shared_ptr<AbstractHeuristic> heuristicPtr) {
+    heuristicPtr_ = heuristicPtr;
 }
 
 void LabelWiseRuleEvaluationImpl::calculateLabelWisePrediction(const intp* labelIndices, const uint8* minorityLabels,
@@ -46,7 +46,7 @@ void LabelWiseRuleEvaluationImpl::calculateLabelWisePrediction(const intp* label
                                                                const float64* confusionMatricesCovered, bool uncovered,
                                                                LabelWisePrediction* prediction) {
     // Class members
-    AbstractHeuristic* heuristic = heuristic_;
+    AbstractHeuristic* heuristic = heuristicPtr_.get();
     // The number of labels to predict for
     intp numPredictions = prediction->numPredictions_;
     // The array that should be used to store the predicted scores

--- a/python/boomer/seco/cpp/label_wise_rule_evaluation.h
+++ b/python/boomer/seco/cpp/label_wise_rule_evaluation.h
@@ -9,6 +9,7 @@
 #include "../../common/cpp/arrays.h"
 #include "../../common/cpp/rule_evaluation.h"
 #include "heuristics.h"
+#include <memory>
 
 
 namespace seco {
@@ -35,14 +36,15 @@ namespace seco {
 
         private:
 
-            AbstractHeuristic* heuristic_;
+            std::shared_ptr<AbstractHeuristic> heuristicPtr_;
 
         public:
 
             /**
-             * @param heuristic The heuristic to be optimized
+             * @param heuristicPtr  A shared pointer to an object of type `AbstractHeuristic`, representing the
+             *                      heuristic to be optimized
              */
-            LabelWiseRuleEvaluationImpl(AbstractHeuristic* heuristic);
+            LabelWiseRuleEvaluationImpl(std::shared_ptr<AbstractHeuristic> heuristicPtr);
 
             /**
              * Calculates the scores to be predicted by a rule, as well as corresponding quality scores, based on

--- a/python/boomer/seco/heuristics.pxd
+++ b/python/boomer/seco/heuristics.pxd
@@ -1,5 +1,7 @@
 from boomer.common._arrays cimport float64
 
+from libcpp.memory cimport shared_ptr
+
 
 cdef extern from "cpp/heuristics.h" namespace "seco" nogil:
 
@@ -71,7 +73,7 @@ cdef class Heuristic:
 
     # Attributes:
 
-    cdef AbstractHeuristic* heuristic
+    cdef shared_ptr[AbstractHeuristic] heuristic_ptr
 
 
 cdef class Precision(Heuristic):

--- a/python/boomer/seco/heuristics.pyx
+++ b/python/boomer/seco/heuristics.pyx
@@ -3,6 +3,7 @@
 
 Provides Cython wrappers for C++ classes that implement different heuristics for assessing the quality of rules.
 """
+from libcpp.memory cimport make_shared
 
 
 cdef class Heuristic:
@@ -18,10 +19,7 @@ cdef class Precision(Heuristic):
     """
 
     def __cinit__(self):
-        self.heuristic = new PrecisionImpl()
-
-    def __dealloc(self):
-        del self.heuristic
+        self.heuristic_ptr = <shared_ptr[AbstractHeuristic]>make_shared[PrecisionImpl]()
 
 
 cdef class Recall(Heuristic):
@@ -30,10 +28,7 @@ cdef class Recall(Heuristic):
     """
 
     def __cinit__(self):
-        self.heuristic = new RecallImpl()
-
-    def __dealloc(self):
-        del self.heuristic
+        self.heuristic_ptr = <shared_ptr[AbstractHeuristic]>make_shared[RecallImpl]()
 
 
 cdef class WRA(Heuristic):
@@ -42,10 +37,7 @@ cdef class WRA(Heuristic):
     """
 
     def __cinit__(self):
-        self.heuristic = new WRAImpl()
-
-    def __dealloc(self):
-        del self.heuristic
+        self.heuristic_ptr = <shared_ptr[AbstractHeuristic]>make_shared[WRAImpl]()
 
 
 cdef class HammingLoss(Heuristic):
@@ -54,10 +46,7 @@ cdef class HammingLoss(Heuristic):
     """
 
     def __cinit__(self):
-        self.heuristic = new HammingLossImpl()
-
-    def __dealloc(self):
-        del self.heuristic
+        self.heuristic_ptr = <shared_ptr[AbstractHeuristic]>make_shared[HammingLossImpl]()
 
 
 cdef class FMeasure(Heuristic):
@@ -69,10 +58,7 @@ cdef class FMeasure(Heuristic):
         """
         :param beta: The value of the beta-parameter. Must be at least 0
         """
-        self.heuristic = new FMeasureImpl(beta)
-
-    def __dealloc(self):
-        del self.heuristic
+        self.heuristic_ptr = <shared_ptr[AbstractHeuristic]>make_shared[FMeasureImpl](beta)
 
 
 cdef class MEstimate(Heuristic):
@@ -84,7 +70,4 @@ cdef class MEstimate(Heuristic):
         """
         :param m: The value of the m-parameter. Must be at least 0
         """
-        self.heuristic = new MEstimateImpl(m)
-
-    def __dealloc__(self):
-        del self.heuristic
+        self.heuristic_ptr = <shared_ptr[AbstractHeuristic]>make_shared[MEstimateImpl](m)

--- a/python/boomer/seco/label_wise_rule_evaluation.pyx
+++ b/python/boomer/seco/label_wise_rule_evaluation.pyx
@@ -28,4 +28,4 @@ cdef class LabelWiseRuleEvaluation:
         """
         :param heuristic: The heuristic that should be used
         """
-        self.rule_evaluation_ptr = make_shared[LabelWiseRuleEvaluationImpl](heuristic.heuristic)
+        self.rule_evaluation_ptr = make_shared[LabelWiseRuleEvaluationImpl](heuristic.heuristic_ptr)


### PR DESCRIPTION
Verwendet Smart Pointer statt herkömmlicher Pointer um Referenzen auf Objekte, die Heuristiken repräsentieren, zu speichern.