### PR TITLE
Bugfix TimeStoppingCriterion

### DIFF
--- a/python/boomer/common/cpp/stopping/stopping_criterion_time.cpp
+++ b/python/boomer/common/cpp/stopping/stopping_criterion_time.cpp
@@ -2,18 +2,20 @@
 
 
 TimeStoppingCriterion::TimeStoppingCriterion(uint32 timeLimit)
-    : timeLimit_(timeLimit), startTime_(nullptr) {
+    : timeLimit_(std::chrono::duration_cast<timer_unit>(std::chrono::seconds(timeLimit))), startTime_(timer::now()),
+      timerStarted_(false) {
 
 }
 
 bool TimeStoppingCriterion::shouldContinue(const IStatistics& statistics, uint32 numRules) {
-    if (startTime_ == nullptr) {
-        time(startTime_);
-        return true;
+    if (timerStarted_) {
+        auto currentTime = timer::now();
+        auto duration = std::chrono::duration_cast<timer_unit>(currentTime - startTime_);
+        return duration < timeLimit_;
     } else {
-        time_t currentTime;
-        time(&currentTime);
-        return difftime(currentTime, *startTime_) < timeLimit_;
+        startTime_ = timer::now();
+        timerStarted_ = true;
+        return true;
     }
 
 }

--- a/python/boomer/common/cpp/stopping/stopping_criterion_time.h
+++ b/python/boomer/common/cpp/stopping/stopping_criterion_time.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "stopping_criterion.h"
-#include <ctime>
+#include <chrono>
 
 
 /**
@@ -14,9 +14,15 @@ class TimeStoppingCriterion final : public IStoppingCriterion {
 
     private:
 
-        uint32 timeLimit_;
+        typedef std::chrono::steady_clock timer;
 
-        time_t* startTime_;
+        typedef std::chrono::seconds timer_unit;
+
+        timer_unit timeLimit_;
+
+        std::chrono::time_point<timer> startTime_;
+
+        bool timerStarted_;
 
     public:
 


### PR DESCRIPTION
Die Klasse `TimeStoppingCriterion` funktioniert mit dem aktuellen Stand aus dem development-Branch nicht. D.h., der Parameter `--time-limit` hat keinerlei Effekt und das angegebene Zeitlimit wird nicht eingehalten. Dieser Pull-Request enthält eine neue Implementierung der Klasse `TimeStoppingCriterion` unter Verwendung der C++-Chrono-Bibliothek, die dieses Problem behebt.

@LukasEberle Wenn du für deine Experimente ein Zeitlimit, unabhängig von der maximalen Laufzeit der Slurm-Jobs, angeben willst, dann solltest du diesen Fix übernehmen. Indem du das Zeitlimit des Algorithmus niedriger als die maximale Laufzeit des Jobs ansetzt, wird das Training kontrolliert abgebrochen noch bevor der Job gekillt wird, was es erlaubt Evaluationsergebnisse für das Modell, das bis dahin gelernt wurde, zu speichern. Anderenfalls werden keinerlei Ergebnisse gespeichert, weil der Prozess vom System abgeschossen wird.