### PR TITLE
Variablen, Methoden und Argumente als "const" kennzeichnen

### DIFF
--- a/python/boomer/boosting/cpp/example_wise_losses.cpp
+++ b/python/boomer/boosting/cpp/example_wise_losses.cpp
@@ -6,7 +6,7 @@ using namespace boosting;
 
 void ExampleWiseLogisticLossImpl::calculateGradientsAndHessians(IRandomAccessLabelMatrix& labelMatrix,
                                                                 uint32 exampleIndex, const float64* predictedScores,
-                                                                float64* gradients, float64* hessians) {
+                                                                float64* gradients, float64* hessians) const {
     uint32 numLabels = labelMatrix.getNumCols();
     float64 sumOfExponentials = 1;
 

--- a/python/boomer/boosting/cpp/example_wise_losses.h
+++ b/python/boomer/boosting/cpp/example_wise_losses.h
@@ -38,7 +38,7 @@ namespace boosting {
              */
             virtual void calculateGradientsAndHessians(IRandomAccessLabelMatrix& labelMatrix, uint32 exampleIndex,
                                                        const float64* predictedScores, float64* gradients,
-                                                       float64* hessians) = 0;
+                                                       float64* hessians) const = 0;
 
     };
 
@@ -51,7 +51,7 @@ namespace boosting {
 
             void calculateGradientsAndHessians(IRandomAccessLabelMatrix& labelMatrix, uint32 exampleIndex,
                                                const float64* predictedScores, float64* gradients,
-                                               float64* hessians) override;
+                                               float64* hessians) const override;
 
     };
 

--- a/python/boomer/boosting/cpp/example_wise_rule_evaluation.cpp
+++ b/python/boomer/boosting/cpp/example_wise_rule_evaluation.cpp
@@ -15,12 +15,10 @@ RegularizedExampleWiseRuleEvaluationImpl::RegularizedExampleWiseRuleEvaluationIm
     lapackPtr_ = std::move(lapackPtr);
 }
 
-void RegularizedExampleWiseRuleEvaluationImpl::calculateLabelWisePrediction(const uint32* labelIndices,
-                                                                            const float64* totalSumsOfGradients,
-                                                                            float64* sumsOfGradients,
-                                                                            const float64* totalSumsOfHessians,
-                                                                            float64* sumsOfHessians, bool uncovered,
-                                                                            LabelWisePredictionCandidate& prediction) {
+void RegularizedExampleWiseRuleEvaluationImpl::calculateLabelWisePrediction(
+        const uint32* labelIndices, const float64* totalSumsOfGradients, float64* sumsOfGradients,
+        const float64* totalSumsOfHessians, float64* sumsOfHessians, bool uncovered,
+        LabelWisePredictionCandidate& prediction) const {
     // The number of elements in the arrays `predictedScores` and `qualityScores`
     uint32 numPredictions = prediction.numPredictions_;
     // The array that should be used to store the predicted scores
@@ -67,19 +65,11 @@ void RegularizedExampleWiseRuleEvaluationImpl::calculateLabelWisePrediction(cons
     prediction.overallQualityScore_ = overallQualityScore;
 }
 
-void RegularizedExampleWiseRuleEvaluationImpl::calculateExampleWisePrediction(const uint32* labelIndices,
-                                                                              const float64* totalSumsOfGradients,
-                                                                              float64* sumsOfGradients,
-                                                                              const float64* totalSumsOfHessians,
-                                                                              float64* sumsOfHessians,
-                                                                              float64* tmpGradients,
-                                                                              float64* tmpHessians, int dsysvLwork,
-                                                                              float64* dsysvTmpArray1,
-                                                                              int* dsysvTmpArray2,
-                                                                              double* dsysvTmpArray3,
-                                                                              float64* dspmvTmpArray,
-                                                                              bool uncovered,
-                                                                              PredictionCandidate& prediction) {
+void RegularizedExampleWiseRuleEvaluationImpl::calculateExampleWisePrediction(
+        const uint32* labelIndices, const float64* totalSumsOfGradients, float64* sumsOfGradients,
+        const float64* totalSumsOfHessians, float64* sumsOfHessians, float64* tmpGradients, float64* tmpHessians,
+        int dsysvLwork, float64* dsysvTmpArray1, int* dsysvTmpArray2, double* dsysvTmpArray3, float64* dspmvTmpArray,
+        bool uncovered, PredictionCandidate& prediction) const {
     // The number of elements in the arrays `predictedScores`
     uint32 numPredictions = prediction.numPredictions_;
     // The array that should be used to store the predicted scores

--- a/python/boomer/boosting/cpp/example_wise_rule_evaluation.h
+++ b/python/boomer/boosting/cpp/example_wise_rule_evaluation.h
@@ -61,7 +61,7 @@ namespace boosting {
             virtual void calculateLabelWisePrediction(const uint32* labelIndices, const float64* totalSumsOfGradients,
                                                       float64* sumsOfGradients, const float64* totalSumsOfHessians,
                                                       float64* sumsOfHessians, bool uncovered,
-                                                      LabelWisePredictionCandidate& prediction) = 0;
+                                                      LabelWisePredictionCandidate& prediction) const = 0;
 
             /**
              * Calculates the scores to be predicted by a rule, as well as an overall quality score, based on the sums
@@ -120,7 +120,7 @@ namespace boosting {
                                                         float64* tmpHessians, int dsysvLwork, float64* dsysvTmpArray1,
                                                         int* dsysvTmpArray2, double* dsysvTmpArray3,
                                                         float64* dspmvTmpArray, bool uncovered,
-                                                        PredictionCandidate& prediction) = 0;
+                                                        PredictionCandidate& prediction) const = 0;
 
     };
 
@@ -155,14 +155,14 @@ namespace boosting {
             void calculateLabelWisePrediction(const uint32* labelIndices, const float64* totalSumsOfGradients,
                                               float64* sumsOfGradients, const float64* totalSumsOfHessians,
                                               float64* sumsOfHessians, bool uncovered,
-                                              LabelWisePredictionCandidate& prediction) override;
+                                              LabelWisePredictionCandidate& prediction) const override;
 
             void calculateExampleWisePrediction(const uint32* labelIndices, const float64* totalSumsOfGradients,
                                                 float64* sumsOfGradients, const float64* totalSumsOfHessians,
                                                 float64* sumsOfHessians, float64* tmpGradients, float64* tmpHessians,
                                                 int dsysvLwork, float64* dsysvTmpArray1, int* dsysvTmpArray2,
                                                 double* dsysvTmpArray3, float64* dspmvTmpArray, bool uncovered,
-                                                PredictionCandidate& prediction) override;
+                                                PredictionCandidate& prediction) const override;
 
     };
 

--- a/python/boomer/boosting/cpp/example_wise_statistics.cpp
+++ b/python/boomer/boosting/cpp/example_wise_statistics.cpp
@@ -237,7 +237,7 @@ DenseExampleWiseStatisticsFactoryImpl::DenseExampleWiseStatisticsFactoryImpl(
     labelMatrixPtr_ = labelMatrixPtr;
 }
 
-std::unique_ptr<AbstractExampleWiseStatistics> DenseExampleWiseStatisticsFactoryImpl::create() {
+std::unique_ptr<AbstractExampleWiseStatistics> DenseExampleWiseStatisticsFactoryImpl::create() const {
     // The number of examples
     uint32 numExamples = labelMatrixPtr_->getNumRows();
     // The number of labels

--- a/python/boomer/boosting/cpp/example_wise_statistics.h
+++ b/python/boomer/boosting/cpp/example_wise_statistics.h
@@ -190,7 +190,7 @@ namespace boosting {
              *
              * @return An unique pointer to an object of type `AbstractExampleWiseStatistics` that has been created
              */
-            virtual std::unique_ptr<AbstractExampleWiseStatistics> create() = 0;
+            virtual std::unique_ptr<AbstractExampleWiseStatistics> create() const = 0;
 
     };
 
@@ -227,7 +227,7 @@ namespace boosting {
                                                   std::unique_ptr<Lapack> lapackPtr,
                                                   std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr);
 
-            std::unique_ptr<AbstractExampleWiseStatistics> create() override;
+            std::unique_ptr<AbstractExampleWiseStatistics> create() const override;
 
     };
 

--- a/python/boomer/boosting/cpp/label_wise_losses.cpp
+++ b/python/boomer/boosting/cpp/label_wise_losses.cpp
@@ -5,7 +5,7 @@ using namespace boosting;
 
 
 std::pair<float64, float64> LabelWiseLogisticLossImpl::calculateGradientAndHessian(
-        IRandomAccessLabelMatrix& labelMatrix, uint32 exampleIndex, uint32 labelIndex, float64 predictedScore) {
+        IRandomAccessLabelMatrix& labelMatrix, uint32 exampleIndex, uint32 labelIndex, float64 predictedScore) const {
     uint8 trueLabel = labelMatrix.getValue(exampleIndex, labelIndex);
     float64 expectedScore = trueLabel ? 1 : -1;
     float64 exponential = exp(expectedScore * predictedScore);
@@ -15,7 +15,7 @@ std::pair<float64, float64> LabelWiseLogisticLossImpl::calculateGradientAndHessi
 }
 
 std::pair<float64, float64> LabelWiseSquaredErrorLossImpl::calculateGradientAndHessian(
-        IRandomAccessLabelMatrix& labelMatrix, uint32 exampleIndex, uint32 labelIndex, float64 predictedScore) {
+        IRandomAccessLabelMatrix& labelMatrix, uint32 exampleIndex, uint32 labelIndex, float64 predictedScore) const {
     uint8 trueLabel = labelMatrix.getValue(exampleIndex, labelIndex);
     float64 expectedScore = trueLabel ? 1 : -1;
     float64 gradient = (2 * predictedScore) - (2 * expectedScore);

--- a/python/boomer/boosting/cpp/label_wise_losses.h
+++ b/python/boomer/boosting/cpp/label_wise_losses.h
@@ -36,7 +36,7 @@ namespace boosting {
              */
             virtual std::pair<float64, float64> calculateGradientAndHessian(IRandomAccessLabelMatrix& labelMatrix,
                                                                             uint32 exampleIndex, uint32 labelIndex,
-                                                                            float64 predictedScore) = 0;
+                                                                            float64 predictedScore) const = 0;
 
     };
 
@@ -49,7 +49,7 @@ namespace boosting {
 
             std::pair<float64, float64> calculateGradientAndHessian(IRandomAccessLabelMatrix& labelMatrix,
                                                                     uint32 exampleIndex, uint32 labelIndex,
-                                                                    float64 predictedScore) override;
+                                                                    float64 predictedScore) const override;
 
     };
 
@@ -62,7 +62,7 @@ namespace boosting {
 
             std::pair<float64, float64> calculateGradientAndHessian(IRandomAccessLabelMatrix& labelMatrix,
                                                                     uint32 exampleIndex, uint32 labelIndex,
-                                                                    float64 predictedScore) override;
+                                                                    float64 predictedScore) const override;
 
     };
 

