### PR TITLE
Sampling aus vordefinierten Indizes

### DIFF
--- a/python/boomer/common/cpp/sampling/feature_sampling_random.cpp
+++ b/python/boomer/common/cpp/sampling/feature_sampling_random.cpp
@@ -1,5 +1,6 @@
 #include "feature_sampling_random.h"
 #include "index_sampling.h"
+#include "../indices/index_iterator.h"
 #include <cmath>
 
 
@@ -17,5 +18,5 @@ std::unique_ptr<IIndexVector> RandomFeatureSubsetSelection::subSample(uint32 num
             numSamples = (uint32) (log2(numFeatures - 1) + 1);
     }
 
-    return sampleIndicesWithoutReplacement(numFeatures, numSamples, rng);
+    return sampleIndicesWithoutReplacement<IndexIterator>(IndexIterator(numFeatures), numFeatures, numSamples, rng);
 }

--- a/python/boomer/common/cpp/sampling/index_sampling.h
+++ b/python/boomer/common/cpp/sampling/index_sampling.h
@@ -11,29 +11,34 @@
  * Randomly selects `numSamples` out of `numTotal` indices without replacement by using a set to keep track of the
  * indices that have already been selected. This method is suitable if `numSamples` is much smaller than `numTotal`
  *
+ * @tparam T            The type of the iterator that provides random access to the available indices
+ * @param iterator      An iterator that provides random access to the available indices
  * @param numTotal      The total number of available indices
  * @param numSamples    The number of indices to be sampled
  * @param rng           A reference to an object of type `RNG`, implementing the random number generator to be used
  * @return              An unique pointer to an object of type `IIndexVector` that provides access to the indices that
  *                      are contained in the sub-sample
  */
