### PR TITLE
Signatur der Funktionen "find_head" und "prune" ändern

### DIFF
--- a/python/boomer/boosting/head_refinement.pxd
+++ b/python/boomer/boosting/head_refinement.pxd
@@ -9,8 +9,8 @@ cdef class FullHeadRefinement(HeadRefinement):
     # Functions:
 
     cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
-                                  intp[::1] label_indices, AbstractRefinementSearch* refinement_search, bint uncovered,
-                                  bint accumulated) nogil
+                                  const intp* label_indices, AbstractRefinementSearch* refinement_search,
+                                  bint uncovered, bint accumulated) nogil
 
     cdef Prediction* calculate_prediction(self, AbstractRefinementSearch* refinement_search, bint uncovered,
                                           bint accumulated) nogil

--- a/python/boomer/boosting/head_refinement.pyx
+++ b/python/boomer/boosting/head_refinement.pyx
@@ -14,8 +14,8 @@ cdef class FullHeadRefinement(HeadRefinement):
     """
 
     cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
-                                  intp[::1] label_indices, AbstractRefinementSearch* refinement_search, bint uncovered,
-                                  bint accumulated) nogil:
+                                  const intp* label_indices, AbstractRefinementSearch* refinement_search,
+                                  bint uncovered, bint accumulated) nogil:
         cdef Prediction* prediction = refinement_search.calculateExampleWisePrediction(uncovered, accumulated)
         cdef intp num_predictions = prediction.numPredictions_
         cdef float64* predicted_scores = prediction.predictedScores_
@@ -33,7 +33,7 @@ cdef class FullHeadRefinement(HeadRefinement):
                 for c in range(num_predictions):
                     candidate_predicted_scores[c] = predicted_scores[c]
 
-                if label_indices is not None:
+                if label_indices != NULL:
                     candidate_label_indices = <intp*>malloc(num_predictions * sizeof(intp))
 
                     for c in range(num_predictions):

--- a/python/boomer/common/head_refinement.pxd
+++ b/python/boomer/common/head_refinement.pxd
@@ -27,8 +27,8 @@ cdef class HeadRefinement:
     # Functions:
 
     cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
-                                  intp[::1] label_indices, AbstractRefinementSearch* refinement_search, bint uncovered,
-                                  bint accumulated) nogil
+                                  const intp* label_indices, AbstractRefinementSearch* refinement_search,
+                                  bint uncovered, bint accumulated) nogil
 
     cdef Prediction* calculate_prediction(self, AbstractRefinementSearch* refinement_search, bint uncovered,
                                           bint accumulated) nogil
@@ -39,8 +39,8 @@ cdef class SingleLabelHeadRefinement(HeadRefinement):
     # Functions:
 
     cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
-                                  intp[::1] label_indices, AbstractRefinementSearch* refinement_search, bint uncovered,
-                                  bint accumulated) nogil
+                                  const intp* label_indices, AbstractRefinementSearch* refinement_search,
+                                  bint uncovered, bint accumulated) nogil
 
     cdef Prediction* calculate_prediction(self, AbstractRefinementSearch* refinement_search, bint uncovered,
                                           bint accumulated) nogil

--- a/python/boomer/common/pruning.pxd
+++ b/python/boomer/common/pruning.pxd
@@ -15,8 +15,9 @@ cdef class Pruning:
 
     cdef pair[uint32[::1], uint32] prune(self, unordered_map[intp, IndexedFloat32Array*]* sorted_feature_values_map,
                                          double_linked_list[Condition] conditions, uint32[::1] covered_examples_mask,
-                                         uint32 covered_examples_target, uint32[::1] weights, intp[::1] label_indices,
-                                         AbstractStatistics* statistics, HeadRefinement head_refinement)
+                                         uint32 covered_examples_target, uint32[::1] weights, intp num_label_indices,
+                                         const intp* label_indices,  AbstractStatistics* statistics,
+                                         HeadRefinement head_refinement)
 
 
 cdef class IREP(Pruning):
@@ -25,5 +26,6 @@ cdef class IREP(Pruning):
 
     cdef pair[uint32[::1], uint32] prune(self, unordered_map[intp, IndexedFloat32Array*]* sorted_feature_values_map,
                                          double_linked_list[Condition] conditions, uint32[::1] covered_examples_mask,
-                                         uint32 covered_examples_target, uint32[::1] weights, intp[::1] label_indices,
-                                         AbstractStatistics* statistics, HeadRefinement head_refinement)
+                                         uint32 covered_examples_target, uint32[::1] weights, intp num_label_indices,
+                                         const intp* label_indices, AbstractStatistics* statistics,
+                                         HeadRefinement head_refinement)

--- a/python/boomer/seco/head_refinement.pxd
+++ b/python/boomer/seco/head_refinement.pxd
@@ -16,8 +16,8 @@ cdef class PartialHeadRefinement(HeadRefinement):
     # Functions:
 
     cdef HeadCandidate* find_head(self, HeadCandidate* best_head, HeadCandidate* recyclable_head,
-                                  intp[::1] label_indices, AbstractRefinementSearch* refinement_search, bint uncovered,
-                                  bint accumulated) nogil
+                                  const intp* label_indices, AbstractRefinementSearch* refinement_search,
+                                  bint uncovered, bint accumulated) nogil
 
     cdef Prediction* calculate_prediction(self, AbstractRefinementSearch* refinement_search, bint uncovered,
                                           bint accumulated) nogil


### PR DESCRIPTION
Ändert die Signaturen der folgenden Funktionen:

* Funktion `find_head` der Klasse `RefinementSearch`
* Funktion `prune` der Klasse `Pruning`

Statt eine Memory View `label_indices` als Argument zu übergeben, wird jetzt einen Pointer auf ein solches Array erwartet. Dadurch kann vermieden werden dass bestehende C-Arrays zu einer Memory View umgewandelt werden müssen und umgekehrt.