### PR TITLE
Refactoring der Funktion "induce_rule"

### DIFF
--- a/python/boomer/common/rule_induction.pxd
+++ b/python/boomer/common/rule_induction.pxd
@@ -1,9 +1,10 @@
 from boomer.common._types cimport uint32, intp
+from boomer.common._indices cimport IIndexVector
 from boomer.common.input cimport IFeatureMatrix, INominalFeatureMask
 from boomer.common.model cimport IModelBuilder
 from boomer.common.statistics cimport StatisticsProvider
 from boomer.common.thresholds cimport IThresholds
-from boomer.common.sampling cimport IInstanceSubSampling, IFeatureSubSampling, ILabelSubSampling, RNG
+from boomer.common.sampling cimport IWeightVector, IFeatureSubSampling, RNG
 from boomer.common.pruning cimport IPruning
 from boomer.common.post_processing cimport IPostProcessor
 from boomer.common.head_refinement cimport IHeadRefinementFactory
@@ -17,10 +18,10 @@ cdef class RuleInduction:
                                   IHeadRefinementFactory* head_refinement_factory, IModelBuilder* model_builder)
 
     cdef bint induce_rule(self, IThresholds* thresholds, INominalFeatureMask* nominal_feature_mask,
-                          IFeatureMatrix* feature_matrix, ILabelSubSampling* label_sub_sampling,
-                          IInstanceSubSampling* instance_sub_sampling, IFeatureSubSampling* feature_sub_sampling,
-                          IPruning* pruning, IPostProcessor* post_processor, uint32 min_coverage, intp max_conditions,
-                          intp max_head_refinements, int num_threads, RNG* rng, IModelBuilder* model_builder)
+                          IFeatureMatrix* feature_matrix, IIndexVector* label_indices, IWeightVector* weight_vector,
+                          IFeatureSubSampling* feature_sub_sampling, IPruning* pruning, IPostProcessor* post_processor,
+                          uint32 min_coverage, intp max_conditions, intp max_head_refinements, int num_threads,
+                          RNG* rng, IModelBuilder* model_builder)
 
 
 cdef class TopDownGreedyRuleInduction(RuleInduction):
@@ -31,7 +32,7 @@ cdef class TopDownGreedyRuleInduction(RuleInduction):
                                   IHeadRefinementFactory* head_refinement_factory, IModelBuilder* model_builder)
 
     cdef bint induce_rule(self, IThresholds* thresholds, INominalFeatureMask* nominal_feature_mask,
-                          IFeatureMatrix* feature_matrix, ILabelSubSampling* label_sub_sampling,
-                          IInstanceSubSampling* instance_sub_sampling, IFeatureSubSampling* feature_sub_sampling,
-                          IPruning* pruning, IPostProcessor* post_processor, uint32 min_coverage, intp max_conditions,
-                          intp max_head_refinements, int num_threads, RNG* rng, IModelBuilder* model_builder)
+                          IFeatureMatrix* feature_matrix, IIndexVector* label_indices, IWeightVector* weight_vector,
+                          IFeatureSubSampling* feature_sub_sampling, IPruning* pruning, IPostProcessor* post_processor,
+                          uint32 min_coverage, intp max_conditions, intp max_head_refinements, int num_threads,
+                          RNG* rng, IModelBuilder* model_builder)

--- a/python/boomer/common/rule_induction.pyx
+++ b/python/boomer/common/rule_induction.pyx
@@ -4,12 +4,11 @@
 Provides classes that implement algorithms for inducing individual classification rules.
 """
 from boomer.common._types cimport float32
-from boomer.common._indices cimport IIndexVector, FullIndexVector
+from boomer.common._indices cimport FullIndexVector
 from boomer.common.head_refinement cimport IHeadRefinement, AbstractEvaluatedPrediction
 from boomer.common.model cimport Condition, Comparator, ConditionList
 from boomer.common.rule_refinement cimport Refinement, IRuleRefinement
 from boomer.common.statistics cimport IStatistics, IStatisticsSubset
-from boomer.common.sampling cimport IWeightVector
 from boomer.common.thresholds cimport IThresholdsSubset, CoverageMask
 
 from libcpp.unordered_map cimport unordered_map
@@ -41,10 +40,10 @@ cdef class RuleInduction:
         pass
 
     cdef bint induce_rule(self, IThresholds* thresholds, INominalFeatureMask* nominal_feature_mask,
-                          IFeatureMatrix* feature_matrix, ILabelSubSampling* label_sub_sampling,
-                          IInstanceSubSampling* instance_sub_sampling, IFeatureSubSampling* feature_sub_sampling,
-                          IPruning* pruning, IPostProcessor* post_processor, uint32 min_coverage, intp max_conditions,
-                          intp max_head_refinements, int num_threads, RNG* rng, IModelBuilder* model_builder):
+                          IFeatureMatrix* feature_matrix, IIndexVector* label_indices, IWeightVector* weight_vector,
+                          IFeatureSubSampling* feature_sub_sampling, IPruning* pruning, IPostProcessor* post_processor,
+                          uint32 min_coverage, intp max_conditions, intp max_head_refinements, int num_threads,
+                          RNG* rng, IModelBuilder* model_builder):
         """
         Induces a new classification rule.
 