--- a/python/boomer/boosting/cpp/label_wise_rule_evaluation.cpp
+++ b/python/boomer/boosting/cpp/label_wise_rule_evaluation.cpp
@@ -10,12 +10,10 @@ RegularizedLabelWiseRuleEvaluationImpl::RegularizedLabelWiseRuleEvaluationImpl(f
     l2RegularizationWeight_ = l2RegularizationWeight;
 }
 
-void RegularizedLabelWiseRuleEvaluationImpl::calculateLabelWisePrediction(const uint32* labelIndices,
-                                                                          const float64* totalSumsOfGradients,
-                                                                          float64* sumsOfGradients,
-                                                                          const float64* totalSumsOfHessians,
-                                                                          float64* sumsOfHessians, bool uncovered,
-                                                                          LabelWisePredictionCandidate& prediction) {
+void RegularizedLabelWiseRuleEvaluationImpl::calculateLabelWisePrediction(
+        const uint32* labelIndices, const float64* totalSumsOfGradients, float64* sumsOfGradients,
+        const float64* totalSumsOfHessians, float64* sumsOfHessians, bool uncovered,
+        LabelWisePredictionCandidate& prediction) const {
     // Class members
     float64 l2RegularizationWeight = l2RegularizationWeight_;
     // The number of labels to predict for

--- a/python/boomer/boosting/cpp/label_wise_rule_evaluation.h
+++ b/python/boomer/boosting/cpp/label_wise_rule_evaluation.h
@@ -58,7 +58,7 @@ namespace boosting {
             virtual void calculateLabelWisePrediction(const uint32* labelIndices, const float64* totalSumsOfGradients,
                                                       float64* sumsOfGradients, const float64* totalSumsOfHessians,
                                                       float64* sumsOfHessians, bool uncovered,
-                                                      LabelWisePredictionCandidate& prediction) = 0;
+                                                      LabelWisePredictionCandidate& prediction) const = 0;
 
     };
 
@@ -84,7 +84,7 @@ namespace boosting {
             void calculateLabelWisePrediction(const uint32* labelIndices, const float64* totalSumsOfGradients,
                                               float64* sumsOfGradients, const float64* totalSumsOfHessians,
                                               float64* sumsOfHessians, bool uncovered,
-                                              LabelWisePredictionCandidate& prediction) override;
+                                              LabelWisePredictionCandidate& prediction) const override;
 
     };
 

--- a/python/boomer/boosting/cpp/label_wise_statistics.cpp
+++ b/python/boomer/boosting/cpp/label_wise_statistics.cpp
@@ -171,7 +171,7 @@ DenseLabelWiseStatisticsFactoryImpl::DenseLabelWiseStatisticsFactoryImpl(
     labelMatrixPtr_ = labelMatrixPtr;
 }
 
