### PR TITLE
Bugfix in Funktion "filterAnyVector"

### DIFF
--- a/python/boomer/common/cpp/thresholds/thresholds_approximate.cpp
+++ b/python/boomer/common/cpp/thresholds/thresholds_approximate.cpp
@@ -156,7 +156,6 @@ static inline void filterAnyVector(const BinVector& vector, FilteredBinCacheEntr
                     it++;
                 }
             }
-
         }
 
         if (!wasEmpty) {


### PR DESCRIPTION
Mir ist in der Funktion `filterAnyVector` (in `thresholds_approximate.cpp`) noch etwas aufgefallen, was meiner Meinung ziemlich sicher ein Bug ist. Dort wurde die `removeFromBin`-Methode, um die Werte im Histogram anzupassen, bisher nur aufgerufen falls der originale und zu filternde Vektor die selben sind. Diese Methode sollte aber immer aufgerufen wenn ein Beispiel nicht mehr abgedeckt wird und sollte absolut unabhängig von den übergebenen Vektoren sein.