@@ -54,10 +53,10 @@ cdef class RuleInduction:
                                         information whether individual features are nominal or not
         :param feature_matrix:          A pointer to an object of type `IFeatureMatrix` that provides column-wise access
                                         to the feature values of the training examples
-        :param label_sub_sampling:      A pointer to an object of type `ILabelSubSampling`, implementing the strategy
-                                        that should be used to sub-sample the labels
-        :param instance_sub_sampling:   A pointer to an object of type `IInstanceSubSampling`, implementing the strategy
-                                        that should be used to sub-sample the training examples
+        :param label_indices:           A pointer to an object of type `IIndexVector` that provides access to the labels
+                                        for which the rule may predict
+        :param weight_vector:           A pointer to an object of type `IWeightVector` that provides access to the
+                                        weights of individual training examples
         :param feature_sub_sampling:    A pointer to an object of type `IFeatureSubSampling`, implementing the strategy
                                         that should be used to sub-sample the available features
         :param pruning:                 A pointer to an object of type `IPruning`, implementing the strategy that should
@@ -121,16 +120,16 @@ cdef class TopDownGreedyRuleInduction(RuleInduction):
             statistics_provider.switch_rule_evaluation()
 
     cdef bint induce_rule(self, IThresholds* thresholds, INominalFeatureMask* nominal_feature_mask,
-                          IFeatureMatrix* feature_matrix, ILabelSubSampling* label_sub_sampling,
-                          IInstanceSubSampling* instance_sub_sampling, IFeatureSubSampling* feature_sub_sampling,
-                          IPruning* pruning, IPostProcessor* post_processor, uint32 min_coverage, intp max_conditions,
-                          intp max_head_refinements, int num_threads, RNG* rng, IModelBuilder* model_builder):
-        # The total number of statistics
-        cdef uint32 num_examples = thresholds.getNumExamples()
+                          IFeatureMatrix* feature_matrix, IIndexVector* label_indices, IWeightVector* weight_vector,
+                          IFeatureSubSampling* feature_sub_sampling, IPruning* pruning, IPostProcessor* post_processor,
+                          uint32 min_coverage, intp max_conditions, intp max_head_refinements, int num_threads,
+                          RNG* rng, IModelBuilder* model_builder):
         # The total number of features
         cdef uint32 num_features = thresholds.getNumFeatures()
-        # The total number of labels
-        cdef uint32 num_labels = thresholds.getNumLabels()
+        # True, if the rule is learned on a sub-sample of the available training examples, False otherwise
+        cdef bint instance_sub_sampling_used = weight_vector.hasZeroWeights()
+        # The label indices for which the next refinement of the rule may predict
+        cdef IIndexVector* current_label_indices = label_indices
         # A (stack-allocated) list that contains the conditions in the rule's body (in the order they have been learned)
         cdef ConditionList conditions
         # The total number of conditions
@@ -152,17 +151,8 @@ cdef class TopDownGreedyRuleInduction(RuleInduction):
         cdef const CoverageMask* coverage_mask
         cdef intp c
 
-        # Sub-sample examples...
-        cdef unique_ptr[IWeightVector] weights_ptr = instance_sub_sampling.subSample(num_examples, dereference(rng))
-        cdef bint instance_sub_sampling_used = weights_ptr.get().hasZeroWeights()
-
-        # Sub-sample labels...
-        cdef unique_ptr[IIndexVector] label_indices_ptr = label_sub_sampling.subSample(num_labels, dereference(rng))
-        cdef IIndexVector* label_indices = label_indices_ptr.get()
-
         # Create a new subset of the given thresholds...
-        cdef unique_ptr[IThresholdsSubset] thresholds_subset_ptr = thresholds.createSubset(
-            dereference(weights_ptr.get()))
+        cdef unique_ptr[IThresholdsSubset] thresholds_subset_ptr = thresholds.createSubset(dereference(weight_vector))
 
         # Search for the best refinement until no improvement in terms of the rule's quality score is possible anymore
         # or the maximum number of conditions has been reached...
@@ -176,7 +166,8 @@ cdef class TopDownGreedyRuleInduction(RuleInduction):
             # For each feature, create an object of type `IRuleRefinement`...
             for c in range(num_sampled_features):
                 f = sampled_feature_indices_ptr.get().getIndex(<uint32>c)
