### PR TITLE
Filterung der von einem Refinement abgedeckten Bins

### DIFF
--- a/python/boomer/common/cpp/thresholds_approximate.cpp
+++ b/python/boomer/common/cpp/thresholds_approximate.cpp
@@ -37,10 +37,11 @@ static inline void filterCurrentVector(BinVector& vector, FilteredCacheEntry<Bin
     for(intp r = start; r < end; r++) {
         for (BinVector::example_const_iterator it = vector.examples_cbegin(r); it != vector.examples_cend(r); it++) {
             BinVector::Example example = *it;
-            if(wasEmpty){
+            coverageMaskIterator[example.index] = numConditions;
+
+            if (wasEmpty) {
                 filteredVector->addExample(r, example);
             }
-            coverageMaskIterator[example.index] = numConditions;
         }
 
         filteredIterator[i].numExamples = iterator[r].numExamples;
@@ -143,7 +144,7 @@ class ApproximateThresholds::ThresholdsSubset : public IThresholdsSubset {
             auto cacheFilteredIterator = cacheFiltered_.emplace(featureIndex, FilteredCacheEntry<BinVector>()).first;
             BinVector* binVector = cacheFilteredIterator->second.vectorPtr.get();
 
-            if(binVector == nullptr){
+            if (binVector == nullptr) {
                 thresholds_.cache_.emplace(featureIndex, BinCacheEntry());
             }
 


### PR DESCRIPTION
Ich habe mal auf Basis des Issues #295 weiter gearbeitet. Das ist der Pull-Request dazu.
Es kompiliert zwar aber ich bin mir nicht sicher, ob es das tut was es tun soll oder ob das so funktioniert, deswegen hätte ich gerne Feedback.

Das kommt daher, dass ich mich an `thresholds_exact.cpp` orientiert habe, aber noch nicht ganz verstanden habe, welche Codeblöcke mit den in #295 angesprochenen Sonderfällen beschäftigen.

Ein paar bestimmte Fragen hätte ich auch noch:

1. In `thresholds_exact.cpp` wird in `filterCurrentVector` sowohl `intp` als auch `uint32` verwendet, hat das einen bestimmten Grund?
2. Was genau soll in der CoverageMask gespeichert werden?