### PR TITLE
Refactoring DSYSV-Methode

### DIFF
--- a/python/boomer/boosting/cpp/math/lapack.cpp
+++ b/python/boomer/boosting/cpp/math/lapack.cpp
@@ -34,28 +34,7 @@ int Lapack::queryDsysvLworkParameter(float64* tmpArray1, float64* output, int n)
     return (int) worksize;
 }
 
-void Lapack::dsysv(const float64* coefficients, const float64* invertedOrdinates, float64* tmpArray1, int* tmpArray2,
-                   double* tmpArray3, float64* output, int n, int lwork, float64 l2RegularizationWeight) {
-    // Copy the values in the arrays `invertedOrdinates` and `coefficients` to the arrays `output` and `tmpArray1`,
-    // respectively...
-    int i = 0;
-
-    for (int c = 0; c < n; c++) {
-        output[c] = -invertedOrdinates[c];
-        int offset = c * n;
-
-        for (int r = 0; r < c + 1; r++) {
-            float64 tmp = coefficients[i];
-
-            if (r == c) {
-                tmp += l2RegularizationWeight;
-            }
-
-            tmpArray1[offset + r] = tmp;
-            i++;
-        }
-    }
-
+void Lapack::dsysv(float64* tmpArray1, int* tmpArray2, double* tmpArray3, float64* output, int n, int lwork) {
     // "U" if the upper-right triangle of A should be used, "L" if the lower-left triangle should be used
     char* uplo = "U";
     // The number of right-hand sides, i.e, the number of columns of the matrix B

--- a/python/boomer/boosting/cpp/math/lapack.h
+++ b/python/boomer/boosting/cpp/math/lapack.h
@@ -67,34 +67,23 @@ namespace boosting {
              * unspecified elements are omitted. This function will implicitly convert the given array into a matrix
              * that is suited for DSYSV.
              *
-             * Optionally, this function allows to specify a weight to be used for L2 regularization. The given weight
-             * is added to each element on the diagonal of the matrix of coefficients A.
-             *
-             * @param coefficients              An array of type `float64`, shape `n * (n + 1) / 2)`, representing the
-             *                                  coefficients
-             * @param invertedOrdinates         An array of type `float64`, shape `(n)`, representing the inverted
-             *                                  ordinates, i.e., the ordinates multiplied by -1. The sign of the
-             *                                  elements in this array will be inverted to when creating the matrix B
-             * @param tmpArray1                 A pointer to an array of type `float64`, shape `(n, n)` that will be
-             *                                  used to temporarily store values computed by the DSYSV routine. May
-             *                                  contain arbitrary values
+             * @param tmpArray1                 A pointer to an array of type `float64`, shape `(n, n)` that stores the
+             *                                  coefficients in the matrix A. It will be used to temporarily store
+             *                                  values computed by the DSYSV routine
              * @param tmpArray2                 A pointer to an array of type `int`, shape `(n)` that will be used to
              *                                  temporarily store values computed by the DSYSV routine. May contain
              *                                  arbitrary values
              * @param tmpArray3                 A pointer to an array of type `double`, shape `(lwork)` that will be
              *                                  used to temporarily store values computed by the DSYSV routine. May
              *                                  contain arbitrary values
-             * @param output                    A pointer to an array of type `float64`, shape `(n)`, the solution of
-             *                                  the system of linear equations should be written to. May contain
-             *                                  arbitrary values
+             * @param output                    A pointer to an array of type `float64`, shape `(n)` that stores the
+             *                                  ordinates in the matrix A. The solution of the system of linear
+             *                                  equations will be written to this array
              * @param n                         The number of equations
              * @param lwork                     The value for the parameter "lwork" to be used by the DSYSV routine.
              *                                  Must have been determined using the function `queryDsysvLworkParameter`
-             * @param l2RegularizationWeight    A scalar of type `float64`, representing the weight of the L2
-             *                                  regularization
              */
-            void dsysv(const float64* coefficients, const float64* invertedOrdinates, float64* tmpArray1, int* tmpArray2,
-                       double* tmpArray3, float64* output, int n, int lwork, float64 l2RegularizationWeight);
+            void dsysv(float64* tmpArray1, int* tmpArray2, double* tmpArray3, float64* output, int n, int lwork);
 
     };
 

--- a/python/boomer/boosting/cpp/rule_evaluation/rule_evaluation_example_wise_regularized.cpp
+++ b/python/boomer/boosting/cpp/rule_evaluation/rule_evaluation_example_wise_regularized.cpp
@@ -6,6 +6,59 @@ using namespace boosting;
 
 
 /**
+ * Copies the Hessians that are stored by a `DenseExampleWiseStatisticVector` to a coefficient matrix that may be passed
+ * to LAPACK's DSYSV routine.
+ *
+ * @param statisticVector   A reference to an object of type `DenseExampleWiseStatisticVector` that stores the Hessians
+ * @param output            A pointer to an array of type `float64`, shape `(n, n)`, the Hessians should be copied to
+ * @param n                 The number of rows and columns in the coefficient matrix
+ */
+static inline void copyCoefficients(const DenseExampleWiseStatisticVector& statisticVector, float64* output, uint32 n) {
+    DenseExampleWiseStatisticVector::hessian_const_iterator hessianIterator = statisticVector.hessians_cbegin();
+
+    for (uint32 c = 0; c < n; c++) {
+        uint32 offset = c * n;
+
+        for (uint32 r = 0; r < c + 1; r++) {
+            float64 hessian = *hessianIterator;
+            output[offset + r] = hessian;
+            hessianIterator++;
+        }
+    }
+}
+
+/**
+ * Adds a specific L2 regularization weight to the diagonal of a coefficient matrix.
+ *
+ * @param output                    A pointer to an array of type `float64`, shape `(n, n)` that stores the coefficients
+ * @param n                         The number of rows and columns in the coefficient matrix
+ * @param l2RegularizationWeight    The L2 regularization weight to be added
+ */
+static inline void addRegularizationWeight(float64* output, uint32 n, float64 l2RegularizationWeight) {
+    for (uint32 i = 0; i < n; i++) {
+        output[(i * n) + i] += l2RegularizationWeight;
+    }
+}
+
+/**
+ * Copies the gradients that are stored by a `DenseExampleWiseStatisticVector` to a vector of ordinates that may be
+ * passed to LAPACK's DSYSV routine.
+ *
+ * @param statisticVector   A reference to an object of type `DenseExampleWiseStatisticVector` that stores the gradients
+ * @param output            A pointer to an array of type `float64`, shape `(n)`, the gradients should be copied to
+ * @param n                 The number of ordinates
+ */
+static inline void copyOrdinates(const DenseExampleWiseStatisticVector& statisticVector, float64* output, uint32 n) {
+    DenseExampleWiseStatisticVector::gradient_const_iterator gradientIterator = statisticVector.gradients_cbegin();
+
+    for (uint32 i = 0; i < n; i++) {
+        float64 gradient = *gradientIterator;
+        output[i] = -gradient;
+        gradientIterator++;
+    }
+}
+
+/**
  * Allows to calculate the predictions of rules, as well as corresponding quality scores, based on the gradients and
  * Hessians that have been calculated according to a loss function that is applied example wise using L2 regularization.
  *
@@ -58,18 +111,20 @@ class RegularizedExampleWiseRuleEvaluation : public AbstractExampleWiseRuleEvalu
                                             DenseScoreVector<T>& scoreVector, int dsysvLwork, float64* dsysvTmpArray1,
                                             int* dsysvTmpArray2, double* dsysvTmpArray3,
                                             float64* dspmvTmpArray) override {
-            DenseExampleWiseStatisticVector::gradient_iterator gradientIterator = statisticVector.gradients_begin();
-            DenseExampleWiseStatisticVector::hessian_iterator hessianIterator = statisticVector.hessians_begin();
             uint32 numPredictions = scoreVector.getNumElements();
             typename DenseScoreVector<T>::score_iterator scoreIterator = scoreVector.scores_begin();
 
             // Calculate the scores to be predicted for the individual labels by solving a system of linear equations...
-            this->lapackPtr_->dsysv(hessianIterator, gradientIterator, dsysvTmpArray1, dsysvTmpArray2, dsysvTmpArray3,
-                                    scoreIterator, numPredictions, dsysvLwork, l2RegularizationWeight_);
+            copyCoefficients(statisticVector, dsysvTmpArray1, numPredictions);
+            addRegularizationWeight(dsysvTmpArray1, numPredictions, l2RegularizationWeight_);
+            copyOrdinates(statisticVector, scoreIterator, numPredictions);
+            this->lapackPtr_->dsysv(dsysvTmpArray1, dsysvTmpArray2, dsysvTmpArray3, scoreIterator, numPredictions,
+                                    dsysvLwork);
 
             // Calculate overall quality score as (gradients * scores) + (0.5 * (scores * (hessians * scores)))...
-            float64 overallQualityScore = blasPtr_->ddot(scoreIterator, gradientIterator, numPredictions);
-            blasPtr_->dspmv(hessianIterator, scoreIterator, dspmvTmpArray, numPredictions);
+            float64 overallQualityScore = blasPtr_->ddot(scoreIterator, statisticVector.gradients_begin(),
+                                                         numPredictions);
+            blasPtr_->dspmv(statisticVector.hessians_begin(), scoreIterator, dspmvTmpArray, numPredictions);
             overallQualityScore += 0.5 * blasPtr_->ddot(scoreIterator, dspmvTmpArray, numPredictions);
 
             // Add the L2 regularization term to the overall quality score...


### PR DESCRIPTION
Ändert die Signatur der Methode, die zum Aufruf von LAPACKs DSYSV-Routine verwendet wird. Die Methode übernimmt jetzt nicht mehr die Aufgabe, die übergebenen Werte in temporäre Arrays zu kopieren. Dies muss vom Aufrufer übernommen werden.