### PR TITLE
Zugriff auf CoverageMask eines IThresholdsSubset-Objekts ermöglichen

### DIFF
--- a/python/boomer/common/cpp/thresholds.h
+++ b/python/boomer/common/cpp/thresholds.h
@@ -109,16 +109,26 @@ class IThresholdsSubset {
         virtual void applyRefinement(Refinement& refinement) = 0;
 
         /**
-         * Recalculates the scores to be predicted by a refinement that has been found by an instance of the type
-         * `IRuleRefinement`, which was previously created via the function `createRuleRefinement`, and updates the head
+         * Returns a `CoverageMask` that specifies which elements are covered by the refinement that has been applied
+         * via the function `applyRefinement`.
+         *
+         * @return A reference to an object of type `CoverageMask` that specifies the elements that are covered by the
+         *         refinement
+         */
+        virtual const CoverageMask& getCoverageMask() const = 0;
+
+        /**
+         * Recalculates the scores to be predicted by a refinement based on a given `CoverageMask` and updates the head
          * of the refinement accordingly.
          *
          * When calculating the updated scores the weights of the individual training examples are ignored and equally
          * distributed weights are assumed instead.
          *
-         * @param refinement A reference to an object of type `Refinement`, whose head should be updated
+         * @param coverageMask  A reference to an object of type `CoverageMask` that specifies which elements are
+         *                      covered by the refinement
+         * @param refinement    A reference to an object of type `Refinement`, whose head should be updated
          */
-        virtual void recalculatePrediction(Refinement& refinement) const = 0;
+        virtual void recalculatePrediction(const CoverageMask& coverageMask, Refinement& refinement) const = 0;
 
         /**
          * Applies the predictions of a rule to the statistics that correspond to the current subset.

--- a/python/boomer/common/cpp/thresholds_approximate.cpp
+++ b/python/boomer/common/cpp/thresholds_approximate.cpp
@@ -111,7 +111,11 @@ class ApproximateThresholds::ThresholdsSubset : virtual public IThresholdsSubset
 
         }
 
-        void recalculatePrediction(Refinement& refinement) const override {
+        const CoverageMask& getCoverageMask() const {
+
+        }
+
+        void recalculatePrediction(const CoverageMask& coverageMask, Refinement& refinement) const override {
 
         }
 

--- a/python/boomer/common/cpp/thresholds_exact.cpp
+++ b/python/boomer/common/cpp/thresholds_exact.cpp
@@ -151,13 +151,17 @@ class ExactThresholds::ThresholdsSubset : virtual public IThresholdsSubset {
                                                coverageMask_, *thresholds_.statisticsPtr_, weights_);
         }
 
-        void recalculatePrediction(Refinement& refinement) const override {
+        const CoverageMask& getCoverageMask() const {
+            return coverageMask_;
+        }
+
+        void recalculatePrediction(const CoverageMask& coverageMask, Refinement& refinement) const override {
             AbstractPrediction& head = *refinement.headPtr;
             std::unique_ptr<IStatisticsSubset> statisticsSubsetPtr = head.createSubset(*thresholds_.statisticsPtr_);
             uint32 numExamples = thresholds_.getNumRows();
 
             for (uint32 r = 0; r < numExamples; r++) {
-                if (coverageMask_.isCovered(r)) {
+                if (coverageMask.isCovered(r)) {
                     statisticsSubsetPtr->addToSubset(r, 1);
                 }
             }

--- a/python/boomer/common/thresholds.pxd
+++ b/python/boomer/common/thresholds.pxd
@@ -11,13 +11,19 @@ from libcpp.memory cimport unique_ptr
 
 cdef extern from "cpp/thresholds.h" nogil:
 
+    cdef cppclass CoverageMask:
+        pass
+
+
     cdef cppclass IThresholdsSubset:
 
         # Functions:
 
         void applyRefinement(Refinement &refinement)
 
-        void recalculatePrediction(Refinement &refinement)
+        const CoverageMask& getCoverageMask()
+
+        void recalculatePrediction(const CoverageMask& coverageMask, Refinement &refinement)
 
         void applyPrediction(AbstractPrediction& prediction)
 


### PR DESCRIPTION
Enthält folgende Änderungen:

* Fügt die Funktion `getCoverageMask` zu der Klasse `IThresholdsSubset` hinzu
* Die Funktion `recalculatePrediction` der Klasse `IThresholdsSubset` wurde um das Argument `coverageMask` erweitert