-static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaTrackingSelection(uint32 numTotal,
+template<class T>
+static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaTrackingSelection(T iterator,
+                                                                                                uint32 numTotal,
                                                                                                 uint32 numSamples,
                                                                                                 RNG& rng) {
     std::unique_ptr<PartialIndexVector> indexVectorPtr = std::make_unique<PartialIndexVector>(numSamples);
-    PartialIndexVector::iterator iterator = indexVectorPtr->begin();
+    PartialIndexVector::iterator sampleIterator = indexVectorPtr->begin();
     std::unordered_set<uint32> selectedIndices;
 
     for (uint32 i = 0; i < numSamples; i++) {
         bool shouldContinue = true;
-        uint32 randomIndex;
+        uint32 sampledIndex;
 
         while (shouldContinue) {
-            randomIndex = rng.random(0, numTotal);
-            shouldContinue = !selectedIndices.insert(randomIndex).second;
+            uint32 randomIndex = rng.random(0, numTotal);
+            sampledIndex = iterator[randomIndex];
+            shouldContinue = !selectedIndices.insert(sampledIndex).second;
         }
 
-        iterator[i] = randomIndex;
+        sampleIterator[i] = sampledIndex;
     }
 
     return indexVectorPtr;;
@@ -43,27 +48,31 @@ static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaTr
  * Randomly selects `numSamples` out of `numTotal` indices without replacement using a reservoir sampling algorithm.
  * This method is suitable if `numSamples` is almost as large as `numTotal`.
  *
+ * @tparam T            The type of the iterator that provides random access to the available indices
+ * @param iterator      An iterator that provides random access to the available indices
  * @param numTotal      The total number of available indices
  * @param numSamples    The number of indices to be sampled
  * @param rng           A reference to an object of type `RNG`, implementing the random number generator to be used
  * @return              A pointer to an object of type `IIndexVector` that provides access to the indices that are
  *                      contained in the sub-sample
  */
-static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaReservoirSampling(uint32 numTotal,
+template<class T>
+static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaReservoirSampling(T iterator,
+                                                                                                uint32 numTotal,
                                                                                                 uint32 numSamples,
                                                                                                 RNG& rng) {
     std::unique_ptr<PartialIndexVector> indexVectorPtr = std::make_unique<PartialIndexVector>(numSamples);
-    PartialIndexVector::iterator iterator = indexVectorPtr->begin();
+    PartialIndexVector::iterator sampleIterator = indexVectorPtr->begin();
 
     for (uint32 i = 0; i < numSamples; i++) {
-        iterator[i] = i;
+        sampleIterator[i] = iterator[i];
     }
 
     for (uint32 i = numSamples; i < numTotal; i++) {
         uint32 randomIndex = rng.random(0, i + 1);
 
         if (randomIndex < numSamples) {
-            iterator[randomIndex] = i;
+            sampleIterator[randomIndex] = iterator[i];
         }
     }
 
@@ -74,43 +83,47 @@ static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaRe
  * Randomly selects `numSamples` out of `numTotal` indices without replacement by first generating a random permutation
  * of the available indices using the Fisher-Yates shuffle and then returning the first `numSamples` indices.
  *
+ * @tparam T            The type of the iterator that provides random access to the available indices
+ * @param iterator      An iterator that provides random access to the available indices
  * @param numTotal      The total number of available indices
  * @param numSamples    The number of indices to be sampled
  * @param rng           A reference to an object of type `RNG`, implementing the random number generator to be used
  * @return              An unique pointer to an object of type `IIndexVector` that provides access to the indices that
  *                      are contained in the sub-sample
  */
-static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaRandomPermutation(uint32 numTotal,
+template<class T>
+static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaRandomPermutation(T iterator,
+                                                                                                uint32 numTotal,
                                                                                                 uint32 numSamples,
                                                                                                 RNG& rng) {
     std::unique_ptr<PartialIndexVector> indexVectorPtr = std::make_unique<PartialIndexVector>(numSamples);
-    PartialIndexVector::iterator iterator = indexVectorPtr->begin();
+    PartialIndexVector::iterator sampleIterator = indexVectorPtr->begin();
     uint32 unusedIndices[numTotal - numSamples];
 
     for (uint32 i = 0; i < numSamples; i++) {
-        iterator[i] = i;
+        sampleIterator[i] = iterator[i];
     }
 
     for (uint32 i = numSamples; i < numTotal; i++) {
-        unusedIndices[i - numSamples] = i;
+        unusedIndices[i - numSamples] = iterator[i];
     }
 
     for (uint32 i = 0; i < numTotal - 2; i++) {
         // Swap elements at index i and at a randomly selected index...
         uint32 randomIndex = rng.random(i, numTotal);
-        uint32 tmp1 = i < numSamples ? iterator[i] : unusedIndices[i - numSamples];
+        uint32 tmp1 = i < numSamples ? sampleIterator[i] : unusedIndices[i - numSamples];
         uint32 tmp2;
 
         if (randomIndex < numSamples) {
-            tmp2 = iterator[randomIndex];
-            iterator[randomIndex] = tmp1;
+            tmp2 = sampleIterator[randomIndex];
+            sampleIterator[randomIndex] = tmp1;
         } else {
             tmp2 = unusedIndices[randomIndex - numSamples];
             unusedIndices[randomIndex - numSamples] = tmp1;
         }
 
         if (i < numSamples) {
-            iterator[i] = tmp2;
+            sampleIterator[i] = tmp2;
         } else {
             unusedIndices[i - numSamples] = tmp2;
         }
@@ -123,25 +136,28 @@ static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaRa
  * Randomly selects `numSamples` out of `numTotal` indices without replacement. The method that is used internally is
  * chosen automatically, depending on the ratio `numSamples / numTotal`.
  *
+ * @tparam T            The type of the iterator that provides random access to the available indices
+ * @param iterator      An iterator that provides random access to the available indices
  * @param numTotal      The total number of available indices
  * @param numSamples    The number of indices to be sampled
  * @param rng           A reference to an object of type `RNG`, implementing the random number generator to be used
  * @return              An unique pointer to an object of type `IIndexVector` that provides access to the indices that
  *                      are contained in the sub-sample
  */
-static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacement(uint32 numTotal, uint32 numSamples,
-                                                                            RNG& rng) {
+template<class T>
+static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacement(T iterator, uint32 numTotal,
+                                                                            uint32 numSamples, RNG& rng) {
     float64 ratio = numTotal > 0 ? ((float64) numSamples) / ((float64) numTotal) : 1;
 
     // The thresholds for choosing a suitable method are based on empirical experiments
     if (ratio < 0.06) {
         // For very small ratios use tracking selection
-        return sampleIndicesWithoutReplacementViaTrackingSelection(numTotal, numSamples, rng);
+        return sampleIndicesWithoutReplacementViaTrackingSelection(iterator, numTotal, numSamples, rng);
     } else if (ratio > 0.5) {
         // For large ratios use reservoir sampling
-        return sampleIndicesWithoutReplacementViaReservoirSampling(numTotal, numSamples, rng);
+        return sampleIndicesWithoutReplacementViaReservoirSampling(iterator, numTotal, numSamples, rng);
     } else {
         // Otherwise, use random permutation as the default method
-        return sampleIndicesWithoutReplacementViaRandomPermutation(numTotal, numSamples, rng);
+        return sampleIndicesWithoutReplacementViaRandomPermutation(iterator, numTotal, numSamples, rng);
     }
 }

--- a/python/boomer/common/cpp/sampling/label_sampling_random.cpp
+++ b/python/boomer/common/cpp/sampling/label_sampling_random.cpp
@@ -1,5 +1,6 @@
 #include "label_sampling_random.h"
 #include "index_sampling.h"
+#include "../indices/index_iterator.h"
 
 RandomLabelSubsetSelection::RandomLabelSubsetSelection(uint32 numSamples)
     : numSamples_(numSamples) {
@@ -7,5 +8,5 @@ RandomLabelSubsetSelection::RandomLabelSubsetSelection(uint32 numSamples)
 }
 
 std::unique_ptr<IIndexVector> RandomLabelSubsetSelection::subSample(uint32 numLabels, RNG& rng) const {
-    return sampleIndicesWithoutReplacement(numLabels, numSamples_, rng);
+    return sampleIndicesWithoutReplacement<IndexIterator>(IndexIterator(numLabels), numLabels, numSamples_, rng);
 }


### PR DESCRIPTION
Dieser Pull-Request enthält Änderungen in `index_sampling.h`, die notwendig sind um aus vordefinierten Indizes zu samplen. Diese Indizes werden dabei mittels eines Iterators (z.B. `IndexIterator`) zur Verfügung gestellt.