### PR TITLE
Cython-Klasse DefaultRuleEvaluation in Wrapper umwandeln

### DIFF
--- a/python/boomer/boosting/example_wise_rule_evaluation.pxd
+++ b/python/boomer/boosting/example_wise_rule_evaluation.pxd
@@ -1,5 +1,5 @@
 from boomer.common._arrays cimport intp, float64
-from boomer.common.input_data cimport LabelMatrix, AbstractLabelMatrix
+from boomer.common.input_data cimport AbstractLabelMatrix
 from boomer.common.rule_evaluation cimport DefaultPrediction, Prediction, LabelWisePrediction, DefaultRuleEvaluation, \
     AbstractDefaultRuleEvaluation
 from boomer.boosting._blas cimport Blas
@@ -42,10 +42,7 @@ cdef extern from "cpp/example_wise_rule_evaluation.h" namespace "boosting" nogil
 
 
 cdef class ExampleWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
-
-    # Functions:
-
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil
+    pass
 
 
 cdef class ExampleWiseRuleEvaluation:

--- a/python/boomer/boosting/example_wise_rule_evaluation.pyx
+++ b/python/boomer/boosting/example_wise_rule_evaluation.pyx
@@ -22,12 +22,10 @@ cdef class ExampleWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
         :param l2_regularization_weight:    The weight of the L2 regularization that is applied for calculating the
                                             scores to be predicted by the default rule
         """
+        cdef shared_ptr[AbstractExampleWiseLoss] loss_function_ptr = loss_function.loss_function_ptr
         cdef Lapack* lapack = init_lapack()
-        self.default_rule_evaluation = new ExampleWiseDefaultRuleEvaluationImpl(loss_function.loss_function_ptr,
-                                                                                l2_regularization_weight, lapack)
-
-    def __dealloc__(self):
-        del self.default_rule_evaluation
+        self.default_rule_evaluation_ptr = <shared_ptr[AbstractDefaultRuleEvaluation]>make_shared[ExampleWiseDefaultRuleEvaluationImpl](
+            loss_function_ptr, l2_regularization_weight, lapack)
 
 
 cdef class ExampleWiseRuleEvaluation:

--- a/python/boomer/boosting/label_wise_rule_evaluation.pxd
+++ b/python/boomer/boosting/label_wise_rule_evaluation.pxd
@@ -1,5 +1,5 @@
 from boomer.common._arrays cimport intp, float64
-from boomer.common.input_data cimport LabelMatrix, AbstractLabelMatrix
+from boomer.common.input_data cimport AbstractLabelMatrix
 from boomer.common.rule_evaluation cimport DefaultPrediction, LabelWisePrediction, DefaultRuleEvaluation, \
     AbstractDefaultRuleEvaluation
 from boomer.boosting.label_wise_losses cimport AbstractLabelWiseLoss
@@ -37,10 +37,7 @@ cdef extern from "cpp/label_wise_rule_evaluation.h" namespace "boosting" nogil:
 
 
 cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
-
-    # Functions:
-
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil
+    pass
 
 
 cdef class LabelWiseRuleEvaluation:

--- a/python/boomer/boosting/label_wise_rule_evaluation.pyx
+++ b/python/boomer/boosting/label_wise_rule_evaluation.pyx
@@ -20,11 +20,9 @@ cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
         :param l2_regularization_weight:    The weight of the L2 regularization that is applied for calculating the
                                             scores to be predicted by the default rule
         """
-        self.default_rule_evaluation = new LabelWiseDefaultRuleEvaluationImpl(loss_function.loss_function_ptr,
-                                                                              l2_regularization_weight)
-
-    def __dealloc__(self):
-        del self.default_rule_evaluation
+        cdef shared_ptr[AbstractLabelWiseLoss] loss_function_ptr = loss_function.loss_function_ptr
+        self.default_rule_evaluation_ptr = <shared_ptr[AbstractDefaultRuleEvaluation]>make_shared[LabelWiseDefaultRuleEvaluationImpl](
+            loss_function_ptr, l2_regularization_weight)
 
 
 cdef class LabelWiseRuleEvaluation:

--- a/python/boomer/common/rule_evaluation.pxd
+++ b/python/boomer/common/rule_evaluation.pxd
@@ -1,5 +1,7 @@
 from boomer.common._arrays cimport intp, float64
-from boomer.common.input_data cimport LabelMatrix, AbstractLabelMatrix
+from boomer.common.input_data cimport AbstractLabelMatrix
+
+from libcpp.memory cimport shared_ptr
 
 
 cdef extern from "cpp/rule_evaluation.h" nogil:
@@ -51,8 +53,4 @@ cdef class DefaultRuleEvaluation:
 
     # Attributes:
 
