### PR TITLE
Funktion "get_index" entfernen

### DIFF
--- a/python/boomer/common/_arrays.pxd
+++ b/python/boomer/common/_arrays.pxd
@@ -107,18 +107,3 @@ cdef inline cvarray c_matrix_uint8(intp num_rows, intp num_cols):
     cdef intp itemsize = sizeof(uint8)
     cdef cvarray array = cvarray(shape, itemsize, FORMAT_UINT8, MODE_C_CONTIGUOUS)
     return array
-
-
-cdef inline intp get_index(intp i, const intp[::1] indices) nogil:
-    """
-    Retrieves and returns the i-th index from an array of indices, if such an array is available. Otherwise i is
-    returned.
-
-    :param i:       The position of the index that should be retrieved
-    :param indices: An array of the dtype int, shape `(num_indices)`, representing the indices, or None
-    :return:        A scalar of dtype int, representing the i-th index in the given array or i, if the array is None
-    """
-    if indices is None:
-        return i
-    else:
-        return indices[i]

--- a/python/boomer/common/head_refinement.pyx
+++ b/python/boomer/common/head_refinement.pyx
@@ -3,7 +3,7 @@
 
 Provides classes that implement strategies for finding the heads of rules.
 """
-from boomer.common._arrays cimport array_intp, array_float64, get_index
+from boomer.common._arrays cimport array_intp, array_float64
 from boomer.common.rule_evaluation cimport LabelWisePrediction
 
 from libc.stdlib cimport malloc
@@ -101,13 +101,13 @@ cdef class SingleLabelHeadRefinement(HeadRefinement):
             if recyclable_head == NULL:
                 # Create a new `HeadCandidate` and return it...
                 candidate_label_indices = <intp*>malloc(sizeof(intp))
-                candidate_label_indices[0] = get_index(best_c, label_indices)
+                candidate_label_indices[0] = best_c if label_indices is None else label_indices[best_c]
                 candidate_predicted_scores = <float64*>malloc(sizeof(float64))
                 candidate_predicted_scores[0] = predicted_scores[best_c]
                 return new HeadCandidate(1, candidate_label_indices, candidate_predicted_scores, best_quality_score)
             else:
                 # Modify the `recyclable_head` and return it...
-                recyclable_head.labelIndices_[0] = get_index(best_c, label_indices)
+                recyclable_head.labelIndices_[0] = best_c if label_indices is None else label_indices[best_c]
                 recyclable_head.predictedScores_[0] = predicted_scores[best_c]
                 recyclable_head.qualityScore_ = best_quality_score
                 return recyclable_head

--- a/python/boomer/common/rule_induction.pyx
+++ b/python/boomer/common/rule_induction.pyx
@@ -3,7 +3,7 @@
 
 Provides classes that implement algorithms for inducing individual classification rules.
 """
-from boomer.common._arrays cimport uint32, float64, array_uint32, array_intp, get_index
+from boomer.common._arrays cimport uint32, float64, array_uint32, array_intp
 from boomer.common.rules cimport Condition, Comparator
 from boomer.common.head_refinement cimport HeadCandidate
 from boomer.common.statistics cimport AbstractRefinementSearch
@@ -233,7 +233,7 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
                 # feature, the examples are traversed in descending order of their respective feature values. For each
                 # potential condition, a quality score is calculated to keep track of the best possible refinement.
                 for c in range(num_sampled_features):
-                    f = get_index(c, feature_indices)
+                    f = c if feature_indices is None else feature_indices[c]
 
                     # Obtain array that contains the indices of the training examples sorted according to the current
                     # feature...

--- a/python/boomer/seco/head_refinement.pyx
+++ b/python/boomer/seco/head_refinement.pyx
@@ -1,4 +1,4 @@
-from boomer.common._arrays cimport float64, array_intp, array_float64, get_index
+from boomer.common._arrays cimport float64, array_intp, array_float64
 from boomer.common._tuples cimport IndexedFloat64, compare_indexed_float64
 from boomer.common.rule_evaluation cimport LabelWisePrediction
 from boomer.seco.lift_functions cimport LiftFunction
@@ -70,7 +70,7 @@ cdef class PartialHeadRefinement(HeadRefinement):
 
                     if label_indices is None:
                         for c in range(0, best_head_candidate_length):
-                            candidate_label_indices[c] = get_index(sorted_indices[c], label_indices)
+                            candidate_label_indices[c] = sorted_indices[c] if label_indices is None else label_indices[sorted_indices[c]]
                             candidate_predicted_scores[c] = predicted_scores[sorted_indices[c]]
                     else:
                         for c in range(0, best_head_candidate_length):
@@ -93,7 +93,7 @@ cdef class PartialHeadRefinement(HeadRefinement):
                     # Modify the `recyclable_head` and return it...
                     if label_indices is None:
                         for c in range(best_head_candidate_length):
-                            candidate_label_indices[c] = get_index(sorted_indices[c], label_indices)
+                            candidate_label_indices[c] = sorted_indices[c] if label_indices is None else label_indices[sorted_indices[c]]
                             candidate_predicted_scores[c] = predicted_scores[sorted_indices[c]]
                     else:
                         for c in range(best_head_candidate_length):


### PR DESCRIPTION
Entfernt die Funktion `get_index` aus `_arrays.pxd`.