### PR TITLE
Interface "IBinningObserver" generisch machen

### DIFF
--- a/python/boomer/boosting/cpp/statistics_example_wise.cpp
+++ b/python/boomer/boosting/cpp/statistics_example_wise.cpp
@@ -240,12 +240,12 @@ class ExampleWiseStatistics : public ExampleWiseHistogram<StatisticVector, Stati
 
             }
 
-            void onBinUpdate(uint32 binIndex, const FeatureVector::Entry& entry) override {
-                uint32 index = entry.index;
-                statisticMatrixPtr_->addToRow(binIndex, statistics_.statisticMatrixPtr_->gradients_row_cbegin(index),
-                                              statistics_.statisticMatrixPtr_->gradients_row_cend(index),
-                                              statistics_.statisticMatrixPtr_->hessians_row_cbegin(index),
-                                              statistics_.statisticMatrixPtr_->hessians_row_cend(index));
+            void onBinUpdate(uint32 binIndex, uint32 originalIndex, float32 value) override {
+                statisticMatrixPtr_->addToRow(binIndex,
+                                              statistics_.statisticMatrixPtr_->gradients_row_cbegin(originalIndex),
+                                              statistics_.statisticMatrixPtr_->gradients_row_cend(originalIndex),
+                                              statistics_.statisticMatrixPtr_->hessians_row_cbegin(originalIndex),
+                                              statistics_.statisticMatrixPtr_->hessians_row_cend(originalIndex));
             }
 
             std::unique_ptr<IHistogram> build() override {

--- a/python/boomer/boosting/cpp/statistics_label_wise.cpp
+++ b/python/boomer/boosting/cpp/statistics_label_wise.cpp
@@ -226,13 +226,12 @@ class LabelWiseStatistics : public LabelWiseHistogram<StatisticVector, Statistic
 
                 }
 
-                void onBinUpdate(uint32 binIndex, const FeatureVector::Entry& entry) override {
-                    uint32 index = entry.index;
+                void onBinUpdate(uint32 binIndex, uint32 originalIndex, float32 value) override {
                     statisticMatrixPtr_->addToRow(binIndex,
-                                                  statistics_.statisticMatrixPtr_->gradients_row_cbegin(index),
-                                                  statistics_.statisticMatrixPtr_->gradients_row_cend(index),
-                                                  statistics_.statisticMatrixPtr_->hessians_row_cbegin(index),
-                                                  statistics_.statisticMatrixPtr_->hessians_row_cend(index));
+                                                  statistics_.statisticMatrixPtr_->gradients_row_cbegin(originalIndex),
+                                                  statistics_.statisticMatrixPtr_->gradients_row_cend(originalIndex),
+                                                  statistics_.statisticMatrixPtr_->hessians_row_cbegin(originalIndex),
+                                                  statistics_.statisticMatrixPtr_->hessians_row_cend(originalIndex));
                 }
 
                 std::unique_ptr<IHistogram> build() override {

--- a/python/boomer/common/cpp/binning.cpp
+++ b/python/boomer/common/cpp/binning.cpp
@@ -36,7 +36,7 @@ IBinning::FeatureInfo EqualFrequencyBinningImpl::getFeatureInfo(FeatureVector& f
 }
 
 void EqualFrequencyBinningImpl::createBins(FeatureInfo featureInfo, const FeatureVector& featureVector,
-                                           IBinningObserver& observer) const {
+                                           IBinningObserver<float32>& observer) const {
     uint32 numBins = featureInfo.numBins;
     //Defining length of the list, because we'll use it at least four times
     uint32 length = featureVector.getNumElements();
@@ -54,7 +54,7 @@ void EqualFrequencyBinningImpl::createBins(FeatureInfo featureInfo, const Featur
         //set last value to the current one for the next iteration
         previousValue = currentValue;
         //notify observer
-        observer.onBinUpdate(binIndex, iterator[i]);
+        observer.onBinUpdate(binIndex, iterator[i].index, currentValue);
     }
 }
 
@@ -101,7 +101,7 @@ IBinning::FeatureInfo EqualWidthBinningImpl::getFeatureInfo(FeatureVector& featu
 }
 
 void EqualWidthBinningImpl::createBins(FeatureInfo featureInfo, const FeatureVector& featureVector,
-                                       IBinningObserver& observer) const {
+                                       IBinningObserver<float32>& observer) const {
     uint32 numBins = featureInfo.numBins;
     float32 min = featureInfo.minValue;
     float32 max = featureInfo.maxValue;
@@ -120,6 +120,6 @@ void EqualWidthBinningImpl::createBins(FeatureInfo featureInfo, const FeatureVec
             binIndex = numBins - 1;
         }
         //notify observer
-        observer.onBinUpdate(binIndex, iterator[i]);
+        observer.onBinUpdate(binIndex, iterator[i].index, currentValue);
     }
 }

--- a/python/boomer/common/cpp/binning.h
+++ b/python/boomer/common/cpp/binning.h
@@ -11,7 +11,10 @@
 
 /**
  * Defines an interface to be implemented by classes that should be notified when values are assigned to bins.
+ *
+ * @tparam T The type of the values that are assigned to bins
  */
+template<class T>
 class IBinningObserver {
 
     public:
@@ -21,11 +24,11 @@ class IBinningObserver {
         /**
          * Notifies the observer that a value has been assigned to a certain bin.
          *
-         * @param binIndex  The index of the bin, the value is assigned to
-         * @param entry     A reference to a struct of type `FeatureVector::Entry` that contains the value and its index
-         *                  in the original array
+         * @param binIndex      The index of the bin, the value is assigned to
+         * @param originalIndex The original index of the value
+         * @param value         The value
          */
-        virtual void onBinUpdate(uint32 binIndex, const FeatureVector::Entry& entry) = 0;
+        virtual void onBinUpdate(uint32 binIndex, uint32 originalIndex, T value) = 0;
 
 };
 
@@ -71,7 +74,7 @@ class IBinning {
          *                      value is assigned to a bin
          */
         virtual void createBins(FeatureInfo featureInfo, const FeatureVector& featureVector,
-                                IBinningObserver& observer) const = 0;
+                                IBinningObserver<float32>& observer) const = 0;
 
 };
 
@@ -95,7 +98,7 @@ class EqualFrequencyBinningImpl : public IBinning {
         FeatureInfo getFeatureInfo(FeatureVector& featureVector) const override;
 
         void createBins(FeatureInfo featureInfo, const FeatureVector& featureVector,
-                        IBinningObserver& observer) const override;
+                        IBinningObserver<float32>& observer) const override;
 
 };
 