-    cdef AbstractDefaultRuleEvaluation* default_rule_evaluation
-
-    # Functions:
-
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil
+    cdef shared_ptr[AbstractDefaultRuleEvaluation] default_rule_evaluation_ptr

--- a/python/boomer/common/rule_evaluation.pyx
+++ b/python/boomer/common/rule_evaluation.pyx
@@ -1,22 +1,12 @@
 """
 @author Michael Rapp (mrapp@ke.tu-darmstadt.de)
 
-Provides classes that allow to calculate the predictions of rules, as well as corresponding quality scores.
+Provides wrappers for classes that allow to calculate the predictions of rules, as well as corresponding quality scores.
 """
 
 
 cdef class DefaultRuleEvaluation:
     """
-    A base class for all classes that allow to calculate the predictions of a default rule.
+    A wrapper for the C++ class `AbstractDefaultRuleEvaluation`.
     """
-
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil:
-        """
-        Calculates the scores to be predicted by a default rule based on the ground truth label matrix.
-
-        :param label_matrix:    A `LabelMatrix` that provides random access to the labels of the training examples
-        :return:                A pointer to an object of type `DefaultPrediction`, representing the predictions of the
-                                default rule
-        """
-        cdef AbstractDefaultRuleEvaluation* default_rule_evaluation = self.default_rule_evaluation
-        return default_rule_evaluation.calculateDefaultPrediction(label_matrix.label_matrix)
+    pass

--- a/python/boomer/common/rule_induction.pxd
+++ b/python/boomer/common/rule_induction.pxd
@@ -8,7 +8,7 @@ from boomer.common.sub_sampling cimport InstanceSubSampling, FeatureSubSampling,
 from boomer.common.pruning cimport Pruning
 from boomer.common.post_processing cimport PostProcessor
 from boomer.common.head_refinement cimport HeadRefinement
-from boomer.common.rule_evaluation cimport DefaultRuleEvaluation
+from boomer.common.rule_evaluation cimport AbstractDefaultRuleEvaluation
 
 from libcpp.memory cimport shared_ptr
 from libcpp.unordered_map cimport unordered_map
@@ -42,7 +42,7 @@ cdef class ExactGreedyRuleInduction(RuleInduction):
 
     # Attributes:
 
-    cdef DefaultRuleEvaluation default_rule_evaluation
+    cdef shared_ptr[AbstractDefaultRuleEvaluation] default_rule_evaluation_ptr
 
     cdef shared_ptr[AbstractStatistics] statistics_ptr
 

--- a/python/boomer/seco/label_wise_rule_evaluation.pxd
+++ b/python/boomer/seco/label_wise_rule_evaluation.pxd
@@ -1,8 +1,8 @@
 from boomer.common._arrays cimport uint8, intp, float64
-from boomer.common.input_data cimport LabelMatrix, AbstractLabelMatrix
+from boomer.common.input_data cimport AbstractLabelMatrix
 from boomer.common.rule_evaluation cimport DefaultPrediction, LabelWisePrediction, DefaultRuleEvaluation, \
     AbstractDefaultRuleEvaluation
-from boomer.seco.heuristics cimport Heuristic, AbstractHeuristic
+from boomer.seco.heuristics cimport AbstractHeuristic
 
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr
@@ -32,10 +32,7 @@ cdef extern from "cpp/label_wise_rule_evaluation.h" namespace "seco" nogil:
 
 
 cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
-
-    # Functions:
-
-    cdef DefaultPrediction* calculate_default_prediction(self, LabelMatrix label_matrix) nogil
+    pass
 
 
 cdef class LabelWiseRuleEvaluation:

--- a/python/boomer/seco/label_wise_rule_evaluation.pyx
+++ b/python/boomer/seco/label_wise_rule_evaluation.pyx
@@ -4,6 +4,8 @@
 Provides Cython wrappers for C++ classes that allow to calculate the predictions of rules, as well as corresponding
 quality scores.
 """
+from boomer.seco.heuristics cimport Heuristic
+
 from libcpp.memory cimport make_shared
 
 
@@ -13,10 +15,7 @@ cdef class LabelWiseDefaultRuleEvaluation(DefaultRuleEvaluation):
     """
 
     def __cinit__(self):
-        self.default_rule_evaluation = new LabelWiseDefaultRuleEvaluationImpl()
-
-    def __dealloc__(self):
-        del self.default_rule_evaluation
+        self.default_rule_evaluation_ptr = <shared_ptr[AbstractDefaultRuleEvaluation]>make_shared[LabelWiseDefaultRuleEvaluationImpl]()
 
 
 cdef class LabelWiseRuleEvaluation:


### PR DESCRIPTION
Die Cython-Klasse `DefaultRuleEvaluation` ist jetzt lediglich ein Wrapper, der einen Smart-Pointer auf ein Objekt der C++-Klasse `AbstractDefaultRuleEvaluation` speichert.