### PR TITLE
Unbenutzte Funktion aus Cython-Klassen ExampleWiseLoss und LabelWiseLoss entfernen

### DIFF
--- a/python/boomer/boosting/example_wise_losses.pxd
+++ b/python/boomer/boosting/example_wise_losses.pxd
@@ -1,5 +1,5 @@
 from boomer.common._arrays cimport intp, float64
-from boomer.common.input_data cimport LabelMatrix, AbstractLabelMatrix
+from boomer.common.input_data cimport AbstractLabelMatrix
 
 from libcpp.memory cimport shared_ptr
 
@@ -28,17 +28,6 @@ cdef class ExampleWiseLoss:
 
     cdef shared_ptr[AbstractExampleWiseLoss] loss_function_ptr
 
-    # Functions:
-
-    cdef void calculate_gradients_and_hessians(self, LabelMatrix label_matrix, intp example_index,
-                                               float64* predicted_scores, float64[::1] gradients,
-                                               float64[::1] hessians) nogil
-
 
 cdef class ExampleWiseLogisticLoss(ExampleWiseLoss):
-
-    # Functions:
-
-    cdef void calculate_gradients_and_hessians(self, LabelMatrix label_matrix, intp example_index,
-                                               float64* predicted_scores, float64[::1] gradients,
-                                               float64[::1] hessians) nogil
+    pass

--- a/python/boomer/boosting/example_wise_losses.pyx
+++ b/python/boomer/boosting/example_wise_losses.pyx
@@ -3,10 +3,6 @@
 
 Provides classes that implement different differentiable loss functions.
 """
-from boomer.common._arrays cimport uint8
-
-from libc.math cimport exp, pow
-
 from libcpp.memory cimport make_shared
 
 
@@ -14,27 +10,7 @@ cdef class ExampleWiseLoss:
     """
     A wrapper for the abstract C++ class `AbstractExampleWiseLoss`.
     """
-
-    cdef void calculate_gradients_and_hessians(self, LabelMatrix label_matrix, intp example_index,
-                                               float64* predicted_scores, float64[::1] gradients,
-                                               float64[::1] hessians) nogil:
-        """
-        Calculates the gradients (first derivatives) and Hessians (second derivatives) of the loss function for each
-        label of a certain example.
-
-        :param label_matrix:        A `LabelMatrix` that provides random access to the labels of the training examples
-        :param example_index:       The index of the example for which the gradients and Hessians should be calculated
-        :param predicted_scores:    A pointer to an array of type `float64`, shape `(num_labels)`, representing the
-                                    scores that are predicted for each label of the respective example
-        :param gradients:           An array of dtype `float64`, shape `(num_labels)`, the gradients that have been
-                                    calculated should be written to
-        :param hessians:            An array of dtype `float64`, shape `(num_labels * (num_labels + 1) / 2)`, the
-                                    Hessians that have been calculated should be written to
-        """
-        cdef AbstractExampleWiseLoss* loss_function = self.loss_function_ptr.get()
-        cdef AbstractLabelMatrix* label_matrix_ptr = label_matrix.label_matrix
-        loss_function.calculateGradientsAndHessians(label_matrix_ptr, example_index, predicted_scores, &gradients[0],
-                                                    &hessians[0])
+    pass
 
 
 cdef class ExampleWiseLogisticLoss(ExampleWiseLoss):

--- a/python/boomer/boosting/label_wise_losses.pxd
+++ b/python/boomer/boosting/label_wise_losses.pxd
@@ -1,5 +1,5 @@
 from boomer.common._arrays cimport intp, float64
-from boomer.common.input_data cimport LabelMatrix, AbstractLabelMatrix
+from boomer.common.input_data cimport AbstractLabelMatrix
 
 from libcpp.pair cimport pair
 from libcpp.memory cimport shared_ptr
@@ -37,23 +37,9 @@ cdef class LabelWiseLoss:
 
     cdef shared_ptr[AbstractLabelWiseLoss] loss_function_ptr
 
-    # Functions:
-
-    cdef pair[float64, float64] calculate_gradient_and_hessian(self, LabelMatrix label_matrix, intp example_index,
-                                                               intp label_index, float64 predicted_score) nogil
-
 
 cdef class LabelWiseLogisticLoss(LabelWiseLoss):
-
-    # Functions:
-
-    cdef pair[float64, float64] calculate_gradient_and_hessian(self, LabelMatrix label_matrix, intp example_index,
-                                                               intp label_index, float64 predicted_score) nogil
-
+    pass
 
 cdef class LabelWiseSquaredErrorLoss(LabelWiseLoss):
-
-    # Functions:
-
-    cdef pair[float64, float64] calculate_gradient_and_hessian(self, LabelMatrix label_matrix, intp example_index,
-                                                               intp label_index, float64 predicted_score) nogil
+    pass

--- a/python/boomer/boosting/label_wise_losses.pyx
+++ b/python/boomer/boosting/label_wise_losses.pyx
@@ -3,10 +3,6 @@
 
 Provides classes that implement different differentiable loss functions.
 """
-from boomer.common._arrays cimport uint8
-
-from libc.math cimport exp, pow
-
 from libcpp.memory cimport make_shared
 
 
@@ -14,24 +10,7 @@ cdef class LabelWiseLoss:
     """
     A wrapper for the abstract C++ class `AbstractLabelWiseLoss`.
     """
-
-    cdef pair[float64, float64] calculate_gradient_and_hessian(self, LabelMatrix label_matrix, intp example_index,
-                                                               intp label_index, float64 predicted_score) nogil:
-        """
-        Calculates the gradient (first derivative) and Hessian (second derivative) of the loss function for a certain
-        example and label.
-
-        :param label_matrix:    A `LabelMatrix` that provides random access to the labels of the training examples
-        :param example_index:   The index of the example for which the gradient and Hessian should be calculated
-        :param label_index:     The index of the label for which the gradient and Hessian should be calculated
-        :param predicted_score: A scalar of dtype float64, representing the score that is predicted for the respective
-                                example and label
-        :return:                A pair that contains two scalars of dtype float64, representing the gradient and the
-                                Hessian that have been calculated
-        """
-        cdef AbstractLabelWiseLoss* loss_function = self.loss_function_ptr.get()
-        cdef AbstractLabelMatrix* label_matrix_ptr = label_matrix.label_matrix
-        return loss_function.calculateGradientAndHessian(label_matrix_ptr, example_index, label_index, predicted_score)
+    pass
 
 
 cdef class LabelWiseLogisticLoss(LabelWiseLoss):


### PR DESCRIPTION
Entfernt nicht verwendete Funktionen aus den Cython-Klassen `ExampleWiseLoss` und `LabelWiseLoss`, sowie deren Unterklassen.