### PR TITLE
Refactoring: Histogramaufbau

### DIFF
--- a/python/boomer/common/cpp/thresholds/thresholds_approximate.cpp
+++ b/python/boomer/common/cpp/thresholds/thresholds_approximate.cpp
@@ -205,8 +205,8 @@ class ApproximateThresholds : public AbstractThresholds {
                                 if (binVector == nullptr) {
                                     // Fetch feature vector...
                                     std::unique_ptr<FeatureVector> featureVectorPtr;
-                                    thresholdsSubset_.thresholds_.featureMatrixPtr_->fetchFeatureVector(featureIndex_,
-                                                                                                    featureVectorPtr);
+                                    thresholdsSubset_.thresholds_.featureMatrixPtr_->fetchFeatureVector(
+                                        featureIndex_, featureVectorPtr);
 
                                     // Apply binning method...
                                     IFeatureBinning::FeatureInfo featureInfo =


### PR DESCRIPTION
Da wir mit Pull-Request #335 nicht so richtig weiterkommen, habe ich mir gedacht dass es vielleicht eine gute Idee wäre, das was dort bereits funktioniert schon einmal zu übernehmen. Die Code in diesem Pull-Request macht genau das selbe wie der aktuelle development-Branch, aber ich habe ihn etwas umgebaut:

* Es gibt eine neue Funktion `buildHistogram`, die zum Erstellen von Histogrammen genutzt werden kann. Was innerhalb der Funktion getan wird, habe ich aus Pull-Request #335 übernommen.

*  Die neue Funktion wird jetzt verwendet um ein Histogram initial zu erstellen. Das funktioniert problemlos, was wohl bedeutet dass zumindest dieser Teil des Codes aus #335 korrekt funktioniert, auch wenn wir hier zuerst den Fehler vermutet haben. Später können wir die Funktion dann auch verwenden um die Histogramme bei Bedarf neu aufzubauen.

Ich habe den Code zusammen mit der Equal-Width- und der Equal-Frequency-Methode getestet. Beide Fälle laufen ohne Absturz durch, egal ob man nur eine Regel oder beliebig viele (getestet mit 1000) lernt.