@@ -119,6 +122,6 @@ class EqualWidthBinningImpl : public IBinning {
         FeatureInfo getFeatureInfo(FeatureVector& featureVector) const override;
 
         void createBins(FeatureInfo featureInfo, const FeatureVector& featureVector,
-                        IBinningObserver& observer) const override;
+                        IBinningObserver<float32>& observer) const override;
 
 };

--- a/python/boomer/common/cpp/statistics.h
+++ b/python/boomer/common/cpp/statistics.h
@@ -221,7 +221,7 @@ class IStatistics : virtual public IHistogram {
          * Defines an interface for all classes that allow to build histograms by aggregating the statistics that
          * correspond to the same bins.
          */
-        class IHistogramBuilder : public IBinningObserver {
+        class IHistogramBuilder : public IBinningObserver<float32> {
 
             public:
 

--- a/python/boomer/common/cpp/thresholds_approximate.cpp
+++ b/python/boomer/common/cpp/thresholds_approximate.cpp
@@ -66,7 +66,7 @@ class ApproximateThresholds::ThresholdsSubset : public IThresholdsSubset {
          * are retrieved from the cache. Otherwise, they are computed by fetching the feature values from the feature
          * matrix and applying a binning method.
          */
-        class Callback : public IBinningObserver, public IRuleRefinementCallback<BinVector> {
+        class Callback : public IBinningObserver<float32>, public IRuleRefinementCallback<BinVector> {
 
             private:
 
@@ -110,25 +110,24 @@ class ApproximateThresholds::ThresholdsSubset : public IThresholdsSubset {
                     return std::make_unique<Result>(*binCacheEntry.histogramPtr, *binCacheEntry.binVectorPtr);
                 }
 
-                void onBinUpdate(uint32 binIndex, const FeatureVector::Entry& entry) override {
+                void onBinUpdate(uint32 binIndex, uint32 originalIndex, float32 value) override {
                     BinVector::iterator binIterator = currentBinVector_->begin();
                     binIterator[binIndex].numExamples += 1;
-                    float32 currentValue = entry.value;
 
-                    if (currentValue < binIterator[binIndex].minValue) {
-                        binIterator[binIndex].minValue = currentValue;
+                    if (value < binIterator[binIndex].minValue) {
+                        binIterator[binIndex].minValue = value;
                     }
 
-                    if (binIterator[binIndex].maxValue < currentValue) {
-                        binIterator[binIndex].maxValue = currentValue;
+                    if (binIterator[binIndex].maxValue < value) {
+                        binIterator[binIndex].maxValue = value;
                     }
 
                     IndexedValue<float32> example;
-                    example.index = entry.index;
-                    example.value = entry.value;
+                    example.index = originalIndex;
+                    example.value = value;
                     currentBinVector_->addExample(binIndex, example);
 
-                    histogramBuilderPtr_->onBinUpdate(binIndex, entry);
+                    histogramBuilderPtr_->onBinUpdate(binIndex, originalIndex, value);
                 }
 
         };


### PR DESCRIPTION
Hi @LukasEberle ,

ich habe eine kleine Änderung an dem Interface `IBinningObserver` vorgenommen so dass es jetzt unabhängig von Feature-Vektoren funktioniert und auch für andere Werte benutzt werden könnte (ich arbeite an einer Binning-Methode, die über Label angewandt wird und eventuell kann ich das so wiederverwenden).

Der Code kompiliert und die Experimente mit aktiviertem Feature-Binning laufen ohne Probleme durch.

Wenn die Änderungen für dich akzeptabel sind, dann kannst du sie mergen.
