### PR TITLE
Overflows verhindern wenn Thresholds berechnet werden

### DIFF
--- a/python/boomer/common/cpp/rule_refinement/rule_refinement_approximate.cpp
+++ b/python/boomer/common/cpp/rule_refinement/rule_refinement_approximate.cpp
@@ -1,4 +1,5 @@
 #include "rule_refinement_approximate.h"
+#include "rule_refinement_common.h"
 
 
 template<class T>
@@ -60,7 +61,7 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
                 if (head != nullptr) {
                     bestHead = head;
                     refinementPtr->comparator = LEQ;
-                    refinementPtr->threshold = (previousValue + currentValue) / 2.0;
+                    refinementPtr->threshold = calculateThreshold(previousValue, currentValue);
                     refinementPtr->end = r;
                     refinementPtr->previous = previousR;
                     refinementPtr->coveredWeights = numCoveredExamples;
@@ -72,7 +73,7 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
                 if (head != nullptr) {
                     bestHead = head;
                     refinementPtr->comparator = GR;
-                    refinementPtr->threshold = (previousValue + currentValue) / 2.0;
+                    refinementPtr->threshold = calculateThreshold(previousValue, currentValue);
                     refinementPtr->end = r;
                     refinementPtr->previous = previousR;
                     refinementPtr->coveredWeights = numCoveredExamples;

--- a/python/boomer/common/cpp/rule_refinement/rule_refinement_common.h
+++ b/python/boomer/common/cpp/rule_refinement/rule_refinement_common.h
@@ -1,0 +1,21 @@
+/**
+ * @author Michael Rapp (mrapp@ke.tu-darmstadt.de)
+ */
+#pragma once
+
+#include "../data/types.h"
+
+
+/**
+ * Calculates a threshold as the average of two adjacent feature values `small` and `large`, where `small < large`.
+ *
+ * The threshold is calculated as `small + ((large - small) * 0.5`, instead of `(small + large) / 2`, in order to avoid
+ * overflows.
+ *
+ * @param small The smaller of both feature values
+ * @param large The larger of both feature values
+ * @return      The threshold that has been calculated
+ */
+static inline float32 calculateThreshold(float32 small, float32 large) {
+    return small + ((large - small) * 0.5);
+}

--- a/python/boomer/common/cpp/rule_refinement/rule_refinement_exact.cpp
+++ b/python/boomer/common/cpp/rule_refinement/rule_refinement_exact.cpp
@@ -1,5 +1,5 @@
 #include "rule_refinement_exact.h"
-#include <cmath>
+#include "rule_refinement_common.h"
 
 
 template<class T>
@@ -105,7 +105,7 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                             refinementPtr->threshold = previousThreshold;
                         } else {
                             refinementPtr->comparator = LEQ;
-                            refinementPtr->threshold = (previousThreshold + currentThreshold) / 2.0;
+                            refinementPtr->threshold = calculateThreshold(previousThreshold, currentThreshold);
                         }
                     }
 
@@ -127,7 +127,7 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                             refinementPtr->threshold = previousThreshold;
                         } else {
                             refinementPtr->comparator = GR;
-                            refinementPtr->threshold = (previousThreshold + currentThreshold) / 2.0;
+                            refinementPtr->threshold = calculateThreshold(previousThreshold, currentThreshold);
                         }
                     }
 
@@ -249,7 +249,7 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                             refinementPtr->threshold = previousThreshold;
                         } else {
                             refinementPtr->comparator = GR;
-                            refinementPtr->threshold = (previousThreshold + currentThreshold) / 2.0;
+                            refinementPtr->threshold = calculateThreshold(currentThreshold, previousThreshold);
                         }
                     }
 
@@ -271,7 +271,7 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                             refinementPtr->threshold = previousThreshold;
                         } else {
                             refinementPtr->comparator = LEQ;
-                            refinementPtr->threshold = (previousThreshold + currentThreshold) / 2.0;
+                            refinementPtr->threshold = calculateThreshold(currentThreshold, previousThreshold);
                         }
                     }
 
@@ -369,7 +369,7 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                 refinementPtr->previous = previousR;
                 refinementPtr->coveredWeights = accumulatedSumOfWeights;
                 refinementPtr->comparator = GR;
-                refinementPtr->threshold = previousThreshold / 2.0;
+                refinementPtr->threshold = previousThreshold * 0.5;
             }
         }
 
@@ -394,7 +394,7 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                 refinementPtr->previous = previousR;
                 refinementPtr->coveredWeights = (totalSumOfWeights_ - accumulatedSumOfWeights);
                 refinementPtr->comparator = LEQ;
-                refinementPtr->threshold = previousThreshold / 2.0;
+                refinementPtr->threshold = previousThreshold * 0.5;
             }
         }
     }
@@ -422,11 +422,10 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
             if (totalAccumulatedSumOfWeights < totalSumOfWeights_) {
                 // If the condition separates an example with feature value < 0 from an (sparse) example with feature
                 // value == 0
-                refinementPtr->threshold = previousThresholdNegative / 2.0;
+                refinementPtr->threshold = previousThresholdNegative * 0.5;
             } else {
                 // If the condition separates an example with feature value < 0 from an example with feature value > 0
-                refinementPtr->threshold =
-                    previousThresholdNegative + (std::fabs(previousThreshold - previousThresholdNegative) / 2.0);
+                refinementPtr->threshold = calculateThreshold(previousThresholdNegative, previousThreshold);
             }
         }
 
@@ -446,11 +445,10 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
             if (totalAccumulatedSumOfWeights < totalSumOfWeights_) {
                 // If the condition separates an example with feature value < 0 from an (sparse) example with feature
                 // value == 0
-                refinementPtr->threshold = previousThresholdNegative / 2.0;
+                refinementPtr->threshold = previousThresholdNegative * 0.5;
             } else {
                 // If the condition separates an example with feature value < 0 from an example with feature value > 0
-                refinementPtr->threshold =
-                    previousThresholdNegative + (std::fabs(previousThreshold - previousThresholdNegative) / 2.0);
+                refinementPtr->threshold = calculateThreshold(previousThresholdNegative, previousThreshold);
             }
         }
     }


### PR DESCRIPTION
Fügt eine neue Funktion `calculateThreshold` zu der Datei `rule_refinement_common.h` hinzu. Diese Funktion erlaubt es, basierend auf benachbarten Featurewerten, von potentiellen Bedingungen zu verwendende Thresholds zu berechnen. Die Berechnung erfolgt auf eine Art und Weise, die die Wahrscheinlichkeit von Overflows minimiert.