### PR TITLE
Argument "freeMemory" to "setNumElements"-Funktion hinzufügen

### DIFF
--- a/python/boomer/common/cpp/data/vector_dense.cpp
+++ b/python/boomer/common/cpp/data/vector_dense.cpp
@@ -12,7 +12,7 @@ DenseVector<T>::DenseVector(uint32 numElements)
 template<class T>
 DenseVector<T>::DenseVector(uint32 numElements, bool init)
     : array_((T*) (init ? calloc(numElements, sizeof(T)) : malloc(numElements * sizeof(T)))),
-      numElements_(numElements) {
+      numElements_(numElements), maxCapacity_(numElements) {
 
 }
 
@@ -52,11 +52,18 @@ typename DenseVector<T>::const_iterator DenseVector<T>::cend() const {
 }
 
 template<class T>
-void DenseVector<T>::setNumElements(uint32 numElements) {
-    if (numElements != numElements_) {
-        numElements_ = numElements;
+void DenseVector<T>::setNumElements(uint32 numElements, bool freeMemory) {
+    if (numElements < maxCapacity_) {
+        if (freeMemory) {
+            array_ = (T*) realloc(array_, numElements * sizeof(T));
+            maxCapacity_ = numElements;
+        }
+    } else if (numElements > maxCapacity_) {
         array_ = (T*) realloc(array_, numElements * sizeof(T));
+        maxCapacity_ = numElements;
     }
+
+    numElements_ = numElements;
 }
 
 template class DenseVector<uint32>;

--- a/python/boomer/common/cpp/data/vector_dense.h
+++ b/python/boomer/common/cpp/data/vector_dense.h
@@ -20,6 +20,8 @@ class DenseVector {
 
         uint32 numElements_;
 
+        uint32 maxCapacity_;
+
     public:
 
         /**
@@ -77,9 +79,10 @@ class DenseVector {
         /**
          * Sets the number of elements in the vector.
          *
-         * @param numElements The number of elements to be set
+         * @param numElements   The number of elements to be set
+         * @param freeMemory    True, if unused memory should be freed, if possible, false otherwise
          */
-        void setNumElements(uint32 numElements);
+        void setNumElements(uint32 numElements, bool freeMemory);
 
         /**
          * Returns the value of the element at a specific position.

--- a/python/boomer/common/cpp/data/vector_sparse_array.cpp
+++ b/python/boomer/common/cpp/data/vector_sparse_array.cpp
@@ -5,7 +5,7 @@
 
 template<class T>
 SparseArrayVector<T>::SparseArrayVector(uint32 numElements)
-    : array_((Entry*) malloc(numElements * sizeof(Entry))), numElements_(numElements) {
+    : array_((Entry*) malloc(numElements * sizeof(Entry))), numElements_(numElements), maxCapacity_(numElements) {
 
 }
 
@@ -20,11 +20,18 @@ uint32 SparseArrayVector<T>::getNumElements() const {
 }
 
 template<class T>
-void SparseArrayVector<T>::setNumElements(uint32 numElements) {
-    if (numElements != numElements_) {
-        numElements_ = numElements;
+void SparseArrayVector<T>::setNumElements(uint32 numElements, bool freeMemory) {
+    if (numElements < maxCapacity_) {
+        if (freeMemory) {
+            array_ = (Entry*) realloc(array_, numElements * sizeof(Entry));
+            maxCapacity_ = numElements;
+        }
+    } else if (numElements > maxCapacity_) {
         array_ = (Entry*) realloc(array_, numElements * sizeof(Entry));
+        maxCapacity_ = numElements;
     }
+
+    numElements_ = numElements;
 }
 
 template<class T>

--- a/python/boomer/common/cpp/data/vector_sparse_array.h
+++ b/python/boomer/common/cpp/data/vector_sparse_array.h
@@ -27,6 +27,8 @@ class SparseArrayVector {
 
         uint32 numElements_;
 
+        uint32 maxCapacity_;
+
     public:
 
         /**
@@ -78,9 +80,10 @@ class SparseArrayVector {
         /**
          * Sets the number of elements in the vector.
          *
-         * @param numElements The number of elements to be set
+         * @param numElements   The number of elements to be set
+         * @param freeMemory    True, if unused memory should be freed if possible, false otherwise
          */
-        void setNumElements(uint32 numElements);
+        void setNumElements(uint32 numElements, bool freeMemory);
 
         /**
          * Sorts the elements in the vector in ascending order based on their values.

--- a/python/boomer/common/cpp/indices/index_vector_full.cpp
+++ b/python/boomer/common/cpp/indices/index_vector_full.cpp
@@ -38,7 +38,7 @@ uint32 FullIndexVector::getNumElements() const {
     return numElements_;
 }
 
-void FullIndexVector::setNumElements(uint32 numElements) {
+void FullIndexVector::setNumElements(uint32 numElements, bool freeMemory) {
     numElements_ = numElements;
 }
 

--- a/python/boomer/common/cpp/indices/index_vector_full.h
+++ b/python/boomer/common/cpp/indices/index_vector_full.h
@@ -64,9 +64,10 @@ class FullIndexVector : public IIndexVector {
         /**
          * Sets the number of indices.
          *
-         * @param numElements The number of indices to be set
+         * @param numElements   The number of indices to be set
+         * @param freeMemory    True, if unused memory should be freed, if possible, false otherwise
          */
-        void setNumElements(uint32 numElements);
+        void setNumElements(uint32 numElements, bool freeMemory);
 
         uint32 getNumElements() const override;
 

--- a/python/boomer/common/cpp/indices/index_vector_partial.cpp
+++ b/python/boomer/common/cpp/indices/index_vector_partial.cpp
@@ -18,8 +18,8 @@ uint32 PartialIndexVector::getNumElements() const {
     return vector_.getNumElements();
 }
 
-void PartialIndexVector::setNumElements(uint32 numElements) {
-    vector_.setNumElements(numElements);
+void PartialIndexVector::setNumElements(uint32 numElements, bool freeMemory) {
+    vector_.setNumElements(numElements, freeMemory);
 }
 
 uint32 PartialIndexVector::getIndex(uint32 pos) const {

--- a/python/boomer/common/cpp/indices/index_vector_partial.h
+++ b/python/boomer/common/cpp/indices/index_vector_partial.h
@@ -58,9 +58,10 @@ class PartialIndexVector : public IIndexVector {
         /**
          * Sets the number of indices.
          *
-         * @param numElements The number of indices to be set
+         * @param numElements   The number of indices to be set
+         * @param freeMemory    True, if unused memory should be freed, if possible, false otherwise
          */
-        void setNumElements(uint32 numElements);
+        void setNumElements(uint32 numElements, bool freeMemory);
 
         uint32 getNumElements() const override;
 

--- a/python/boomer/common/cpp/input/feature_matrix_csc.cpp
+++ b/python/boomer/common/cpp/input/feature_matrix_csc.cpp
@@ -42,5 +42,5 @@ void CscFeatureMatrix::fetchFeatureVector(uint32 featureIndex, std::unique_ptr<F
         }
     }
 
-    featureVectorPtr->setNumElements(i);
+    featureVectorPtr->setNumElements(i, true);
 }

--- a/python/boomer/common/cpp/input/feature_matrix_dense.cpp
+++ b/python/boomer/common/cpp/input/feature_matrix_dense.cpp
@@ -38,5 +38,5 @@ void DenseFeatureMatrix::fetchFeatureVector(uint32 featureIndex,
         }
     }
 
-    featureVectorPtr->setNumElements(i);
+    featureVectorPtr->setNumElements(i, true);
 }

--- a/python/boomer/common/cpp/predictions.cpp
+++ b/python/boomer/common/cpp/predictions.cpp
@@ -14,8 +14,8 @@ uint32 AbstractPrediction::getNumElements() const {
     return predictedScoreVector_.getNumElements();
 }
 
-void AbstractPrediction::setNumElements(uint32 numElements) {
-    predictedScoreVector_.setNumElements(numElements);
+void AbstractPrediction::setNumElements(uint32 numElements, bool freeMemory) {
+    predictedScoreVector_.setNumElements(numElements, freeMemory);
 }
 
 AbstractPrediction::score_iterator AbstractPrediction::scores_begin() {
@@ -52,9 +52,9 @@ FullPrediction::index_const_iterator FullPrediction::indices_cend() const {
     return indexVector_.cend();
 }
 
-void FullPrediction::setNumElements(uint32 numElements) {
-    AbstractPrediction::setNumElements(numElements);
-    indexVector_.setNumElements(numElements);
+void FullPrediction::setNumElements(uint32 numElements, bool freeMemory) {
+    AbstractPrediction::setNumElements(numElements, freeMemory);
+    indexVector_.setNumElements(numElements, freeMemory);
 }
 
 bool FullPrediction::isPartial() const {
@@ -103,9 +103,9 @@ PartialPrediction::index_const_iterator PartialPrediction::indices_cend() const 
     return indexVector_.cend();
 }
 
-void PartialPrediction::setNumElements(uint32 numElements) {
-    AbstractPrediction::setNumElements(numElements);
-    indexVector_.setNumElements(numElements);
+void PartialPrediction::setNumElements(uint32 numElements, bool freeMemory) {
+    AbstractPrediction::setNumElements(numElements, freeMemory);
+    indexVector_.setNumElements(numElements, freeMemory);
 }
 
 bool PartialPrediction::isPartial() const {

--- a/python/boomer/common/cpp/predictions.h
+++ b/python/boomer/common/cpp/predictions.h
@@ -73,9 +73,10 @@ class AbstractPrediction : public IIndexVector {
         /**
          * Sets the number of labels for which the rule predict.
          *
-         * @param The number of labels to be set
+         * @param numElements   The number of labels to be set
+         * @param freeMemory    True, if unused memory should be freed if possible, false otherwise
          */
-        virtual void setNumElements(uint32 numElements);
+        virtual void setNumElements(uint32 numElements, bool freeMemory);
 
         uint32 getNumElements() const override;
 
@@ -133,7 +134,7 @@ class FullPrediction : public AbstractEvaluatedPrediction {
          */
         index_const_iterator indices_cend() const;
 
-        void setNumElements(uint32 numElements) override;
+        void setNumElements(uint32 numElements, bool freeMemory) override;
 
         bool isPartial() const override;
 
@@ -198,7 +199,7 @@ class PartialPrediction : public AbstractEvaluatedPrediction {
          */
         index_const_iterator indices_cend() const;
 
-        void setNumElements(uint32 numElements) override;
+        void setNumElements(uint32 numElements, bool freeMemory) override;
 
         bool isPartial() const override;
 

--- a/python/boomer/common/cpp/thresholds_approximate.cpp
+++ b/python/boomer/common/cpp/thresholds_approximate.cpp
@@ -50,7 +50,7 @@ static inline void filterCurrentVector(BinVector& vector, FilteredCacheEntry<Bin
         i++;
     }
 
-    filteredVector->setNumElements(numElements);
+    filteredVector->setNumElements(numElements, true);
     cacheEntry.numConditions = numConditions;
 }
 

--- a/python/boomer/common/cpp/thresholds_exact.cpp
+++ b/python/boomer/common/cpp/thresholds_exact.cpp
@@ -191,7 +191,7 @@ static inline void filterCurrentVector(const FeatureVector& vector, FilteredCach
         }
     }
 
-    filteredVector->setNumElements(numElements);
+    filteredVector->setNumElements(numElements, true);
     cacheEntry.numConditions = numConditions;
 }
 
@@ -242,7 +242,7 @@ static inline void filterAnyVector(const FeatureVector& vector, FilteredCacheEnt
         }
     }
 
-    filteredVector->setNumElements(i);
+    filteredVector->setNumElements(i, true);
     cacheEntry.numConditions = numConditions;
 }
 

--- a/python/boomer/seco/cpp/head_refinement/head_refinement_partial.cpp
+++ b/python/boomer/seco/cpp/head_refinement/head_refinement_partial.cpp
@@ -95,7 +95,7 @@ class PartialHeadRefinement : public IHeadRefinement {
                 if (headPtr_.get() == nullptr) {
                     headPtr_ = std::make_unique<PartialPrediction>(bestNumPredictions);
                 } else if (headPtr_->getNumElements() != bestNumPredictions) {
-                    headPtr_->setNumElements(bestNumPredictions);
+                    headPtr_->setNumElements(bestNumPredictions, false);
                 }
 
                 typename T::const_iterator indexIterator = labelIndices_.cbegin();


### PR DESCRIPTION
Fügt ein `bool`-Argument `freeMemory` zu den Funktionen `setNumElements` hinzu. Die erlaubt es anzugeben ob nicht mehr verwendeter Speicher freigegeben werden soll wenn eine Array-basierte Datenstruktur, z.B. `DenseVector` oder `SparseArrayVector`, verkleinert wird. Im Falle von Datenstrukturen, deren Größe häufig geändert wird, empfielt es sich unverwendeten Speicher nicht freizugeben, da ansonsten bei der nächsten Vergrößerung wieder neuer Speicher allokiert werden muss (und das Array eventuell sogar kopiert werden muss).