-                rule_refinement_ptr = label_indices.createRuleRefinement(dereference(thresholds_subset_ptr.get()), f)
+                rule_refinement_ptr = current_label_indices.createRuleRefinement(
+                    dereference(thresholds_subset_ptr.get()), f)
                 rule_refinements[f] = rule_refinement_ptr.release()
 
             # Search for the best condition among all available features to be added to the current rule...
@@ -208,7 +199,7 @@ cdef class TopDownGreedyRuleInduction(RuleInduction):
 
                 if max_head_refinements > 0 and num_conditions >= max_head_refinements:
                     # Keep the labels for which the rule predicts, if the head should not be further refined...
-                    label_indices = <IIndexVector*>best_refinement_ptr.get().headPtr.get()
+                    current_label_indices = <IIndexVector*>best_refinement_ptr.get().headPtr.get()
 
                 if num_covered_examples <= min_coverage:
                     # Abort refinement process if the rule is not allowed to cover less examples...

--- a/python/boomer/common/sequential_rule_induction.pyx
+++ b/python/boomer/common/sequential_rule_induction.pyx
@@ -3,6 +3,7 @@
 
 Provides classes that allow to sequentially induce models that consist of several classification rules.
 """
+from boomer.common._indices cimport IIndexVector
 from boomer.common.input cimport IFeatureMatrix, INominalFeatureMask
 from boomer.common.model cimport IModelBuilder
 from boomer.common.pruning cimport IPruning
@@ -10,7 +11,7 @@ from boomer.common.post_processing cimport IPostProcessor
 from boomer.common.statistics cimport StatisticsProvider, IStatistics
 from boomer.common.thresholds cimport IThresholds
 from boomer.common.stopping cimport IStoppingCriterion, StoppingCriterion
-from boomer.common.sampling cimport IInstanceSubSampling, IFeatureSubSampling, ILabelSubSampling, RNG
+from boomer.common.sampling cimport IWeightVector, IInstanceSubSampling, IFeatureSubSampling, ILabelSubSampling, RNG
 from boomer.common.head_refinement cimport IHeadRefinementFactory
 
 from libcpp.memory cimport shared_ptr, unique_ptr, make_unique
@@ -120,6 +121,8 @@ cdef class SequentialRuleInduction:
         # The number of rules induced so far
         cdef uint32 num_rules = 0
         # Temporary variables
+        cdef unique_ptr[IWeightVector] weights_ptr
+        cdef unique_ptr[IIndexVector] label_indices_ptr
         cdef bint success
 
         # Induce default rule...
@@ -146,12 +149,19 @@ cdef class SequentialRuleInduction:
         cdef unique_ptr[IThresholds] thresholds_ptr = thresholds_factory.thresholds_factory_ptr.get().create(
             feature_matrix_ptr, nominal_feature_mask_ptr, statistics_provider.statistics_ptr, head_refinement_factory_ptr)
 
+        # The total number of examples
+        cdef uint32 num_examples = thresholds_ptr.get().getNumExamples()
+        # The total number of labels
+        cdef uint32 num_labels = thresholds_ptr.get().getNumLabels()
+
         while __should_continue(stopping_criteria, statistics_provider.get(), num_rules):
+            weights_ptr = instance_sub_sampling_ptr.get().subSample(num_examples, dereference(rng_ptr.get()))
+            label_indices_ptr = label_sub_sampling_ptr.get().subSample(num_labels, dereference(rng_ptr.get()))
             success = rule_induction.induce_rule(thresholds_ptr.get(), nominal_feature_mask_ptr.get(),
-                                                 feature_matrix_ptr.get(), label_sub_sampling_ptr.get(),
-                                                 instance_sub_sampling_ptr.get(), feature_sub_sampling_ptr.get(),
-                                                 pruning_ptr.get(), post_processor_ptr.get(), min_coverage,
-                                                 max_conditions, max_head_refinements, num_threads, rng_ptr.get(),
+                                                 feature_matrix_ptr.get(), label_indices_ptr.get(), weights_ptr.get(),
+                                                 feature_sub_sampling_ptr.get(), pruning_ptr.get(),
+                                                 post_processor_ptr.get(), min_coverage, max_conditions,
+                                                 max_head_refinements, num_threads, rng_ptr.get(),
                                                  model_builder_ptr.get())
 
             if not success:


### PR DESCRIPTION
Statt (Cython-)Objekte vom Typ `InstanceSubSampling` und `LabelSubSampling` an die Funktion `induce_rule` der Klasse `RuleInduction` zu übergeben und das Sampling intern durchzuführen, wird jetzt das Ergebnis des Samplings (ein Pointer auf einen `IWeightVector` bzw. einen `IIndexVector`) an diese Funktion übergeben. Die Verantwortung, die Sampling-Methoden aufzurufen, liegen nun hiermit bei der Klasse `SequentialRuleInduction`.