-std::unique_ptr<AbstractLabelWiseStatistics> DenseLabelWiseStatisticsFactoryImpl::create() {
+std::unique_ptr<AbstractLabelWiseStatistics> DenseLabelWiseStatisticsFactoryImpl::create() const {
     // The number of examples
     uint32 numExamples = labelMatrixPtr_->getNumRows();
     // The number of labels

--- a/python/boomer/boosting/cpp/label_wise_statistics.h
+++ b/python/boomer/boosting/cpp/label_wise_statistics.h
@@ -166,7 +166,7 @@ namespace boosting {
              *
              * @return An unique pointer to an object of type `AbstractLabelWiseStatistics` that has been created
              */
-            virtual std::unique_ptr<AbstractLabelWiseStatistics> create() = 0;
+            virtual std::unique_ptr<AbstractLabelWiseStatistics> create() const = 0;
 
     };
 
@@ -197,7 +197,7 @@ namespace boosting {
                                                 std::shared_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr,
                                                 std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr);
 
-            std::unique_ptr<AbstractLabelWiseStatistics> create() override;
+            std::unique_ptr<AbstractLabelWiseStatistics> create() const override;
 
     };
 

--- a/python/boomer/common/cpp/data.cpp
+++ b/python/boomer/common/cpp/data.cpp
@@ -5,15 +5,15 @@ RangeIndexVector::RangeIndexVector(uint32 numIndices) {
     numIndices_ = numIndices;
 }
 
-uint32 RangeIndexVector::getNumElements() {
+uint32 RangeIndexVector::getNumElements() const {
     return numIndices_;
 }
 
-bool RangeIndexVector::hasZeroElements() {
+bool RangeIndexVector::hasZeroElements() const {
     return false;
 }
 
-uint32 RangeIndexVector::getIndex(uint32 pos) {
+uint32 RangeIndexVector::getIndex(uint32 pos) const {
     return pos;
 }
 
@@ -21,15 +21,15 @@ BinaryDokVector::BinaryDokVector(uint32 numElements) {
     numElements_ = numElements;
 }
 
-uint32 BinaryDokVector::getNumElements() {
+uint32 BinaryDokVector::getNumElements() const {
     return numElements_;
 }
 
-bool BinaryDokVector::hasZeroElements() {
+bool BinaryDokVector::hasZeroElements() const {
     return data_.size() < numElements_;
 }
 
-uint8 BinaryDokVector::getValue(uint32 pos) {
+uint8 BinaryDokVector::getValue(uint32 pos) const {
     return data_.find(pos) != data_.end();
 }
 
@@ -42,15 +42,15 @@ BinaryDokMatrix::BinaryDokMatrix(uint32 numRows, uint32 numCols) {
     numCols_ = numCols;
 }
 
-uint32 BinaryDokMatrix::getNumRows() {
+uint32 BinaryDokMatrix::getNumRows() const {
     return numRows_;
 }
 
-uint32 BinaryDokMatrix::getNumCols() {
+uint32 BinaryDokMatrix::getNumCols() const {
     return numCols_;
 }
 
-uint8 BinaryDokMatrix::getValue(uint32 row, uint32 column) {
+uint8 BinaryDokMatrix::getValue(uint32 row, uint32 column) const {
     return data_.find(std::make_pair(row, column)) != data_.end();
 }
 

--- a/python/boomer/common/cpp/data.h
+++ b/python/boomer/common/cpp/data.h
@@ -35,7 +35,7 @@ class IVector {
          *
          * @return The number of elements
          */
-        virtual uint32 getNumElements() = 0;
+        virtual uint32 getNumElements() const = 0;
 
 };
 
@@ -55,7 +55,7 @@ class IRandomAccessVector : virtual public IVector {
          * @param pos   The position of the element. Must be in [0, getNumElements())
          * @return      The value of the given element
          */
-        virtual T getValue(uint32 pos) = 0;
+        virtual T getValue(uint32 pos) const = 0;
 
 };
 
@@ -73,7 +73,7 @@ class ISparseVector : virtual public IVector {
          *
          * @return True, if the vector contains any zero elements, false otherwise
          */
-        virtual bool hasZeroElements() = 0;
+        virtual bool hasZeroElements() const = 0;
 
 };
 
@@ -92,7 +92,7 @@ class IIndexVector : virtual public ISparseVector {
          * @param pos   The position of the index. Must be in [0, getNumElements())
          * @return      The index at the given position
          */
-        virtual uint32 getIndex(uint32 pos) = 0;
+        virtual uint32 getIndex(uint32 pos) const = 0;
 
 };
 
@@ -125,11 +125,11 @@ class RangeIndexVector : virtual public IIndexVector {
          */
         RangeIndexVector(uint32 numIndices);
 
-        uint32 getNumElements() override;
+        uint32 getNumElements() const override;
 
-        bool hasZeroElements() override;
+        bool hasZeroElements() const override;
 
-        uint32 getIndex(uint32 pos) override;
+        uint32 getIndex(uint32 pos) const override;
 
 };
 
@@ -158,11 +158,11 @@ class BinaryDokVector : virtual public ISparseRandomAccessVector<uint8> {
          */
         void setValue(uint32 pos);
 
-        uint32 getNumElements() override;
+        uint32 getNumElements() const override;
 
-        bool hasZeroElements() override;
+        bool hasZeroElements() const override;
 
-        uint8 getValue(uint32 pos) override;
+        uint8 getValue(uint32 pos) const override;
 
 };
 
@@ -180,14 +180,14 @@ class IMatrix {
          *
          * @return The number of rows
          */
-        virtual uint32 getNumRows() = 0;
+        virtual uint32 getNumRows() const = 0;
 
         /**
          * Returns the number of columns in the matrix.
          *
          * @return The number of columns
          */
-        virtual uint32 getNumCols() = 0;
+        virtual uint32 getNumCols() const = 0;
 
 };
 
@@ -208,7 +208,7 @@ class IRandomAccessMatrix : virtual public IMatrix {
          * @param col   The column of the element. Must be in [0, getNumCols())
          * @return      The value of the given element
          */
-        virtual T getValue(uint32 row, uint32 col) = 0;
+        virtual T getValue(uint32 row, uint32 col) const = 0;
 
 };
 
@@ -241,10 +241,10 @@ class BinaryDokMatrix : virtual public IRandomAccessMatrix<uint8> {
          */
         void setValue(uint32 row, uint32 column);
 
-        uint8 getValue(uint32 row, uint32 col) override;
+        uint8 getValue(uint32 row, uint32 col) const override;
 
-        uint32 getNumRows() override;
+        uint32 getNumRows() const override;
 
-        uint32 getNumCols() override;
+        uint32 getNumCols() const override;
 
 };

--- a/python/boomer/common/cpp/head_refinement.cpp
+++ b/python/boomer/common/cpp/head_refinement.cpp
@@ -2,9 +2,10 @@
 #include <stdlib.h>
 
 
-bool SingleLabelHeadRefinementImpl::findHead(PredictionCandidate* bestHead,
+bool SingleLabelHeadRefinementImpl::findHead(const PredictionCandidate* bestHead,
                                              std::unique_ptr<PredictionCandidate>& headPtr, const uint32* labelIndices,
-                                             IStatisticsSubset& statisticsSubset, bool uncovered, bool accumulated) {
+                                             IStatisticsSubset& statisticsSubset, bool uncovered,
+                                             bool accumulated) const {
     LabelWisePredictionCandidate& prediction = statisticsSubset.calculateLabelWisePrediction(uncovered, accumulated);
     uint32 numPredictions = prediction.numPredictions_;
     float64* qualityScores = prediction.qualityScores_;
@@ -47,13 +48,13 @@ bool SingleLabelHeadRefinementImpl::findHead(PredictionCandidate* bestHead,
 }
 
 PredictionCandidate& SingleLabelHeadRefinementImpl::calculatePrediction(IStatisticsSubset& statisticsSubset,
-                                                                        bool uncovered, bool accumulated) {
+                                                                        bool uncovered, bool accumulated) const {
     return statisticsSubset.calculateLabelWisePrediction(uncovered, accumulated);
 }
 
-bool FullHeadRefinementImpl::findHead(PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
+bool FullHeadRefinementImpl::findHead(const PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
                                       const uint32* labelIndices, IStatisticsSubset& statisticsSubset, bool uncovered,
-                                      bool accumulated) {
+                                      bool accumulated) const {
     PredictionCandidate& prediction = statisticsSubset.calculateExampleWisePrediction(uncovered, accumulated);
     float64 overallQualityScore = prediction.overallQualityScore_;
 
@@ -98,6 +99,6 @@ bool FullHeadRefinementImpl::findHead(PredictionCandidate* bestHead, std::unique
 }
 
 PredictionCandidate& FullHeadRefinementImpl::calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                                 bool accumulated) {
+                                                                 bool accumulated) const {
     return statisticsSubset.calculateExampleWisePrediction(uncovered, accumulated);
 }

--- a/python/boomer/common/cpp/head_refinement.h
+++ b/python/boomer/common/cpp/head_refinement.h
@@ -46,9 +46,9 @@ class IHeadRefinement {
          *                          statistics that have been added so far
          * @return                  True, if the head that has been found is better than `bestHead`, false otherwise
          */
-        virtual bool findHead(PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
+        virtual bool findHead(const PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
                               const uint32* labelIndices, IStatisticsSubset& statisticsSubset, bool uncovered,
-                              bool accumulated) = 0;
+                              bool accumulated) const = 0;
 
         /**
          * Calculates the optimal scores to be predicted by a rule, as well as the rule's overall quality score,
@@ -69,7 +69,7 @@ class IHeadRefinement {
          *                          scores to be predicted by the rule, as well as its overall quality score
          */
         virtual PredictionCandidate& calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                         bool accumulated) = 0;
+                                                         bool accumulated) const = 0;
 
 };
 
@@ -80,12 +80,12 @@ class SingleLabelHeadRefinementImpl : virtual public IHeadRefinement {
 
     public:
 
-        bool findHead(PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
+        bool findHead(const PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
                       const uint32* labelIndices, IStatisticsSubset& statisticsSubset, bool uncovered,
-                      bool accumulated) override;
+                      bool accumulated) const override;
 
         PredictionCandidate& calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                 bool accumulated) override;
+                                                 bool accumulated) const override;
 
 };
 
@@ -96,11 +96,11 @@ class FullHeadRefinementImpl : virtual public IHeadRefinement {
 
     public:
 
-        bool findHead(PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
+        bool findHead(const PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
                       const uint32* labelIndices, IStatisticsSubset& statisticsSubset, bool uncovered,
-                      bool accumulated) override;
+                      bool accumulated) const override;
 
         PredictionCandidate& calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                 bool accumulated) override;
+                                                 bool accumulated) const override;
 
 };

--- a/python/boomer/common/cpp/input_data.cpp
+++ b/python/boomer/common/cpp/input_data.cpp
@@ -8,15 +8,15 @@ DenseLabelMatrixImpl::DenseLabelMatrixImpl(uint32 numExamples, uint32 numLabels,
     y_ = y;
 }
 
-uint32 DenseLabelMatrixImpl::getNumRows() {
+uint32 DenseLabelMatrixImpl::getNumRows() const {
     return numExamples_;
 }
 
-uint32 DenseLabelMatrixImpl::getNumCols() {
+uint32 DenseLabelMatrixImpl::getNumCols() const {
     return numLabels_;
 }
 
-uint8 DenseLabelMatrixImpl::getValue(uint32 row, uint32 col) {
+uint8 DenseLabelMatrixImpl::getValue(uint32 row, uint32 col) const {
     uint32 i = (row * this->getNumCols()) + col;
     return y_[i];
 }
@@ -25,15 +25,15 @@ DokLabelMatrixImpl::DokLabelMatrixImpl(std::unique_ptr<BinaryDokMatrix> matrixPt
     matrixPtr_ = std::move(matrixPtr);
 }
 
-uint32 DokLabelMatrixImpl::getNumRows() {
+uint32 DokLabelMatrixImpl::getNumRows() const {
     return matrixPtr_->getNumRows();
 }
 
-uint32 DokLabelMatrixImpl::getNumCols() {
+uint32 DokLabelMatrixImpl::getNumCols() const {
     return matrixPtr_->getNumCols();
 }
 
-uint8 DokLabelMatrixImpl::getValue(uint32 row, uint32 col) {
+uint8 DokLabelMatrixImpl::getValue(uint32 row, uint32 col) const {
     return matrixPtr_->getValue(row, col);
 }
 
@@ -43,15 +43,15 @@ DenseFeatureMatrixImpl::DenseFeatureMatrixImpl(uint32 numExamples, uint32 numFea
     x_ = x;
 }
 
-uint32 DenseFeatureMatrixImpl::getNumRows() {
+uint32 DenseFeatureMatrixImpl::getNumRows() const {
     return numExamples_;
 }
 
-uint32 DenseFeatureMatrixImpl::getNumCols() {
+uint32 DenseFeatureMatrixImpl::getNumCols() const {
     return numFeatures_;
 }
 
-void DenseFeatureMatrixImpl::fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) {
+void DenseFeatureMatrixImpl::fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) const {
     // The number of elements to be returned
     uint32 numElements = this->getNumRows();
     // The array that stores the indices
@@ -78,15 +78,15 @@ CscFeatureMatrixImpl::CscFeatureMatrixImpl(uint32 numExamples, uint32 numFeature
     xColIndices_ = xColIndices;
 }
 
-uint32 CscFeatureMatrixImpl::getNumRows() {
+uint32 CscFeatureMatrixImpl::getNumRows() const {
     return numExamples_;
 }
 
-uint32 CscFeatureMatrixImpl::getNumCols() {
+uint32 CscFeatureMatrixImpl::getNumCols() const {
     return numFeatures_;
 }
 
-void CscFeatureMatrixImpl::fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) {
+void CscFeatureMatrixImpl::fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) const {
     // The index of the first element in `xData_` and `xRowIndices_` that corresponds to the given feature index+
     uint32 start = xColIndices_[featureIndex];
     // The index of the last element in `xData_` and `xRowIndices_` that corresponds to the given feature index
@@ -116,14 +116,14 @@ DokNominalFeatureVectorImpl::DokNominalFeatureVectorImpl(std::unique_ptr<BinaryD
     vectorPtr_ = std::move(vectorPtr);
 }
 
-uint32 DokNominalFeatureVectorImpl::getNumElements() {
+uint32 DokNominalFeatureVectorImpl::getNumElements() const {
     return vectorPtr_->getNumElements();
 }
 
-bool DokNominalFeatureVectorImpl::hasZeroElements() {
+bool DokNominalFeatureVectorImpl::hasZeroElements() const {
     return vectorPtr_->hasZeroElements();
 }
 
-uint8 DokNominalFeatureVectorImpl::getValue(uint32 pos) {
+uint8 DokNominalFeatureVectorImpl::getValue(uint32 pos) const {
     return vectorPtr_->getValue(pos);
 }

--- a/python/boomer/common/cpp/input_data.h
+++ b/python/boomer/common/cpp/input_data.h
@@ -56,11 +56,11 @@ class DenseLabelMatrixImpl : virtual public IRandomAccessLabelMatrix {
          */
         DenseLabelMatrixImpl(uint32 numExamples, uint32 numLabels, const uint8* y);
 
-        uint32 getNumRows() override;
+        uint32 getNumRows() const override;
 
-        uint32 getNumCols() override;
+        uint32 getNumCols() const override;
 
-        uint8 getValue(uint32 row, uint32 col) override;
+        uint8 getValue(uint32 row, uint32 col) const override;
 
 };
 
@@ -82,11 +82,11 @@ class DokLabelMatrixImpl : virtual public IRandomAccessLabelMatrix {
          */
         DokLabelMatrixImpl(std::unique_ptr<BinaryDokMatrix> matrixPtr);
 
-        uint32 getNumRows() override;
+        uint32 getNumRows() const override;
 
-        uint32 getNumCols() override;
+        uint32 getNumCols() const override;
 
-        uint8 getValue(uint32 row, uint32 col) override;
+        uint8 getValue(uint32 row, uint32 col) const override;
 
 };
 
@@ -108,7 +108,7 @@ class IFeatureMatrix : virtual public IMatrix {
          * @param indexedArray  A reference to a struct of type `IndexedFloat32Array`, which should be used to store the
          *                      indices and feature values
          */
-        virtual void fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) = 0;
+        virtual void fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) const = 0;
 
 };
 
@@ -135,11 +135,11 @@ class DenseFeatureMatrixImpl : virtual public IFeatureMatrix {
          */
         DenseFeatureMatrixImpl(uint32 numExamples, uint32 numFeatures, const float32* x);
 
-        uint32 getNumRows() override;
+        uint32 getNumRows() const override;
 
-        uint32 getNumCols() override;
+        uint32 getNumCols() const override;
 
-        void fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) override;
+        void fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) const override;
 
 };
 
@@ -177,11 +177,11 @@ class CscFeatureMatrixImpl : virtual public IFeatureMatrix {
         CscFeatureMatrixImpl(uint32 numExamples, uint32 numFeatures, const float32* xData, const uint32* xRowIndices,
                              const uint32* xColIndices);
 
-        uint32 getNumRows() override;
+        uint32 getNumRows() const override;
 
-        uint32 getNumCols() override;
+        uint32 getNumCols() const override;
 
-        void fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) override;
+        void fetchFeatureValues(uint32 featureIndex, IndexedFloat32Array& indexedArray) const override;
 
 };
 
@@ -214,10 +214,10 @@ class DokNominalFeatureVectorImpl : virtual public INominalFeatureVector {
          */
         DokNominalFeatureVectorImpl(std::unique_ptr<BinaryDokVector> vectorPtr);
 
-        uint32 getNumElements() override;
+        uint32 getNumElements() const override;
 
-        bool hasZeroElements() override;
+        bool hasZeroElements() const override;
 
-        uint8 getValue(uint32 pos) override;
+        uint8 getValue(uint32 pos) const override;
 
 };

--- a/python/boomer/common/cpp/rule_refinement.cpp
+++ b/python/boomer/common/cpp/rule_refinement.cpp
@@ -2,11 +2,11 @@
 #include <math.h>
 
 
-bool Refinement::isBetterThan(Refinement& another) {
-    PredictionCandidate* head = headPtr.get();
+bool Refinement::isBetterThan(Refinement& another) const {
+    const PredictionCandidate* head = headPtr.get();
 
     if (head != NULL) {
-        PredictionCandidate* anotherHead = another.headPtr.get();
+        const PredictionCandidate* anotherHead = another.headPtr.get();
         return anotherHead == NULL || head->overallQualityScore_ < anotherHead->overallQualityScore_;
     }
 
@@ -25,11 +25,11 @@ ExactRuleRefinementImpl::ExactRuleRefinementImpl(
     callbackPtr_ = std::move(callbackPtr);
 }
 
-void ExactRuleRefinementImpl::findRefinement(IHeadRefinement& headRefinement, PredictionCandidate* currentHead,
+void ExactRuleRefinementImpl::findRefinement(IHeadRefinement& headRefinement, const PredictionCandidate* currentHead,
                                              uint32 numLabelIndices, const uint32* labelIndices) {
     std::unique_ptr<Refinement> refinementPtr = std::make_unique<Refinement>();
     refinementPtr->featureIndex = featureIndex_;
-    PredictionCandidate* bestHead = currentHead;
+    const PredictionCandidate* bestHead = currentHead;
 
     // Create a new, empty subset of the current statistics when processing a new feature...
     std::unique_ptr<IStatisticsSubset> statisticsSubsetPtr = statisticsPtr_->createSubset(numLabelIndices,
@@ -37,7 +37,7 @@ void ExactRuleRefinementImpl::findRefinement(IHeadRefinement& headRefinement, Pr
 
     // Retrieve the array to be iterated...
     IndexedFloat32Array& indexedArray = callbackPtr_->get(featureIndex_);
-    IndexedFloat32* indexedValues = indexedArray.data;
+    const IndexedFloat32* indexedValues = indexedArray.data;
     uint32 numIndexedValues = indexedArray.numElements;
 
     // In the following, we start by processing all examples with feature values < 0...

--- a/python/boomer/common/cpp/rule_refinement.h
+++ b/python/boomer/common/cpp/rule_refinement.h
@@ -28,7 +28,7 @@ class Refinement {
          * @param   A reference to an object of type `Refinement` to be compared to
          * @return  True, if this refinement is better than the given one, false otherwise
          */
-        bool isBetterThan(Refinement& another);
+        bool isBetterThan(Refinement& another) const;
 
         std::unique_ptr<PredictionCandidate> headPtr;
 
@@ -67,7 +67,7 @@ class IRuleRefinementCallback {
          * @param featureIndex  The index of the feature
          * @return              A reference to an object of template type `T` that stores the information
          */
-        virtual T& get(uint32 featureIndex) = 0;
+        virtual T& get(uint32 featureIndex) const = 0;
 
 };
 
@@ -91,7 +91,7 @@ class AbstractRuleRefinement {
          * @param labelIndices      A pointer to an array of type `uint32`, shape `(numLabelIndices)`, representing the
          *                          indices of the labels for which the refined rule may predict
          */
-        virtual void findRefinement(IHeadRefinement& headRefinement, PredictionCandidate* currentHead,
+        virtual void findRefinement(IHeadRefinement& headRefinement, const PredictionCandidate* currentHead,
                                     uint32 numLabelIndices, const uint32* labelIndices) = 0;
 
         /**
@@ -143,7 +143,7 @@ class ExactRuleRefinementImpl : public AbstractRuleRefinement {
                                 uint32 featureIndex, bool nominal,
                                 std::unique_ptr<IRuleRefinementCallback<IndexedFloat32Array>> callbackPtr);
 
-        void findRefinement(IHeadRefinement& headRefinement, PredictionCandidate* currentHead, uint32 numLabelIndices,
-                            const uint32* labelIndices) override;
+        void findRefinement(IHeadRefinement& headRefinement, const PredictionCandidate* currentHead,
+                            uint32 numLabelIndices, const uint32* labelIndices) override;
 
 };

--- a/python/boomer/common/cpp/statistics.cpp
+++ b/python/boomer/common/cpp/statistics.cpp
@@ -12,10 +12,10 @@ AbstractStatistics::AbstractStatistics(uint32 numStatistics, uint32 numLabels) {
     numLabels_ = numLabels;
 }
 
-uint32 AbstractStatistics::getNumRows() {
+uint32 AbstractStatistics::getNumRows() const {
     return numStatistics_;
 }
 
-uint32 AbstractStatistics::getNumCols() {
+uint32 AbstractStatistics::getNumCols() const {
     return numLabels_;
 }

--- a/python/boomer/common/cpp/statistics.h
+++ b/python/boomer/common/cpp/statistics.h
@@ -252,8 +252,8 @@ class AbstractStatistics : virtual public IMatrix {
          */
         virtual void applyPrediction(uint32 statisticIndex, Prediction& prediction) = 0;
 
-        uint32 getNumRows() override;
+        uint32 getNumRows() const override;
 
-        uint32 getNumCols() override;
+        uint32 getNumCols() const override;
 
 };

--- a/python/boomer/common/cpp/sub_sampling.cpp
+++ b/python/boomer/common/cpp/sub_sampling.cpp
@@ -229,7 +229,7 @@ static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacement(uint
 }
 
 template<class T>
-DenseWeightVector<T>::DenseWeightVector(T* weights, uint32 numElements, uint32 sumOfWeights) {
+DenseWeightVector<T>::DenseWeightVector(const T* weights, uint32 numElements, uint32 sumOfWeights) {
     weights_ = weights;
     numElements_ = numElements;
     sumOfWeights_ = sumOfWeights;
@@ -241,22 +241,22 @@ DenseWeightVector<T>::~DenseWeightVector() {
 }
 
 template<class T>
-uint32 DenseWeightVector<T>::getNumElements() {
+uint32 DenseWeightVector<T>::getNumElements() const {
     return numElements_;
 }
 
 template<class T>
-bool DenseWeightVector<T>::hasZeroElements() {
+bool DenseWeightVector<T>::hasZeroElements() const {
     return true;
 }
 
 template<class T>
-uint32 DenseWeightVector<T>::getValue(uint32 pos) {
+uint32 DenseWeightVector<T>::getValue(uint32 pos) const {
     return (uint32) weights_[pos];
 }
 
 template<class T>
-uint32 DenseWeightVector<T>::getSumOfWeights() {
+uint32 DenseWeightVector<T>::getSumOfWeights() const {
     return sumOfWeights_;
 }
 
@@ -264,23 +264,23 @@ EqualWeightVector::EqualWeightVector(uint32 numElements) {
     numElements_ = numElements;
 }
 
-uint32 EqualWeightVector::getNumElements() {
+uint32 EqualWeightVector::getNumElements() const {
     return numElements_;
 }
 
-bool EqualWeightVector::hasZeroElements() {
+bool EqualWeightVector::hasZeroElements() const {
     return false;
 }
 
-uint32 EqualWeightVector::getValue(uint32 pos) {
+uint32 EqualWeightVector::getValue(uint32 pos) const {
     return 1;
 }
 
-uint32 EqualWeightVector::getSumOfWeights() {
+uint32 EqualWeightVector::getSumOfWeights() const {
     return numElements_;
 }
 
-DenseIndexVector::DenseIndexVector(uint32* indices, uint32 numElements) {
+DenseIndexVector::DenseIndexVector(const uint32* indices, uint32 numElements) {
     indices_ = indices;
     numElements_ = numElements;
 }
@@ -289,15 +289,15 @@ DenseIndexVector::~DenseIndexVector() {
     delete[] indices_;
 }
 
-uint32 DenseIndexVector::getNumElements() {
+uint32 DenseIndexVector::getNumElements() const {
     return numElements_;
 }
 
-bool DenseIndexVector::hasZeroElements() {
+bool DenseIndexVector::hasZeroElements() const {
     return true;
 }
 
-uint32 DenseIndexVector::getIndex(uint32 pos) {
+uint32 DenseIndexVector::getIndex(uint32 pos) const {
     return indices_[pos];
 }
 
@@ -305,7 +305,7 @@ BaggingImpl::BaggingImpl(float32 sampleSize) {
     sampleSize_ = sampleSize;
 }
 
-std::unique_ptr<IWeightVector> BaggingImpl::subSample(uint32 numExamples, RNG& rng) {
+std::unique_ptr<IWeightVector> BaggingImpl::subSample(uint32 numExamples, RNG& rng) const {
     uint32 numSamples = (uint32) (sampleSize_ * numExamples);
     uint32* weights = new uint32[numExamples]{0};
 
@@ -324,12 +324,12 @@ RandomInstanceSubsetSelectionImpl::RandomInstanceSubsetSelectionImpl(float32 sam
     sampleSize_ = sampleSize;
 }
 
-std::unique_ptr<IWeightVector> RandomInstanceSubsetSelectionImpl::subSample(uint32 numExamples, RNG& rng) {
+std::unique_ptr<IWeightVector> RandomInstanceSubsetSelectionImpl::subSample(uint32 numExamples, RNG& rng) const {
     uint32 numSamples = (uint32) (sampleSize_ * numExamples);
     return sampleWeightsWithoutReplacement(numExamples, numSamples, rng);
 }
 
-std::unique_ptr<IWeightVector> NoInstanceSubSamplingImpl::subSample(uint32 numExamples, RNG& rng) {
+std::unique_ptr<IWeightVector> NoInstanceSubSamplingImpl::subSample(uint32 numExamples, RNG& rng) const {
     return std::make_unique<EqualWeightVector>(numExamples);
 }
 
@@ -337,7 +337,7 @@ RandomFeatureSubsetSelectionImpl::RandomFeatureSubsetSelectionImpl(float32 sampl
     sampleSize_ = sampleSize;
 }
 
-std::unique_ptr<IIndexVector> RandomFeatureSubsetSelectionImpl::subSample(uint32 numFeatures, RNG& rng) {
+std::unique_ptr<IIndexVector> RandomFeatureSubsetSelectionImpl::subSample(uint32 numFeatures, RNG& rng) const {
     uint32 numSamples;
 
     if (sampleSize_ > 0) {
@@ -349,7 +349,7 @@ std::unique_ptr<IIndexVector> RandomFeatureSubsetSelectionImpl::subSample(uint32
     return sampleIndicesWithoutReplacement(numFeatures, numSamples, rng);
 }
 
-std::unique_ptr<IIndexVector> NoFeatureSubSamplingImpl::subSample(uint32 numFeatures, RNG& rng) {
+std::unique_ptr<IIndexVector> NoFeatureSubSamplingImpl::subSample(uint32 numFeatures, RNG& rng) const {
     return std::make_unique<RangeIndexVector>(numFeatures);
 }
 
@@ -357,10 +357,10 @@ RandomLabelSubsetSelectionImpl::RandomLabelSubsetSelectionImpl(uint32 numSamples
     numSamples_ = numSamples;
 }
 
-std::unique_ptr<IIndexVector> RandomLabelSubsetSelectionImpl::subSample(uint32 numLabels, RNG& rng) {
+std::unique_ptr<IIndexVector> RandomLabelSubsetSelectionImpl::subSample(uint32 numLabels, RNG& rng) const {
     return sampleIndicesWithoutReplacement(numLabels, numSamples_, rng);
 }
 
-std::unique_ptr<IIndexVector> NoLabelSubSamplingImpl::subSample(uint32 numLabels, RNG& rng) {
+std::unique_ptr<IIndexVector> NoLabelSubSamplingImpl::subSample(uint32 numLabels, RNG& rng) const {
     return std::make_unique<RangeIndexVector>(numLabels);
 }

--- a/python/boomer/common/cpp/sub_sampling.h
+++ b/python/boomer/common/cpp/sub_sampling.h
@@ -25,7 +25,7 @@ class IWeightVector : virtual public ISparseRandomAccessVector<uint32> {
          *
          * @return The sum of the weights
          */
-        virtual uint32 getSumOfWeights() = 0;
+        virtual uint32 getSumOfWeights() const = 0;
 
 };
 
@@ -37,7 +37,7 @@ class DenseWeightVector : virtual public IWeightVector {
 
     private:
 
-        T* weights_;
+        const T* weights_;
 
         uint32 numElements_;
 
@@ -51,17 +51,17 @@ class DenseWeightVector : virtual public IWeightVector {
          * @param numElements   The number of elements in the vector. Must be at least 1
          * @param sumOfWeights  The sum of the weights in the vector
          */
-        DenseWeightVector(T* weights, uint32 numElements, uint32 sumOfWeights);
+        DenseWeightVector(const T* weights, uint32 numElements, uint32 sumOfWeights);
 
         ~DenseWeightVector();
 
-        uint32 getNumElements() override;
+        uint32 getNumElements() const override;
 
-        bool hasZeroElements() override;
+        bool hasZeroElements() const override;
 
-        uint32 getValue(uint32 pos) override;
+        uint32 getValue(uint32 pos) const override;
 
-        uint32 getSumOfWeights() override;
+        uint32 getSumOfWeights() const override;
 
 };
 
@@ -81,13 +81,13 @@ class EqualWeightVector : virtual public IWeightVector {
          */
         EqualWeightVector(uint32 numElements);
 
-        uint32 getNumElements() override;
+        uint32 getNumElements() const override;
 
-        bool hasZeroElements();
+        bool hasZeroElements() const override;
 
-        uint32 getValue(uint32 pos) override;
+        uint32 getValue(uint32 pos) const override;
 
-        uint32 getSumOfWeights() override;
+        uint32 getSumOfWeights() const override;
 
 };
 
@@ -98,7 +98,7 @@ class DenseIndexVector : virtual public IIndexVector {
 
     private:
 
-        uint32* indices_;
+        const uint32* indices_;
 
         uint32 numElements_;
 
@@ -108,15 +108,15 @@ class DenseIndexVector : virtual public IIndexVector {
          * @param indices       A pointer to an array of type `uint32`, shape `(numElements)`, that stores the indices
          * @param numElements   The number of elements in the vector. Must be at least 1
          */
-        DenseIndexVector(uint32* indices, uint32 numElements);
+        DenseIndexVector(const uint32* indices, uint32 numElements);
 
         ~DenseIndexVector();
 
-        uint32 getNumElements() override;
+        uint32 getNumElements() const override;
 
-        bool hasZeroElements() override;
+        bool hasZeroElements() const override;
 
-        uint32 getIndex(uint32 pos) override;
+        uint32 getIndex(uint32 pos) const override;
 
 };
 
@@ -138,7 +138,7 @@ class IInstanceSubSampling {
          * @return              An unique pointer to an object type `WeightVector` that provides access to the weights
          *                      of the individual training examples
          */
-        virtual std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) = 0;
+        virtual std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) const = 0;
 
 };
 
@@ -160,7 +160,7 @@ class BaggingImpl : virtual public IInstanceSubSampling {
          */
         BaggingImpl(float32 sampleSize);
 
-        std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) override;
+        std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) const override;
 
 };
 
@@ -182,7 +182,7 @@ class RandomInstanceSubsetSelectionImpl : virtual public IInstanceSubSampling {
          */
         RandomInstanceSubsetSelectionImpl(float32 sampleSize);
 
-        std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) override;
+        std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) const override;
 
 };
 
@@ -194,7 +194,7 @@ class NoInstanceSubSamplingImpl : virtual public IInstanceSubSampling {
 
     public:
 
-        std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) override;
+        std::unique_ptr<IWeightVector> subSample(uint32 numExamples, RNG& rng) const override;
 
 };
 
@@ -216,7 +216,7 @@ class IFeatureSubSampling {
          * @return              An unique pointer to an object of type `IIndexVector` that provides access to the
          *                      indices of the features that are contained in the sub-sample
          */
-        virtual std::unique_ptr<IIndexVector> subSample(uint32 numFeatures, RNG& rng) = 0;
+        virtual std::unique_ptr<IIndexVector> subSample(uint32 numFeatures, RNG& rng) const = 0;
 
 };
 
@@ -239,7 +239,7 @@ class RandomFeatureSubsetSelectionImpl : virtual public IFeatureSubSampling {
          */
         RandomFeatureSubsetSelectionImpl(float32 sampleSize);
 
-        std::unique_ptr<IIndexVector> subSample(uint32 numFeatures, RNG& rng) override;
+        std::unique_ptr<IIndexVector> subSample(uint32 numFeatures, RNG& rng) const override;
 
 };
 
@@ -250,7 +250,7 @@ class NoFeatureSubSamplingImpl : virtual public IFeatureSubSampling {
 
     public:
 
-        std::unique_ptr<IIndexVector> subSample(uint32 numFeatures, RNG& rng) override;
+        std::unique_ptr<IIndexVector> subSample(uint32 numFeatures, RNG& rng) const override;
 
 };
 
@@ -271,7 +271,7 @@ class ILabelSubSampling {
          * @return          An unique pointer to an object of type `IIndexVector` that provides access to the indices of
          *                  the labels that are contained in the sub-sample
          */
-        virtual std::unique_ptr<IIndexVector> subSample(uint32 numLabels, RNG& rng) = 0;
+        virtual std::unique_ptr<IIndexVector> subSample(uint32 numLabels, RNG& rng) const = 0;
 
 };
 
@@ -291,7 +291,7 @@ class RandomLabelSubsetSelectionImpl : virtual public ILabelSubSampling {
          */
         RandomLabelSubsetSelectionImpl(uint32 numSamples);
 
-        std::unique_ptr<IIndexVector> subSample(uint32 numLabels, RNG& rng) override;
+        std::unique_ptr<IIndexVector> subSample(uint32 numLabels, RNG& rng) const override;
 
 };
 
@@ -302,6 +302,6 @@ class NoLabelSubSamplingImpl : virtual public ILabelSubSampling {
 
     public:
 
-        std::unique_ptr<IIndexVector> subSample(uint32 numLabels, RNG& rng) override;
+        std::unique_ptr<IIndexVector> subSample(uint32 numLabels, RNG& rng) const override;
 
 };

--- a/python/boomer/common/cpp/thresholds.h
+++ b/python/boomer/common/cpp/thresholds.h
@@ -62,7 +62,7 @@ class IThresholdsSubset {
          *                          the updated scores
          * @param refinement        A reference to an object of type `Refinement`, whose head should be updated
          */
-        virtual void recalculatePrediction(IHeadRefinement& headRefinement, Refinement& refinement) = 0;
+        virtual void recalculatePrediction(IHeadRefinement& headRefinement, Refinement& refinement) const = 0;
 
         /**
          * Applies the predictions of a rule to the statistics that correspond to the current subset.
@@ -115,11 +115,11 @@ class AbstractThresholds : virtual public IMatrix {
          *
          * @return The total number of available labels
          */
-        uint32 getNumLabels();
+        uint32 getNumLabels() const;
 
-        uint32 getNumRows() override;
+        uint32 getNumRows() const override;
 
-        uint32 getNumCols() override;
+        uint32 getNumCols() const override;
 
 };
 
@@ -156,7 +156,7 @@ class ExactThresholdsImpl : public AbstractThresholds {
                          */
                         RuleRefinementCallbackImpl(ThresholdsSubsetImpl& thresholdsSubset);
 
-                        IndexedFloat32Array& get(uint32 featureIndex) override;
+                        IndexedFloat32Array& get(uint32 featureIndex) const override;
 
                 };
 
@@ -190,7 +190,7 @@ class ExactThresholdsImpl : public AbstractThresholds {
 
                 void applyRefinement(Refinement& refinement) override;
 
-                void recalculatePrediction(IHeadRefinement& headRefinement, Refinement& refinement) override;
+                void recalculatePrediction(IHeadRefinement& headRefinement, Refinement& refinement) const override;
 
                 void applyPrediction(Prediction& prediction) override;
 

--- a/python/boomer/seco/cpp/head_refinement.cpp
+++ b/python/boomer/seco/cpp/head_refinement.cpp
@@ -28,9 +28,9 @@ PartialHeadRefinementImpl::PartialHeadRefinementImpl(std::shared_ptr<ILiftFuncti
     liftFunctionPtr_ = liftFunctionPtr;
 }
 
-bool PartialHeadRefinementImpl::findHead(PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
-                                         const uint32* labelIndices, IStatisticsSubset& statisticsSubset,
-                                         bool uncovered, bool accumulated) {
+bool PartialHeadRefinementImpl::findHead(const PredictionCandidate* bestHead,
+                                         std::unique_ptr<PredictionCandidate>& headPtr, const uint32* labelIndices,
+                                         IStatisticsSubset& statisticsSubset, bool uncovered, bool accumulated) const {
     bool result = false;
     LabelWisePredictionCandidate& prediction = statisticsSubset.calculateLabelWisePrediction(uncovered, accumulated);
     uint32 numPredictions = prediction.numPredictions_;
@@ -124,6 +124,6 @@ bool PartialHeadRefinementImpl::findHead(PredictionCandidate* bestHead, std::uni
 }
 
 PredictionCandidate& PartialHeadRefinementImpl::calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                                    bool accumulated) {
+                                                                    bool accumulated) const {
     return statisticsSubset.calculateLabelWisePrediction(uncovered, accumulated);
 }

--- a/python/boomer/seco/cpp/head_refinement.h
+++ b/python/boomer/seco/cpp/head_refinement.h
@@ -26,12 +26,12 @@ namespace seco {
              */
             PartialHeadRefinementImpl(std::shared_ptr<ILiftFunction> liftFunctionPtr);
 
-            bool findHead(PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
+            bool findHead(const PredictionCandidate* bestHead, std::unique_ptr<PredictionCandidate>& headPtr,
                           const uint32* labelIndices, IStatisticsSubset& statisticsSubset, bool uncovered,
-                          bool accumulated) override;
+                          bool accumulated) const override;
 
             PredictionCandidate& calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                     bool accumulated) override;
+                                                     bool accumulated) const override;
 
     };
 

--- a/python/boomer/seco/cpp/heuristics.cpp
+++ b/python/boomer/seco/cpp/heuristics.cpp
@@ -43,22 +43,22 @@ static inline float64 wra(float64 cin, float64 cip, float64 crn, float64 crp, fl
 }
 
 float64 PrecisionImpl::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                               float64 uip, float64 urn, float64 urp) {
+                                               float64 uip, float64 urn, float64 urp) const {
     return precision(cin, cip, crn, crp);
 }
 
 float64 RecallImpl::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                            float64 uip, float64 urn, float64 urp) {
+                                            float64 uip, float64 urn, float64 urp) const {
     return recall(cin, crp, uin, urp);
 }
 
 float64 WRAImpl::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin, float64 uip,
-                                         float64 urn, float64 urp) {
+                                         float64 urn, float64 urp) const {
     return wra(cin, cip, crn, crp, uin, uip, urn, urp);
 }
 
 float64 HammingLossImpl::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                                 float64 uip, float64 urn, float64 urp) {
+                                                 float64 uip, float64 urn, float64 urp) const {
     float64 numCoveredIncorrect = cip + crn;
     float64 numCoveredCorrect = cin + crp;
     float64 numCovered = numCoveredIncorrect + numCoveredCorrect;
@@ -77,7 +77,7 @@ FMeasureImpl::FMeasureImpl(float64 beta) {
 }
 
 float64 FMeasureImpl::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                              float64 uip, float64 urn, float64 urp) {
+                                              float64 uip, float64 urn, float64 urp) const {
     if (isinf(beta_)) {
         // Equivalent to recall
         return recall(cin, crp, uin, urp);
@@ -104,7 +104,7 @@ MEstimateImpl::MEstimateImpl(float64 m) {
 }
 
 float64 MEstimateImpl::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                               float64 uip, float64 urn, float64 urp) {
+                                               float64 uip, float64 urn, float64 urp) const {
     if (isinf(m_)) {
         // Equivalent to weighted relative accuracy
         return wra(cin, cip, crn, crp, uin, uip, urn, urp);

--- a/python/boomer/seco/cpp/heuristics.h
+++ b/python/boomer/seco/cpp/heuristics.h
@@ -108,7 +108,7 @@ namespace seco {
              * @return      The quality score that has been calculated
              */
             virtual float64 evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                                    float64 uip, float64 urn, float64 urp) = 0;
+                                                    float64 uip, float64 urn, float64 urp) const = 0;
 
     };
 
@@ -120,7 +120,7 @@ namespace seco {
         public:
 
             float64 evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                            float64 uip, float64 urn, float64 urp) override;
+                                            float64 uip, float64 urn, float64 urp) const override;
 
     };
 
@@ -133,7 +133,7 @@ namespace seco {
         public:
 
             float64 evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                            float64 uip, float64 urn, float64 urp) override;
+                                            float64 uip, float64 urn, float64 urp) const override;
 
     };
 
@@ -145,7 +145,7 @@ namespace seco {
         public:
 
             float64 evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                            float64 uip, float64 urn, float64 urp) override;
+                                            float64 uip, float64 urn, float64 urp) const override;
 
     };
 
@@ -157,7 +157,7 @@ namespace seco {
         public:
 
             float64 evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                            float64 uip, float64 urn, float64 urp) override;
+                                            float64 uip, float64 urn, float64 urp) const override;
 
     };
 
@@ -187,7 +187,7 @@ namespace seco {
             FMeasureImpl(float64 beta);
 
             float64 evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                            float64 uip, float64 urn, float64 urp) override;
+                                            float64 uip, float64 urn, float64 urp) const override;
 
     };
 
@@ -217,7 +217,7 @@ namespace seco {
             MEstimateImpl(float64 beta);
 
             float64 evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                            float64 uip, float64 urn, float64 urp) override;
+                                            float64 uip, float64 urn, float64 urp) const override;
 
     };
 

--- a/python/boomer/seco/cpp/label_wise_rule_evaluation.cpp
+++ b/python/boomer/seco/cpp/label_wise_rule_evaluation.cpp
@@ -11,13 +11,10 @@ HeuristicLabelWiseRuleEvaluationImpl::HeuristicLabelWiseRuleEvaluationImpl(std::
     predictMajority_ = predictMajority;
 }
 
-void HeuristicLabelWiseRuleEvaluationImpl::calculateLabelWisePrediction(const uint32* labelIndices,
-                                                                        const uint8* minorityLabels,
-                                                                        const float64* confusionMatricesTotal,
-                                                                        const float64* confusionMatricesSubset,
-                                                                        const float64* confusionMatricesCovered,
-                                                                        bool uncovered,
-                                                                        LabelWisePredictionCandidate& prediction) {
+void HeuristicLabelWiseRuleEvaluationImpl::calculateLabelWisePrediction(
+        const uint32* labelIndices, const uint8* minorityLabels, const float64* confusionMatricesTotal,
+        const float64* confusionMatricesSubset, const float64* confusionMatricesCovered, bool uncovered,
+        LabelWisePredictionCandidate& prediction) const {
     // The number of labels to predict for
     uint32 numPredictions = prediction.numPredictions_;
     // The array that should be used to store the predicted scores

--- a/python/boomer/seco/cpp/label_wise_rule_evaluation.h
+++ b/python/boomer/seco/cpp/label_wise_rule_evaluation.h
@@ -57,7 +57,7 @@ namespace seco {
                                                       const float64* confusionMatricesTotal,
                                                       const float64* confusionMatricesSubset,
                                                       const float64* confusionMatricesCovered, bool uncovered,
-                                                      LabelWisePredictionCandidate& prediction) = 0;
+                                                      LabelWisePredictionCandidate& prediction) const = 0;
 
     };
 
@@ -87,7 +87,7 @@ namespace seco {
                                               const float64* confusionMatricesTotal,
                                               const float64* confusionMatricesSubset,
                                               const float64* confusionMatricesCovered, bool uncovered,
-                                              LabelWisePredictionCandidate& prediction) override;
+                                              LabelWisePredictionCandidate& prediction) const override;
 
     };
 

--- a/python/boomer/seco/cpp/label_wise_statistics.cpp
+++ b/python/boomer/seco/cpp/label_wise_statistics.cpp
@@ -211,7 +211,7 @@ DenseLabelWiseStatisticsFactoryImpl::DenseLabelWiseStatisticsFactoryImpl(
     labelMatrixPtr_ = labelMatrixPtr;
 }
 
-std::unique_ptr<AbstractLabelWiseStatistics> DenseLabelWiseStatisticsFactoryImpl::create() {
+std::unique_ptr<AbstractLabelWiseStatistics> DenseLabelWiseStatisticsFactoryImpl::create() const {
     // The number of examples
     uint32 numExamples = labelMatrixPtr_->getNumRows();
     // The number of labels

--- a/python/boomer/seco/cpp/label_wise_statistics.h
+++ b/python/boomer/seco/cpp/label_wise_statistics.h
@@ -160,7 +160,7 @@ namespace seco {
              *
              * @return An unique pointer to an object of type `AbstractLabelWiseStatistics` that has been created
              */
-            virtual std::unique_ptr<AbstractLabelWiseStatistics> create() = 0;
+            virtual std::unique_ptr<AbstractLabelWiseStatistics> create() const = 0;
 
     };
 
@@ -186,7 +186,7 @@ namespace seco {
             DenseLabelWiseStatisticsFactoryImpl(std::shared_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr,
                                                 std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr);
 
-            std::unique_ptr<AbstractLabelWiseStatistics> create() override;
+            std::unique_ptr<AbstractLabelWiseStatistics> create() const override;
 
     };
 

--- a/python/boomer/seco/cpp/lift_functions.cpp
+++ b/python/boomer/seco/cpp/lift_functions.cpp
@@ -11,7 +11,7 @@ PeakLiftFunctionImpl::PeakLiftFunctionImpl(uint32 numLabels, uint32 peakLabel, f
     exponent_ = 1.0 / curvature;
 }
 
-float64 PeakLiftFunctionImpl::calculateLift(uint32 numLabels) {
+float64 PeakLiftFunctionImpl::calculateLift(uint32 numLabels) const {
     float64 normalization;
 
     if (numLabels < peakLabel_) {
@@ -25,6 +25,6 @@ float64 PeakLiftFunctionImpl::calculateLift(uint32 numLabels) {
     return 1 + pow(normalization, exponent_) * (maxLift_ - 1);
 }
 
-float64 PeakLiftFunctionImpl::getMaxLift() {
+float64 PeakLiftFunctionImpl::getMaxLift() const {
     return maxLift_;
 }

--- a/python/boomer/seco/cpp/lift_functions.h
+++ b/python/boomer/seco/cpp/lift_functions.h
@@ -26,14 +26,14 @@ namespace seco {
              * @param numLabels The number of labels for which the lift should be calculated
              * @return          The lift that has been calculated
              */
-            virtual float64 calculateLift(uint32 numLabels) = 0;
+            virtual float64 calculateLift(uint32 numLabels) const = 0;
 
             /**
              * Returns the maximum lift possible.
              *
              * @return The maximum lift possible
              */
-            virtual float64 getMaxLift() = 0;
+            virtual float64 getMaxLift() const = 0;
 
     };
 
@@ -64,9 +64,9 @@ namespace seco {
              */
             PeakLiftFunctionImpl(uint32 numLabels, uint32 peakLabel, float64 maxLift, float64 curvature);
 
-            float64 calculateLift(uint32 numLabels) override;
+            float64 calculateLift(uint32 numLabels) const override;
 
-            float64 getMaxLift() override;
+            float64 getMaxLift() const override;
 
     };
 


### PR DESCRIPTION
Fügt das Keyword `const` zu allen Variablen, Methoden und Argumenten hinzu bei denen dies Sinn macht.