### PR TITLE
Refactoring Namespaces

### DIFF
--- a/python/boomer/boosting/cpp/data/matrix_dense_example_wise.cpp
+++ b/python/boomer/boosting/cpp/data/matrix_dense_example_wise.cpp
@@ -2,102 +2,105 @@
 #include "../math/math.h"
 #include <cstdlib>
 
-using namespace boosting;
 
+namespace boosting {
 
-DenseExampleWiseStatisticMatrix::DenseExampleWiseStatisticMatrix(uint32 numRows, uint32 numGradients)
-    : DenseExampleWiseStatisticMatrix(numRows, numGradients, false) {
+    DenseExampleWiseStatisticMatrix::DenseExampleWiseStatisticMatrix(uint32 numRows, uint32 numGradients)
+        : DenseExampleWiseStatisticMatrix(numRows, numGradients, false) {
 
-}
-
-DenseExampleWiseStatisticMatrix::DenseExampleWiseStatisticMatrix(uint32 numRows, uint32 numGradients, bool init)
-    : numRows_(numRows), numGradients_(numGradients), numHessians_(triangularNumber(numGradients)),
-      gradients_((float64*) (init ? calloc(numRows * numGradients, sizeof(float64))
-                                  : malloc(numRows * numGradients * sizeof(float64)))),
-      hessians_((float64*) (init ? calloc(numRows * numHessians_, sizeof(float64))
-                                 : malloc(numRows * numHessians_ * sizeof(float64)))) {
-
-}
-
-DenseExampleWiseStatisticMatrix::~DenseExampleWiseStatisticMatrix() {
-    free(gradients_);
-    free(hessians_);
-}
-
-DenseExampleWiseStatisticMatrix::gradient_iterator DenseExampleWiseStatisticMatrix::gradients_row_begin(uint32 row) {
-    return &gradients_[row * numGradients_];
-}
-
-DenseExampleWiseStatisticMatrix::gradient_iterator DenseExampleWiseStatisticMatrix::gradients_row_end(uint32 row) {
-    return &gradients_[(row + 1) * numGradients_];
-}
-
-DenseExampleWiseStatisticMatrix::gradient_const_iterator DenseExampleWiseStatisticMatrix::gradients_row_cbegin(
-        uint32 row) const {
-    return &gradients_[row * numGradients_];
-}
-
-DenseExampleWiseStatisticMatrix::gradient_const_iterator DenseExampleWiseStatisticMatrix::gradients_row_cend(
-        uint32 row) const {
-    return &gradients_[(row + 1) * numGradients_];
-}
-
-DenseExampleWiseStatisticMatrix::hessian_iterator DenseExampleWiseStatisticMatrix::hessians_row_begin(uint32 row) {
-    return &hessians_[row * numHessians_];
-}
-
-DenseExampleWiseStatisticMatrix::hessian_iterator DenseExampleWiseStatisticMatrix::hessians_row_end(uint32 row) {
-    return &hessians_[(row + 1) * numHessians_];
-}
-
-DenseExampleWiseStatisticMatrix::hessian_const_iterator DenseExampleWiseStatisticMatrix::hessians_row_cbegin(
-        uint32 row) const {
-    return &hessians_[row * numHessians_];
-}
-
-DenseExampleWiseStatisticMatrix::hessian_const_iterator DenseExampleWiseStatisticMatrix::hessians_row_cend(
-        uint32 row) const {
-    return &hessians_[(row + 1) * numHessians_];
-}
-
-uint32 DenseExampleWiseStatisticMatrix::getNumRows() const {
-    return numRows_;
-}
-
-uint32 DenseExampleWiseStatisticMatrix::getNumCols() const {
-    return numGradients_;
-}
-
-void DenseExampleWiseStatisticMatrix::addToRow(uint32 row, gradient_const_iterator gradientsBegin,
-                                               gradient_const_iterator gradientsEnd,
-                                               hessian_const_iterator hessiansBegin,
-                                               hessian_const_iterator hessiansEnd, float64 weight) {
-    uint32 offset = row * numGradients_;
-
-    for (uint32 i = 0; i < numGradients_; i++) {
-        gradients_[offset + i] += (gradientsBegin[i] * weight);
     }
 
-    offset = row * numHessians_;
+    DenseExampleWiseStatisticMatrix::DenseExampleWiseStatisticMatrix(uint32 numRows, uint32 numGradients, bool init)
+        : numRows_(numRows), numGradients_(numGradients), numHessians_(triangularNumber(numGradients)),
+          gradients_((float64*) (init ? calloc(numRows * numGradients, sizeof(float64))
+                                      : malloc(numRows * numGradients * sizeof(float64)))),
+          hessians_((float64*) (init ? calloc(numRows * numHessians_, sizeof(float64))
+                                     : malloc(numRows * numHessians_ * sizeof(float64)))) {
 
-    for (uint32 i = 0; i < numHessians_; i++) {
-        hessians_[offset + i] += (hessiansBegin[i] * weight);
-    }
-}
-
-void DenseExampleWiseStatisticMatrix::subtractFromRow(uint32 row, gradient_const_iterator gradientsBegin,
-                                                      gradient_const_iterator gradientsEnd,
-                                                      hessian_const_iterator hessiansBegin,
-                                                      hessian_const_iterator hessiansEnd, float64 weight) {
-    uint32 offset = row * numGradients_;
-
-    for (uint32 i = 0; i < numGradients_; i++) {
-        gradients_[offset + i] -= (gradientsBegin[i] * weight);
     }
 
-    offset = row * numHessians_;
-
-    for (uint32 i = 0; i < numHessians_; i++) {
-        hessians_[offset + i] -= (hessiansBegin[i] * weight);
+    DenseExampleWiseStatisticMatrix::~DenseExampleWiseStatisticMatrix() {
+        free(gradients_);
+        free(hessians_);
     }
+
+    DenseExampleWiseStatisticMatrix::gradient_iterator DenseExampleWiseStatisticMatrix::gradients_row_begin(
+            uint32 row) {
+        return &gradients_[row * numGradients_];
+    }
+
+    DenseExampleWiseStatisticMatrix::gradient_iterator DenseExampleWiseStatisticMatrix::gradients_row_end(uint32 row) {
+        return &gradients_[(row + 1) * numGradients_];
+    }
+
+    DenseExampleWiseStatisticMatrix::gradient_const_iterator DenseExampleWiseStatisticMatrix::gradients_row_cbegin(
+            uint32 row) const {
+        return &gradients_[row * numGradients_];
+    }
+
+    DenseExampleWiseStatisticMatrix::gradient_const_iterator DenseExampleWiseStatisticMatrix::gradients_row_cend(
+            uint32 row) const {
+        return &gradients_[(row + 1) * numGradients_];
+    }
+
+    DenseExampleWiseStatisticMatrix::hessian_iterator DenseExampleWiseStatisticMatrix::hessians_row_begin(uint32 row) {
+        return &hessians_[row * numHessians_];
+    }
+
+    DenseExampleWiseStatisticMatrix::hessian_iterator DenseExampleWiseStatisticMatrix::hessians_row_end(uint32 row) {
+        return &hessians_[(row + 1) * numHessians_];
+    }
+
+    DenseExampleWiseStatisticMatrix::hessian_const_iterator DenseExampleWiseStatisticMatrix::hessians_row_cbegin(
+            uint32 row) const {
+        return &hessians_[row * numHessians_];
+    }
+
+    DenseExampleWiseStatisticMatrix::hessian_const_iterator DenseExampleWiseStatisticMatrix::hessians_row_cend(
+            uint32 row) const {
+        return &hessians_[(row + 1) * numHessians_];
+    }
+
+    uint32 DenseExampleWiseStatisticMatrix::getNumRows() const {
+        return numRows_;
+    }
+
+    uint32 DenseExampleWiseStatisticMatrix::getNumCols() const {
+        return numGradients_;
+    }
+
+    void DenseExampleWiseStatisticMatrix::addToRow(uint32 row, gradient_const_iterator gradientsBegin,
+                                                   gradient_const_iterator gradientsEnd,
+                                                   hessian_const_iterator hessiansBegin,
+                                                   hessian_const_iterator hessiansEnd, float64 weight) {
+        uint32 offset = row * numGradients_;
+
+        for (uint32 i = 0; i < numGradients_; i++) {
+            gradients_[offset + i] += (gradientsBegin[i] * weight);
+        }
+
+        offset = row * numHessians_;
+
+        for (uint32 i = 0; i < numHessians_; i++) {
+            hessians_[offset + i] += (hessiansBegin[i] * weight);
+        }
+    }
+
+    void DenseExampleWiseStatisticMatrix::subtractFromRow(uint32 row, gradient_const_iterator gradientsBegin,
+                                                          gradient_const_iterator gradientsEnd,
+                                                          hessian_const_iterator hessiansBegin,
+                                                          hessian_const_iterator hessiansEnd, float64 weight) {
+        uint32 offset = row * numGradients_;
+
+        for (uint32 i = 0; i < numGradients_; i++) {
+            gradients_[offset + i] -= (gradientsBegin[i] * weight);
+        }
+
+        offset = row * numHessians_;
+
+        for (uint32 i = 0; i < numHessians_; i++) {
+            hessians_[offset + i] -= (hessiansBegin[i] * weight);
+        }
+    }
+
 }

--- a/python/boomer/boosting/cpp/data/matrix_dense_label_wise.cpp
+++ b/python/boomer/boosting/cpp/data/matrix_dense_label_wise.cpp
@@ -1,93 +1,96 @@
 #include "matrix_dense_label_wise.h"
 #include <cstdlib>
 
-using namespace boosting;
 
+namespace boosting {
 
-DenseLabelWiseStatisticMatrix::DenseLabelWiseStatisticMatrix(uint32 numRows, uint32 numCols)
-    : DenseLabelWiseStatisticMatrix(numRows, numCols, false) {
+    DenseLabelWiseStatisticMatrix::DenseLabelWiseStatisticMatrix(uint32 numRows, uint32 numCols)
+        : DenseLabelWiseStatisticMatrix(numRows, numCols, false) {
 
-}
-
-DenseLabelWiseStatisticMatrix::DenseLabelWiseStatisticMatrix(uint32 numRows, uint32 numCols, bool init)
-    : numRows_(numRows), numCols_(numCols),
-      gradients_((float64*) (init ? calloc(numRows * numCols, sizeof(float64))
-                                  : malloc(numRows * numCols * sizeof(float64)))),
-      hessians_((float64*) (init ? calloc(numRows * numCols, sizeof(float64))
-                                 : malloc(numRows * numCols * sizeof(float64)))) {
-
-}
-
-DenseLabelWiseStatisticMatrix::~DenseLabelWiseStatisticMatrix() {
-    free(gradients_);
-    free(hessians_);
-}
-
-DenseLabelWiseStatisticMatrix::gradient_iterator DenseLabelWiseStatisticMatrix::gradients_row_begin(uint32 row) {
-    return &gradients_[row * numCols_];
-}
-
-DenseLabelWiseStatisticMatrix::gradient_iterator DenseLabelWiseStatisticMatrix::gradients_row_end(uint32 row) {
-    return &gradients_[(row + 1) * numCols_];
-}
-
-DenseLabelWiseStatisticMatrix::gradient_const_iterator DenseLabelWiseStatisticMatrix::gradients_row_cbegin(
-        uint32 row) const {
-    return &gradients_[row * numCols_];
-}
-
-DenseLabelWiseStatisticMatrix::gradient_const_iterator DenseLabelWiseStatisticMatrix::gradients_row_cend(
-        uint32 row) const {
-    return &gradients_[(row + 1) * numCols_];
-}
-
-DenseLabelWiseStatisticMatrix::hessian_iterator DenseLabelWiseStatisticMatrix::hessians_row_begin(uint32 row) {
-    return &hessians_[row * numCols_];
-}
-
-DenseLabelWiseStatisticMatrix::hessian_iterator DenseLabelWiseStatisticMatrix::hessians_row_end(uint32 row) {
-    return &hessians_[(row + 1) * numCols_];
-}
-
-DenseLabelWiseStatisticMatrix::hessian_const_iterator DenseLabelWiseStatisticMatrix::hessians_row_cbegin(
-        uint32 row) const {
-    return &hessians_[row * numCols_];
-}
-
-DenseLabelWiseStatisticMatrix::hessian_const_iterator DenseLabelWiseStatisticMatrix::hessians_row_cend(
-        uint32 row) const {
-    return &hessians_[(row + 1) * numCols_];
-}
-
-uint32 DenseLabelWiseStatisticMatrix::getNumRows() const {
-    return numRows_;
-}
-
-uint32 DenseLabelWiseStatisticMatrix::getNumCols() const {
-    return numCols_;
-}
-
-void DenseLabelWiseStatisticMatrix::addToRow(uint32 row, gradient_const_iterator gradientsBegin,
-                                             gradient_const_iterator gradientsEnd, hessian_const_iterator hessiansBegin,
-                                             hessian_const_iterator hessiansEnd, float64 weight) {
-    uint32 offset = row * numCols_;
-
-    for (uint32 i = 0; i < numCols_; i++) {
-        uint32 index = offset + i;
-        gradients_[index] += (gradientsBegin[i] * weight);
-        hessians_[index] += (hessiansBegin[i] * weight);
     }
-}
 
-void DenseLabelWiseStatisticMatrix::subtractFromRow(uint32 row, gradient_const_iterator gradientsBegin,
-                                                    gradient_const_iterator gradientsEnd,
-                                                    hessian_const_iterator hessiansBegin,
-                                                    hessian_const_iterator hessiansEnd, float64 weight) {
-    uint32 offset = row * numCols_;
+    DenseLabelWiseStatisticMatrix::DenseLabelWiseStatisticMatrix(uint32 numRows, uint32 numCols, bool init)
+        : numRows_(numRows), numCols_(numCols),
+          gradients_((float64*) (init ? calloc(numRows * numCols, sizeof(float64))
+                                      : malloc(numRows * numCols * sizeof(float64)))),
+          hessians_((float64*) (init ? calloc(numRows * numCols, sizeof(float64))
+                                     : malloc(numRows * numCols * sizeof(float64)))) {
 
-    for (uint32 i = 0; i < numCols_; i++) {
-        uint32 index = offset + i;
-        gradients_[index] -= (gradientsBegin[i] * weight);
-        hessians_[index] -= (hessiansBegin[i] * weight);
     }
+
+    DenseLabelWiseStatisticMatrix::~DenseLabelWiseStatisticMatrix() {
+        free(gradients_);
+        free(hessians_);
+    }
+
+    DenseLabelWiseStatisticMatrix::gradient_iterator DenseLabelWiseStatisticMatrix::gradients_row_begin(uint32 row) {
+        return &gradients_[row * numCols_];
+    }
+
+    DenseLabelWiseStatisticMatrix::gradient_iterator DenseLabelWiseStatisticMatrix::gradients_row_end(uint32 row) {
+        return &gradients_[(row + 1) * numCols_];
+    }
+
+    DenseLabelWiseStatisticMatrix::gradient_const_iterator DenseLabelWiseStatisticMatrix::gradients_row_cbegin(
+            uint32 row) const {
+        return &gradients_[row * numCols_];
+    }
+
+    DenseLabelWiseStatisticMatrix::gradient_const_iterator DenseLabelWiseStatisticMatrix::gradients_row_cend(
+            uint32 row) const {
+        return &gradients_[(row + 1) * numCols_];
+    }
+
+    DenseLabelWiseStatisticMatrix::hessian_iterator DenseLabelWiseStatisticMatrix::hessians_row_begin(uint32 row) {
+        return &hessians_[row * numCols_];
+    }
+
+    DenseLabelWiseStatisticMatrix::hessian_iterator DenseLabelWiseStatisticMatrix::hessians_row_end(uint32 row) {
+        return &hessians_[(row + 1) * numCols_];
+    }
+
+    DenseLabelWiseStatisticMatrix::hessian_const_iterator DenseLabelWiseStatisticMatrix::hessians_row_cbegin(
+            uint32 row) const {
+        return &hessians_[row * numCols_];
+    }
+
+    DenseLabelWiseStatisticMatrix::hessian_const_iterator DenseLabelWiseStatisticMatrix::hessians_row_cend(
+            uint32 row) const {
+        return &hessians_[(row + 1) * numCols_];
+    }
+
+    uint32 DenseLabelWiseStatisticMatrix::getNumRows() const {
+        return numRows_;
+    }
+
+    uint32 DenseLabelWiseStatisticMatrix::getNumCols() const {
+        return numCols_;
+    }
+
+    void DenseLabelWiseStatisticMatrix::addToRow(uint32 row, gradient_const_iterator gradientsBegin,
+                                                 gradient_const_iterator gradientsEnd,
+                                                 hessian_const_iterator hessiansBegin,
+                                                 hessian_const_iterator hessiansEnd, float64 weight) {
+        uint32 offset = row * numCols_;
+
+        for (uint32 i = 0; i < numCols_; i++) {
+            uint32 index = offset + i;
+            gradients_[index] += (gradientsBegin[i] * weight);
+            hessians_[index] += (hessiansBegin[i] * weight);
+        }
+    }
+
+    void DenseLabelWiseStatisticMatrix::subtractFromRow(uint32 row, gradient_const_iterator gradientsBegin,
+                                                        gradient_const_iterator gradientsEnd,
+                                                        hessian_const_iterator hessiansBegin,
+                                                        hessian_const_iterator hessiansEnd, float64 weight) {
+        uint32 offset = row * numCols_;
+
+        for (uint32 i = 0; i < numCols_; i++) {
+            uint32 index = offset + i;
+            gradients_[index] -= (gradientsBegin[i] * weight);
+            hessians_[index] -= (hessiansBegin[i] * weight);
+        }
+    }
+
 }

--- a/python/boomer/boosting/cpp/data/matrix_dense_numeric.cpp
+++ b/python/boomer/boosting/cpp/data/matrix_dense_numeric.cpp
@@ -1,45 +1,47 @@
 #include "matrix_dense_numeric.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-template<class T>
-DenseNumericMatrix<T>::DenseNumericMatrix(uint32 numRows, uint32 numCols)
-    : DenseMatrix<T>(numRows, numCols) {
+    template<class T>
+    DenseNumericMatrix<T>::DenseNumericMatrix(uint32 numRows, uint32 numCols)
+        : DenseMatrix<T>(numRows, numCols) {
 
-}
-
-template<class T>
-DenseNumericMatrix<T>::DenseNumericMatrix(uint32 numRows, uint32 numCols, bool init)
-    : DenseMatrix<T>(numRows, numCols, init) {
-
-}
-
-template<class T>
-void DenseNumericMatrix<T>::addToRowFromSubset(uint32 row, typename DenseVector<T>::const_iterator begin,
-                                               typename DenseVector<T>::const_iterator end,
-                                               FullIndexVector::const_iterator indicesBegin,
-                                               FullIndexVector::const_iterator indicesEnd) {
-    uint32 offset = row * DenseMatrix<T>::numCols_;
-
-    for (uint32 i = 0; i < DenseMatrix<T>::numCols_; i++) {
-        DenseMatrix<T>::array_[offset + i] += begin[i];
     }
-}
 
-template<class T>
-void DenseNumericMatrix<T>::addToRowFromSubset(uint32 row, typename DenseVector<T>::const_iterator begin,
-                                               typename DenseVector<T>::const_iterator end,
-                                               PartialIndexVector::const_iterator indicesBegin,
-                                               PartialIndexVector::const_iterator indicesEnd) {
-    uint32 offset = row * DenseMatrix<T>::numCols_;
-    typename DenseVector<T>::const_iterator valueIterator = begin;
+    template<class T>
+    DenseNumericMatrix<T>::DenseNumericMatrix(uint32 numRows, uint32 numCols, bool init)
+        : DenseMatrix<T>(numRows, numCols, init) {
 
-    for (auto indexIterator = indicesBegin; indexIterator != indicesEnd; indexIterator++) {
-        uint32 index = *indexIterator;
-        DenseMatrix<T>::array_[offset + index] += *valueIterator;
-        valueIterator++;
     }
-}
 
-template class DenseNumericMatrix<float64>;
+    template<class T>
+    void DenseNumericMatrix<T>::addToRowFromSubset(uint32 row, typename DenseVector<T>::const_iterator begin,
+                                                   typename DenseVector<T>::const_iterator end,
+                                                   FullIndexVector::const_iterator indicesBegin,
+                                                   FullIndexVector::const_iterator indicesEnd) {
+        uint32 offset = row * DenseMatrix<T>::numCols_;
+
+        for (uint32 i = 0; i < DenseMatrix<T>::numCols_; i++) {
+            DenseMatrix<T>::array_[offset + i] += begin[i];
+        }
+    }
+
+    template<class T>
+    void DenseNumericMatrix<T>::addToRowFromSubset(uint32 row, typename DenseVector<T>::const_iterator begin,
+                                                   typename DenseVector<T>::const_iterator end,
+                                                   PartialIndexVector::const_iterator indicesBegin,
+                                                   PartialIndexVector::const_iterator indicesEnd) {
+        uint32 offset = row * DenseMatrix<T>::numCols_;
+        typename DenseVector<T>::const_iterator valueIterator = begin;
+
+        for (auto indexIterator = indicesBegin; indexIterator != indicesEnd; indexIterator++) {
+            uint32 index = *indexIterator;
+            DenseMatrix<T>::array_[offset + index] += *valueIterator;
+            valueIterator++;
+        }
+    }
+
+    template class DenseNumericMatrix<float64>;
+
+}

--- a/python/boomer/boosting/cpp/data/vector_dense_example_wise.cpp
+++ b/python/boomer/boosting/cpp/data/vector_dense_example_wise.cpp
@@ -3,235 +3,242 @@
 #include "../math/math.h"
 #include <cstdlib>
 
-using namespace boosting;
 
+namespace boosting {
 
-DenseExampleWiseStatisticVector::HessianDiagonalIterator::HessianDiagonalIterator(
-        const DenseExampleWiseStatisticVector& vector, uint32 index)
-    : vector_(vector), index_(index) {
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator::HessianDiagonalIterator(
+            const DenseExampleWiseStatisticVector& vector, uint32 index)
+        : vector_(vector), index_(index) {
 
-}
-
-DenseExampleWiseStatisticVector::HessianDiagonalIterator::reference DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator[](
-        uint32 index) const {
-    return vector_.hessians_[triangularNumber(index + 1) - 1];
-}
-
-DenseExampleWiseStatisticVector::HessianDiagonalIterator::reference DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator*() const {
-    return vector_.hessians_[triangularNumber(index_ + 1) - 1];
-}
-
-DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator++() {
-    ++index_;
-    return *this;
-}
-
-DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator++(
-        int n) {
-    index_++;
-    return *this;
-}
-
-DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator--() {
-    --index_;
-    return *this;
-}
-
-DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator--(
-        int n) {
-    index_--;
-    return *this;
-}
-
-bool DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator!=(
-        const DenseExampleWiseStatisticVector::HessianDiagonalIterator& rhs) const {
-    return index_ != rhs.index_;
-}
-
-DenseExampleWiseStatisticVector::HessianDiagonalIterator::difference_type DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator-(
-        const DenseExampleWiseStatisticVector::HessianDiagonalIterator& rhs) const {
-    return (difference_type) index_ - (difference_type) rhs.index_;
-}
-
-DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(uint32 numGradients)
-    : DenseExampleWiseStatisticVector(numGradients, false) {
-
-}
-
-DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(uint32 numGradients, bool init)
-    : numGradients_(numGradients), numHessians_(triangularNumber(numGradients)),
-      gradients_((float64*) (init ? calloc(numGradients, sizeof(float64)) : malloc(numGradients * sizeof(float64)))),
-      hessians_((float64*) (init ? calloc(numHessians_, sizeof(float64)) : malloc(numHessians_ * sizeof(float64)))) {
-
-}
-
-DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(const DenseExampleWiseStatisticVector& vector)
-    : DenseExampleWiseStatisticVector(vector.numGradients_) {
-    copyArray(vector.gradients_, gradients_, numGradients_);
-    copyArray(vector.hessians_, hessians_, numHessians_);
-}
-
-DenseExampleWiseStatisticVector::~DenseExampleWiseStatisticVector() {
-    free(gradients_);
-    free(hessians_);
-}
-
-DenseExampleWiseStatisticVector::gradient_iterator DenseExampleWiseStatisticVector::gradients_begin() {
-    return gradients_;
-}
-
-DenseExampleWiseStatisticVector::gradient_iterator DenseExampleWiseStatisticVector::gradients_end() {
-    return &gradients_[numGradients_];
-}
-
-DenseExampleWiseStatisticVector::gradient_const_iterator DenseExampleWiseStatisticVector::gradients_cbegin() const {
-    return gradients_;
-}
-
-DenseExampleWiseStatisticVector::gradient_const_iterator DenseExampleWiseStatisticVector::gradients_cend() const {
-    return &gradients_[numGradients_];
-}
-
-DenseExampleWiseStatisticVector::hessian_iterator DenseExampleWiseStatisticVector::hessians_begin() {
-    return hessians_;
-}
-
-DenseExampleWiseStatisticVector::hessian_iterator DenseExampleWiseStatisticVector::hessians_end() {
-    return &hessians_[numHessians_];
-}
-
-DenseExampleWiseStatisticVector::hessian_const_iterator DenseExampleWiseStatisticVector::hessians_cbegin() const {
-    return hessians_;
-}
-
-DenseExampleWiseStatisticVector::hessian_const_iterator DenseExampleWiseStatisticVector::hessians_cend() const {
-    return &hessians_[numHessians_];
-}
-
-DenseExampleWiseStatisticVector::hessian_diagonal_const_iterator DenseExampleWiseStatisticVector::hessians_diagonal_cbegin() const  {
-    return DenseExampleWiseStatisticVector::HessianDiagonalIterator(*this, 0);
-}
-
-DenseExampleWiseStatisticVector::hessian_diagonal_const_iterator DenseExampleWiseStatisticVector::hessians_diagonal_cend() const  {
-    return DenseExampleWiseStatisticVector::HessianDiagonalIterator(*this, numGradients_);
-}
-
-uint32 DenseExampleWiseStatisticVector::getNumElements() const {
-    return numGradients_;
-}
-
-void DenseExampleWiseStatisticVector::setAllToZero() {
-    setArrayToZeros(gradients_, numGradients_);
-    setArrayToZeros(hessians_, numHessians_);
-}
-
-void DenseExampleWiseStatisticVector::add(gradient_const_iterator gradientsBegin, gradient_const_iterator gradientsEnd,
-                                          hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd) {
-    std::copy(gradientsBegin, gradientsEnd, gradients_);
-    std::copy(hessiansBegin, hessiansEnd, hessians_);
-}
-
-void DenseExampleWiseStatisticVector::add(gradient_const_iterator gradientsBegin, gradient_const_iterator gradientsEnd,
-                                          hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd,
-                                          float64 weight) {
-    for (uint32 i = 0; i < numGradients_; i++) {
-        gradients_[i] += (gradientsBegin[i] * weight);
     }
 
-    for (uint32 i = 0; i < numHessians_; i++) {
-        hessians_[i] += (hessiansBegin[i] * weight);
-    }
-}
-
-void DenseExampleWiseStatisticVector::subtract(gradient_const_iterator gradientsBegin,
-                                               gradient_const_iterator gradientsEnd,
-                                               hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd,
-                                               float64 weight) {
-    for (uint32 i = 0; i < numGradients_; i++) {
-        gradients_[i] -= (gradientsBegin[i] * weight);
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator::reference DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator[](
+            uint32 index) const {
+        return vector_.hessians_[triangularNumber(index + 1) - 1];
     }
 
-    for (uint32 i = 0; i < numHessians_; i++) {
-        hessians_[i] -= (hessiansBegin[i] * weight);
-    }
-}
-
-void DenseExampleWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
-                                                  gradient_const_iterator gradientsEnd,
-                                                  hessian_const_iterator hessiansBegin,
-                                                  hessian_const_iterator hessiansEnd, const FullIndexVector& indices,
-                                                  float64 weight) {
-    for (uint32 i = 0; i < numGradients_; i++) {
-        gradients_[i] += (gradientsBegin[i] * weight);
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator::reference DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator*() const {
+        return vector_.hessians_[triangularNumber(index_ + 1) - 1];
     }
 
-    for (uint32 i = 0; i < numHessians_; i++) {
-        hessians_[i] += (hessiansBegin[i] * weight);
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator++() {
+        ++index_;
+        return *this;
     }
-}
 
-void DenseExampleWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
-                                                  gradient_const_iterator gradientsEnd,
-                                                  hessian_const_iterator hessiansBegin,
-                                                  hessian_const_iterator hessiansEnd, const PartialIndexVector& indices,
-                                                  float64 weight) {
-    PartialIndexVector::const_iterator indexIterator = indices.cbegin();
-    hessian_iterator hessianIterator = hessians_;
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator++(
+            int n) {
+        index_++;
+        return *this;
+    }
 
-    for (uint32 i = 0; i < numGradients_; i++) {
-        uint32 index = indexIterator[i];
-        gradients_[i] += (gradientsBegin[index] * weight);
-        uint32 offset = triangularNumber(index);
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator--() {
+        --index_;
+        return *this;
+    }
 
-        for (uint32 j = 0; j < i + 1; j++) {
-            uint32 index2 = indexIterator[j];
-            *hessianIterator += (weight * hessiansBegin[offset + index2]);
-            hessianIterator++;
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator& DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator--(
+            int n) {
+        index_--;
+        return *this;
+    }
+
+    bool DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator!=(
+            const DenseExampleWiseStatisticVector::HessianDiagonalIterator& rhs) const {
+        return index_ != rhs.index_;
+    }
+
+    DenseExampleWiseStatisticVector::HessianDiagonalIterator::difference_type DenseExampleWiseStatisticVector::HessianDiagonalIterator::operator-(
+            const DenseExampleWiseStatisticVector::HessianDiagonalIterator& rhs) const {
+        return (difference_type) index_ - (difference_type) rhs.index_;
+    }
+
+    DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(uint32 numGradients)
+        : DenseExampleWiseStatisticVector(numGradients, false) {
+
+    }
+
+    DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(uint32 numGradients, bool init)
+        : numGradients_(numGradients), numHessians_(triangularNumber(numGradients)),
+          gradients_((float64*) (init ? calloc(numGradients, sizeof(float64))
+                                      : malloc(numGradients * sizeof(float64)))),
+          hessians_((float64*) (init ? calloc(numHessians_, sizeof(float64))
+                                      : malloc(numHessians_ * sizeof(float64)))) {
+
+    }
+
+    DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(const DenseExampleWiseStatisticVector& vector)
+        : DenseExampleWiseStatisticVector(vector.numGradients_) {
+        copyArray(vector.gradients_, gradients_, numGradients_);
+        copyArray(vector.hessians_, hessians_, numHessians_);
+    }
+
+    DenseExampleWiseStatisticVector::~DenseExampleWiseStatisticVector() {
+        free(gradients_);
+        free(hessians_);
+    }
+
+    DenseExampleWiseStatisticVector::gradient_iterator DenseExampleWiseStatisticVector::gradients_begin() {
+        return gradients_;
+    }
+
+    DenseExampleWiseStatisticVector::gradient_iterator DenseExampleWiseStatisticVector::gradients_end() {
+        return &gradients_[numGradients_];
+    }
+
+    DenseExampleWiseStatisticVector::gradient_const_iterator DenseExampleWiseStatisticVector::gradients_cbegin() const {
+        return gradients_;
+    }
+
+    DenseExampleWiseStatisticVector::gradient_const_iterator DenseExampleWiseStatisticVector::gradients_cend() const {
+        return &gradients_[numGradients_];
+    }
+
+    DenseExampleWiseStatisticVector::hessian_iterator DenseExampleWiseStatisticVector::hessians_begin() {
+        return hessians_;
+    }
+
+    DenseExampleWiseStatisticVector::hessian_iterator DenseExampleWiseStatisticVector::hessians_end() {
+        return &hessians_[numHessians_];
+    }
+
+    DenseExampleWiseStatisticVector::hessian_const_iterator DenseExampleWiseStatisticVector::hessians_cbegin() const {
+        return hessians_;
+    }
+
+    DenseExampleWiseStatisticVector::hessian_const_iterator DenseExampleWiseStatisticVector::hessians_cend() const {
+        return &hessians_[numHessians_];
+    }
+
+    DenseExampleWiseStatisticVector::hessian_diagonal_const_iterator DenseExampleWiseStatisticVector::hessians_diagonal_cbegin() const  {
+        return DenseExampleWiseStatisticVector::HessianDiagonalIterator(*this, 0);
+    }
+
+    DenseExampleWiseStatisticVector::hessian_diagonal_const_iterator DenseExampleWiseStatisticVector::hessians_diagonal_cend() const  {
+        return DenseExampleWiseStatisticVector::HessianDiagonalIterator(*this, numGradients_);
+    }
+
+    uint32 DenseExampleWiseStatisticVector::getNumElements() const {
+        return numGradients_;
+    }
+
+    void DenseExampleWiseStatisticVector::setAllToZero() {
+        setArrayToZeros(gradients_, numGradients_);
+        setArrayToZeros(hessians_, numHessians_);
+    }
+
+    void DenseExampleWiseStatisticVector::add(gradient_const_iterator gradientsBegin,
+                                              gradient_const_iterator gradientsEnd,
+                                              hessian_const_iterator hessiansBegin,
+                                              hessian_const_iterator hessiansEnd) {
+        std::copy(gradientsBegin, gradientsEnd, gradients_);
+        std::copy(hessiansBegin, hessiansEnd, hessians_);
+    }
+
+    void DenseExampleWiseStatisticVector::add(gradient_const_iterator gradientsBegin,
+                                              gradient_const_iterator gradientsEnd,
+                                              hessian_const_iterator hessiansBegin,
+                                              hessian_const_iterator hessiansEnd, float64 weight) {
+        for (uint32 i = 0; i < numGradients_; i++) {
+            gradients_[i] += (gradientsBegin[i] * weight);
+        }
+
+        for (uint32 i = 0; i < numHessians_; i++) {
+            hessians_[i] += (hessiansBegin[i] * weight);
         }
     }
-}
 
-void DenseExampleWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
-                                                 gradient_const_iterator firstGradientsEnd,
-                                                 hessian_const_iterator firstHessiansBegin,
-                                                 hessian_const_iterator firstHessiansEnd,
-                                                 const FullIndexVector& firstIndices,
-                                                 gradient_const_iterator secondGradientsBegin,
-                                                 gradient_const_iterator secondGradientsEnd,
-                                                 hessian_const_iterator secondHessiansBegin,
-                                                 hessian_const_iterator secondHessiansEnd) {
-    for (uint32 i = 0; i < numGradients_; i++) {
-        gradients_[i] = firstGradientsBegin[i] - secondGradientsBegin[i];
-    }
+    void DenseExampleWiseStatisticVector::subtract(gradient_const_iterator gradientsBegin,
+                                                   gradient_const_iterator gradientsEnd,
+                                                   hessian_const_iterator hessiansBegin,
+                                                   hessian_const_iterator hessiansEnd, float64 weight) {
+        for (uint32 i = 0; i < numGradients_; i++) {
+            gradients_[i] -= (gradientsBegin[i] * weight);
+        }
 
-    for (uint32 i = 0; i < numHessians_; i++) {
-        hessians_[i] = firstHessiansBegin[i] - secondHessiansBegin[i];
-    }
-}
-
-void DenseExampleWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
-                                                 gradient_const_iterator firstGradientsEnd,
-                                                 hessian_const_iterator firstHessiansBegin,
-                                                 hessian_const_iterator firstHessiansEnd,
-                                                 const PartialIndexVector& firstIndices,
-                                                 gradient_const_iterator secondGradientsBegin,
-                                                 gradient_const_iterator secondGradientsEnd,
-                                                 hessian_const_iterator secondHessiansBegin,
-                                                 hessian_const_iterator secondHessiansEnd) {
-    PartialIndexVector::const_iterator firstIndexIterator = firstIndices.cbegin();
-    hessian_iterator hessianIterator = hessians_;
-    hessian_const_iterator secondHessianIterator = secondHessiansBegin;
-
-    for (uint32 i = 0; i < numGradients_; i++) {
-        uint32 firstIndex = firstIndexIterator[i];
-        gradients_[i] = firstGradientsBegin[firstIndex] - secondGradientsBegin[i];
-        uint32 offset = triangularNumber(firstIndex);
-
-        for (uint32 j = 0; j < i + 1; j++) {
-            uint32 firstIndex2 = firstIndexIterator[j];
-            *hessianIterator = firstHessiansBegin[offset + firstIndex2] - *secondHessianIterator;
-            hessianIterator++;
-            secondHessianIterator++;
+        for (uint32 i = 0; i < numHessians_; i++) {
+            hessians_[i] -= (hessiansBegin[i] * weight);
         }
     }
+
+    void DenseExampleWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
+                                                      gradient_const_iterator gradientsEnd,
+                                                      hessian_const_iterator hessiansBegin,
+                                                      hessian_const_iterator hessiansEnd,
+                                                      const FullIndexVector& indices, float64 weight) {
+        for (uint32 i = 0; i < numGradients_; i++) {
+            gradients_[i] += (gradientsBegin[i] * weight);
+        }
+
+        for (uint32 i = 0; i < numHessians_; i++) {
+            hessians_[i] += (hessiansBegin[i] * weight);
+        }
+    }
+
+    void DenseExampleWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
+                                                      gradient_const_iterator gradientsEnd,
+                                                      hessian_const_iterator hessiansBegin,
+                                                      hessian_const_iterator hessiansEnd,
+                                                      const PartialIndexVector& indices, float64 weight) {
+        PartialIndexVector::const_iterator indexIterator = indices.cbegin();
+        hessian_iterator hessianIterator = hessians_;
+
+        for (uint32 i = 0; i < numGradients_; i++) {
+            uint32 index = indexIterator[i];
+            gradients_[i] += (gradientsBegin[index] * weight);
+            uint32 offset = triangularNumber(index);
+
+            for (uint32 j = 0; j < i + 1; j++) {
+                uint32 index2 = indexIterator[j];
+                *hessianIterator += (weight * hessiansBegin[offset + index2]);
+                hessianIterator++;
+            }
+        }
+    }
+
+    void DenseExampleWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
+                                                     gradient_const_iterator firstGradientsEnd,
+                                                     hessian_const_iterator firstHessiansBegin,
+                                                     hessian_const_iterator firstHessiansEnd,
+                                                     const FullIndexVector& firstIndices,
+                                                     gradient_const_iterator secondGradientsBegin,
+                                                     gradient_const_iterator secondGradientsEnd,
+                                                     hessian_const_iterator secondHessiansBegin,
+                                                     hessian_const_iterator secondHessiansEnd) {
+        for (uint32 i = 0; i < numGradients_; i++) {
+            gradients_[i] = firstGradientsBegin[i] - secondGradientsBegin[i];
+        }
+
+        for (uint32 i = 0; i < numHessians_; i++) {
+            hessians_[i] = firstHessiansBegin[i] - secondHessiansBegin[i];
+        }
+    }
+
+    void DenseExampleWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
+                                                     gradient_const_iterator firstGradientsEnd,
+                                                     hessian_const_iterator firstHessiansBegin,
+                                                     hessian_const_iterator firstHessiansEnd,
+                                                     const PartialIndexVector& firstIndices,
+                                                     gradient_const_iterator secondGradientsBegin,
+                                                     gradient_const_iterator secondGradientsEnd,
+                                                     hessian_const_iterator secondHessiansBegin,
+                                                     hessian_const_iterator secondHessiansEnd) {
+        PartialIndexVector::const_iterator firstIndexIterator = firstIndices.cbegin();
+        hessian_iterator hessianIterator = hessians_;
+        hessian_const_iterator secondHessianIterator = secondHessiansBegin;
+
+        for (uint32 i = 0; i < numGradients_; i++) {
+            uint32 firstIndex = firstIndexIterator[i];
+            gradients_[i] = firstGradientsBegin[firstIndex] - secondGradientsBegin[i];
+            uint32 offset = triangularNumber(firstIndex);
+
+            for (uint32 j = 0; j < i + 1; j++) {
+                uint32 firstIndex2 = firstIndexIterator[j];
+                *hessianIterator = firstHessiansBegin[offset + firstIndex2] - *secondHessianIterator;
+                hessianIterator++;
+                secondHessianIterator++;
+            }
+        }
+    }
+
 }

--- a/python/boomer/boosting/cpp/data/vector_dense_label_wise.cpp
+++ b/python/boomer/boosting/cpp/data/vector_dense_label_wise.cpp
@@ -2,152 +2,155 @@
 #include "../../../common/cpp/data/arrays.h"
 #include <cstdlib>
 
-using namespace boosting;
 
+namespace boosting {
 
-DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(uint32 numElements)
-    : DenseLabelWiseStatisticVector(numElements, false) {
+    DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(uint32 numElements)
+        : DenseLabelWiseStatisticVector(numElements, false) {
 
-}
-
-DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(uint32 numElements, bool init)
-    : numElements_(numElements),
-      gradients_((float64*) (init ? calloc(numElements, sizeof(float64)) : malloc(numElements * sizeof(float64)))),
-      hessians_((float64*) (init ? calloc(numElements, sizeof(float64)) : malloc(numElements * sizeof(float64)))) {
-
-}
-
-DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(const DenseLabelWiseStatisticVector& vector)
-    : DenseLabelWiseStatisticVector(vector.numElements_) {
-    copyArray(vector.gradients_, gradients_, numElements_);
-    copyArray(vector.hessians_, hessians_, numElements_);
-}
-
-DenseLabelWiseStatisticVector::~DenseLabelWiseStatisticVector() {
-    free(gradients_);
-    free(hessians_);
-}
-
-DenseLabelWiseStatisticVector::gradient_iterator DenseLabelWiseStatisticVector::gradients_begin() {
-    return gradients_;
-}
-
-DenseLabelWiseStatisticVector::gradient_iterator DenseLabelWiseStatisticVector::gradients_end() {
-    return &gradients_[numElements_];
-}
-
-DenseLabelWiseStatisticVector::gradient_const_iterator DenseLabelWiseStatisticVector::gradients_cbegin() const {
-    return gradients_;
-}
-
-DenseLabelWiseStatisticVector::gradient_const_iterator DenseLabelWiseStatisticVector::gradients_cend() const {
-    return &gradients_[numElements_];
-}
-
-DenseLabelWiseStatisticVector::hessian_iterator DenseLabelWiseStatisticVector::hessians_begin() {
-    return hessians_;
-}
-
-DenseLabelWiseStatisticVector::hessian_iterator DenseLabelWiseStatisticVector::hessians_end() {
-    return &hessians_[numElements_];
-}
-
-DenseLabelWiseStatisticVector::hessian_const_iterator DenseLabelWiseStatisticVector::hessians_cbegin() const {
-    return hessians_;
-}
-
-DenseLabelWiseStatisticVector::hessian_const_iterator DenseLabelWiseStatisticVector::hessians_cend() const {
-    return &hessians_[numElements_];
-}
-
-uint32 DenseLabelWiseStatisticVector::getNumElements() const {
-    return numElements_;
-}
-
-void DenseLabelWiseStatisticVector::setAllToZero() {
-    setArrayToZeros(gradients_, numElements_);
-    setArrayToZeros(hessians_, numElements_);
-}
-
-void DenseLabelWiseStatisticVector::add(gradient_const_iterator gradientsBegin, gradient_const_iterator gradientsEnd,
-                                        hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd) {
-    std::copy(gradientsBegin, gradientsEnd, gradients_);
-    std::copy(hessiansBegin, hessiansEnd, hessians_);
-}
-
-void DenseLabelWiseStatisticVector::add(gradient_const_iterator gradientsBegin, gradient_const_iterator gradientsEnd,
-                                        hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd,
-                                        float64 weight) {
-    for (uint32 i = 0; i < numElements_; i++) {
-        gradients_[i] += (gradientsBegin[i] * weight);
-        hessians_[i] += (hessiansBegin[i] * weight);
     }
-}
 
-void DenseLabelWiseStatisticVector::subtract(gradient_const_iterator gradientsBegin,
-                                             gradient_const_iterator gradientsEnd,
-                                             hessian_const_iterator hessiansBegin,
-                                             hessian_const_iterator hessiansEnd, float64 weight) {
-    for (uint32 i = 0; i < numElements_; i++) {
-        gradients_[i] -= (gradientsBegin[i] * weight);
-        hessians_[i] -= (hessiansBegin[i] * weight);
+    DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(uint32 numElements, bool init)
+        : numElements_(numElements),
+          gradients_((float64*) (init ? calloc(numElements, sizeof(float64)) : malloc(numElements * sizeof(float64)))),
+          hessians_((float64*) (init ? calloc(numElements, sizeof(float64)) : malloc(numElements * sizeof(float64)))) {
+
     }
-}
 
-void DenseLabelWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
-                                                gradient_const_iterator gradientsEnd,
-                                                hessian_const_iterator hessiansBegin,
-                                                hessian_const_iterator hessiansEnd, const FullIndexVector& indices,
-                                                float64 weight) {
-    for (uint32 i = 0; i < numElements_; i++) {
-        gradients_[i] += (gradientsBegin[i] * weight);
-        hessians_[i] += (hessiansBegin[i] * weight);
+    DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(const DenseLabelWiseStatisticVector& vector)
+        : DenseLabelWiseStatisticVector(vector.numElements_) {
+        copyArray(vector.gradients_, gradients_, numElements_);
+        copyArray(vector.hessians_, hessians_, numElements_);
     }
-}
 
-void DenseLabelWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
-                                                gradient_const_iterator gradientsEnd,
-                                                hessian_const_iterator hessiansBegin,
-                                                hessian_const_iterator hessiansEnd, const PartialIndexVector& indices,
-                                                float64 weight) {
-    PartialIndexVector::const_iterator indexIterator = indices.cbegin();
-
-    for (uint32 i = 0; i < numElements_; i++) {
-        uint32 index = indexIterator[i];
-        gradients_[i] += (gradientsBegin[index] * weight);
-        hessians_[i] += (hessiansBegin[index] * weight);
+    DenseLabelWiseStatisticVector::~DenseLabelWiseStatisticVector() {
+        free(gradients_);
+        free(hessians_);
     }
-}
 
-void DenseLabelWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
-                                               gradient_const_iterator firstGradientsEnd,
-                                               hessian_const_iterator firstHessiansBegin,
-                                               hessian_const_iterator firstHessiansEnd,
-                                               const FullIndexVector& firstIndices,
-                                               gradient_const_iterator secondGradientsBegin,
-                                               gradient_const_iterator secondGradientsEnd,
-                                               hessian_const_iterator secondHessiansBegin,
-                                               hessian_const_iterator secondHessiansEnd) {
-    for (uint32 i = 0; i < numElements_; i++) {
-        gradients_[i] = firstGradientsBegin[i] - secondGradientsBegin[i];
-        hessians_[i] = firstHessiansBegin[i] - secondHessiansBegin[i];
+    DenseLabelWiseStatisticVector::gradient_iterator DenseLabelWiseStatisticVector::gradients_begin() {
+        return gradients_;
     }
-}
 
-void DenseLabelWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
-                                               gradient_const_iterator firstGradientsEnd,
-                                               hessian_const_iterator firstHessiansBegin,
-                                               hessian_const_iterator firstHessiansEnd,
-                                               const PartialIndexVector& firstIndices,
-                                               gradient_const_iterator secondGradientsBegin,
-                                               gradient_const_iterator secondGradientsEnd,
-                                               hessian_const_iterator secondHessiansBegin,
-                                               hessian_const_iterator secondHessiansEnd) {
-    PartialIndexVector::const_iterator firstIndexIterator = firstIndices.cbegin();
-
-    for (uint32 i = 0; i < numElements_; i++) {
-        uint32 firstIndex = firstIndexIterator[i];
-        gradients_[i] = firstGradientsBegin[firstIndex] - secondGradientsBegin[i];
-        hessians_[i] = firstHessiansBegin[firstIndex] - secondHessiansBegin[i];
+    DenseLabelWiseStatisticVector::gradient_iterator DenseLabelWiseStatisticVector::gradients_end() {
+        return &gradients_[numElements_];
     }
+
+    DenseLabelWiseStatisticVector::gradient_const_iterator DenseLabelWiseStatisticVector::gradients_cbegin() const {
+        return gradients_;
+    }
+
+    DenseLabelWiseStatisticVector::gradient_const_iterator DenseLabelWiseStatisticVector::gradients_cend() const {
+        return &gradients_[numElements_];
+    }
+
+    DenseLabelWiseStatisticVector::hessian_iterator DenseLabelWiseStatisticVector::hessians_begin() {
+        return hessians_;
+    }
+
+    DenseLabelWiseStatisticVector::hessian_iterator DenseLabelWiseStatisticVector::hessians_end() {
+        return &hessians_[numElements_];
+    }
+
+    DenseLabelWiseStatisticVector::hessian_const_iterator DenseLabelWiseStatisticVector::hessians_cbegin() const {
+        return hessians_;
+    }
+
+    DenseLabelWiseStatisticVector::hessian_const_iterator DenseLabelWiseStatisticVector::hessians_cend() const {
+        return &hessians_[numElements_];
+    }
+
+    uint32 DenseLabelWiseStatisticVector::getNumElements() const {
+        return numElements_;
+    }
+
+    void DenseLabelWiseStatisticVector::setAllToZero() {
+        setArrayToZeros(gradients_, numElements_);
+        setArrayToZeros(hessians_, numElements_);
+    }
+
+    void DenseLabelWiseStatisticVector::add(gradient_const_iterator gradientsBegin,
+                                            gradient_const_iterator gradientsEnd, hessian_const_iterator hessiansBegin,
+                                            hessian_const_iterator hessiansEnd) {
+        std::copy(gradientsBegin, gradientsEnd, gradients_);
+        std::copy(hessiansBegin, hessiansEnd, hessians_);
+    }
+
+    void DenseLabelWiseStatisticVector::add(gradient_const_iterator gradientsBegin,
+                                            gradient_const_iterator gradientsEnd, hessian_const_iterator hessiansBegin,
+                                            hessian_const_iterator hessiansEnd, float64 weight) {
+        for (uint32 i = 0; i < numElements_; i++) {
+            gradients_[i] += (gradientsBegin[i] * weight);
+            hessians_[i] += (hessiansBegin[i] * weight);
+        }
+    }
+
+    void DenseLabelWiseStatisticVector::subtract(gradient_const_iterator gradientsBegin,
+                                                 gradient_const_iterator gradientsEnd,
+                                                 hessian_const_iterator hessiansBegin,
+                                                 hessian_const_iterator hessiansEnd, float64 weight) {
+        for (uint32 i = 0; i < numElements_; i++) {
+            gradients_[i] -= (gradientsBegin[i] * weight);
+            hessians_[i] -= (hessiansBegin[i] * weight);
+        }
+    }
+
+    void DenseLabelWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
+                                                    gradient_const_iterator gradientsEnd,
+                                                    hessian_const_iterator hessiansBegin,
+                                                    hessian_const_iterator hessiansEnd, const FullIndexVector& indices,
+                                                    float64 weight) {
+        for (uint32 i = 0; i < numElements_; i++) {
+            gradients_[i] += (gradientsBegin[i] * weight);
+            hessians_[i] += (hessiansBegin[i] * weight);
+        }
+    }
+
+    void DenseLabelWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
+                                                    gradient_const_iterator gradientsEnd,
+                                                    hessian_const_iterator hessiansBegin,
+                                                    hessian_const_iterator hessiansEnd,
+                                                    const PartialIndexVector& indices, float64 weight) {
+        PartialIndexVector::const_iterator indexIterator = indices.cbegin();
+
+        for (uint32 i = 0; i < numElements_; i++) {
+            uint32 index = indexIterator[i];
+            gradients_[i] += (gradientsBegin[index] * weight);
+            hessians_[i] += (hessiansBegin[index] * weight);
+        }
+    }
+
+    void DenseLabelWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
+                                                   gradient_const_iterator firstGradientsEnd,
+                                                   hessian_const_iterator firstHessiansBegin,
+                                                   hessian_const_iterator firstHessiansEnd,
+                                                   const FullIndexVector& firstIndices,
+                                                   gradient_const_iterator secondGradientsBegin,
+                                                   gradient_const_iterator secondGradientsEnd,
+                                                   hessian_const_iterator secondHessiansBegin,
+                                                   hessian_const_iterator secondHessiansEnd) {
+        for (uint32 i = 0; i < numElements_; i++) {
+            gradients_[i] = firstGradientsBegin[i] - secondGradientsBegin[i];
+            hessians_[i] = firstHessiansBegin[i] - secondHessiansBegin[i];
+        }
+    }
+
+    void DenseLabelWiseStatisticVector::difference(gradient_const_iterator firstGradientsBegin,
+                                                   gradient_const_iterator firstGradientsEnd,
+                                                   hessian_const_iterator firstHessiansBegin,
+                                                   hessian_const_iterator firstHessiansEnd,
+                                                   const PartialIndexVector& firstIndices,
+                                                   gradient_const_iterator secondGradientsBegin,
+                                                   gradient_const_iterator secondGradientsEnd,
+                                                   hessian_const_iterator secondHessiansBegin,
+                                                   hessian_const_iterator secondHessiansEnd) {
+        PartialIndexVector::const_iterator firstIndexIterator = firstIndices.cbegin();
+
+        for (uint32 i = 0; i < numElements_; i++) {
+            uint32 firstIndex = firstIndexIterator[i];
+            gradients_[i] = firstGradientsBegin[firstIndex] - secondGradientsBegin[i];
+            hessians_[i] = firstHessiansBegin[firstIndex] - secondHessiansBegin[i];
+        }
+    }
+
 }

--- a/python/boomer/boosting/cpp/losses/loss_example_wise_logistic.cpp
+++ b/python/boomer/boosting/cpp/losses/loss_example_wise_logistic.cpp
@@ -1,98 +1,101 @@
 #include "loss_example_wise_logistic.h"
 #include "../math/math.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-void ExampleWiseLogisticLoss::updateExampleWiseStatistics(uint32 exampleIndex,
-                                                          const IRandomAccessLabelMatrix& labelMatrix,
-                                                          const DenseNumericMatrix<float64>& scoreMatrix,
-                                                          DenseExampleWiseStatisticMatrix& statisticMatrix) const {
-    // This implementation uses the so-called "exp-normalize-trick" to increase numerical stability (see, e.g.,
-    // https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/). It is based on rewriting a fraction of
-    // the form `exp(x_1) / (exp(x_1) + exp(x_2) + ...)` as `exp(x_1 - max) / (exp(x_1 - max) + exp(x_2 - max) + ...)`,
-    // where `max = max(x_1, x_2, ...)`. To be able to exploit this equivalence for the calculation of gradients and
-    // Hessians, they are calculated as products of fractions of the above form.
-    DenseNumericMatrix<float64>::const_iterator scoreIterator = scoreMatrix.row_cbegin(exampleIndex);
-    DenseExampleWiseStatisticMatrix::gradient_iterator gradientIterator =
-        statisticMatrix.gradients_row_begin(exampleIndex);
-    DenseExampleWiseStatisticMatrix::hessian_iterator hessianIterator =
-        statisticMatrix.hessians_row_begin(exampleIndex);
-    uint32 numLabels = labelMatrix.getNumCols();
+    void ExampleWiseLogisticLoss::updateExampleWiseStatistics(uint32 exampleIndex,
+                                                              const IRandomAccessLabelMatrix& labelMatrix,
+                                                              const DenseNumericMatrix<float64>& scoreMatrix,
+                                                              DenseExampleWiseStatisticMatrix& statisticMatrix) const {
+        // This implementation uses the so-called "exp-normalize-trick" to increase numerical stability (see, e.g.,
+        // https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/). It is based on rewriting a fraction
+        // of the form `exp(x_1) / (exp(x_1) + exp(x_2) + ...)` as
+        // `exp(x_1 - max) / (exp(x_1 - max) + exp(x_2 - max) + ...)`, where `max = max(x_1, x_2, ...)`. To be able to
+        // exploit this equivalence for the calculation of gradients and Hessians, they are calculated as products of
+        // fractions of the above form.
+        DenseNumericMatrix<float64>::const_iterator scoreIterator = scoreMatrix.row_cbegin(exampleIndex);
+        DenseExampleWiseStatisticMatrix::gradient_iterator gradientIterator =
+            statisticMatrix.gradients_row_begin(exampleIndex);
+        DenseExampleWiseStatisticMatrix::hessian_iterator hessianIterator =
+            statisticMatrix.hessians_row_begin(exampleIndex);
+        uint32 numLabels = labelMatrix.getNumCols();
 
-    // For each label `c`, calculate `x = -expectedScore_c * predictedScore_c` and find the largest and second largest
-    // values (that must be greater than 0, because `exp(1) = 0`) among all of them...
-    float64 max = 0;  // The largest value
-    float64 max2 = 0;  // The second largest value
+        // For each label `c`, calculate `x = -expectedScore_c * predictedScore_c` and find the largest and second
+        // largest values (that must be greater than 0, because `exp(1) = 0`) among all of them...
+        float64 max = 0;  // The largest value
+        float64 max2 = 0;  // The second largest value
 
-    for (uint32 c = 0; c < numLabels; c++) {
-        float64 predictedScore = scoreIterator[c];
-        uint32 trueLabel = labelMatrix.getValue(exampleIndex, c);
-        float64 x = trueLabel ? -predictedScore : predictedScore;
-        gradientIterator[c] = x;  // Temporarily store `x` in the array of gradients
+        for (uint32 c = 0; c < numLabels; c++) {
+            float64 predictedScore = scoreIterator[c];
+            uint32 trueLabel = labelMatrix.getValue(exampleIndex, c);
+            float64 x = trueLabel ? -predictedScore : predictedScore;
+            gradientIterator[c] = x;  // Temporarily store `x` in the array of gradients
 
-        if (x > max) {
-            max2 = max;
-            max = x;
-        } else if (x > max2) {
-            max2 = x;
+            if (x > max) {
+                max2 = max;
+                max = x;
+            } else if (x > max2) {
+                max2 = x;
+            }
         }
-    }
 
-    // In the following, the largest value the exponential function may be applied to is `max + max2`, which happens
-    // when Hessians that belong to the upper triangle of the Hessian matrix are calculated...
-    max2 += max;
+        // In the following, the largest value the exponential function may be applied to is `max + max2`, which happens
+        // when Hessians that belong to the upper triangle of the Hessian matrix are calculated...
+        max2 += max;
 
-    // Calculate `sumExp = exp(0 - max) + exp(x_1 - max) + exp(x_2 - max) + ...`
-    float64 sumExp = std::exp(0.0 - max);
-    float64 zeroExp = std::exp(0.0 - max2);
-    float64 sumExp2 = zeroExp;
+        // Calculate `sumExp = exp(0 - max) + exp(x_1 - max) + exp(x_2 - max) + ...`
+        float64 sumExp = std::exp(0.0 - max);
+        float64 zeroExp = std::exp(0.0 - max2);
+        float64 sumExp2 = zeroExp;
 
-    for (uint32 c = 0; c < numLabels; c++) {
-        float64 x = gradientIterator[c];
-        sumExp += std::exp(x - max);
-        sumExp2 += std::exp(x - max2);
-    }
+        for (uint32 c = 0; c < numLabels; c++) {
+            float64 x = gradientIterator[c];
+            sumExp += std::exp(x - max);
+            sumExp2 += std::exp(x - max2);
+        }
 
-    // Calculate `zeroExp / sumExp2` (it is needed multiple times for calculating Hessians that belong to the upper
-    // triangle of the Hessian matrix)...
-    zeroExp = divideOrZero<float64>(zeroExp, sumExp2);
+        // Calculate `zeroExp / sumExp2` (it is needed multiple times for calculating Hessians that belong to the upper
+        // triangle of the Hessian matrix)...
+        zeroExp = divideOrZero<float64>(zeroExp, sumExp2);
 
-    // Calculate the gradients and Hessians by traversing the labels in reverse order (to ensure that the values that
-    // have temporarily been stored in the array of gradients have not been overwritten yet)
-    intp i = triangularNumber(numLabels) - 1;
+        // Calculate the gradients and Hessians by traversing the labels in reverse order (to ensure that the values
+        // that have temporarily been stored in the array of gradients have not been overwritten yet)
+        intp i = triangularNumber(numLabels) - 1;
 
-    for (intp c = numLabels - 1; c >= 0; c--) {
-        uint8 trueLabel = labelMatrix.getValue(exampleIndex, c);
-        float64 invertedExpectedScore = trueLabel ? -1 : 1;
-        float64 x = gradientIterator[c];
+        for (intp c = numLabels - 1; c >= 0; c--) {
+            uint8 trueLabel = labelMatrix.getValue(exampleIndex, c);
+            float64 invertedExpectedScore = trueLabel ? -1 : 1;
+            float64 x = gradientIterator[c];
 
-        // Calculate the gradient that corresponds to the current label. The gradient calculates as
-        // `-expectedScore_c * exp(x_c) / (1 + exp(x_1) + exp(x_2) + ...)`, which can be rewritten as
-        // `-expectedScore_c * (exp(x_c - max) / sumExp)`
-        float64 xExp = std::exp(x - max);
-        float64 tmp = divideOrZero<float64>(xExp, sumExp);
-        float64 gradient = invertedExpectedScore * tmp;
+            // Calculate the gradient that corresponds to the current label. The gradient calculates as
+            // `-expectedScore_c * exp(x_c) / (1 + exp(x_1) + exp(x_2) + ...)`, which can be rewritten as
+            // `-expectedScore_c * (exp(x_c - max) / sumExp)`
+            float64 xExp = std::exp(x - max);
+            float64 tmp = divideOrZero<float64>(xExp, sumExp);
+            float64 gradient = invertedExpectedScore * tmp;
 
-        // Calculate the Hessian on the diagonal of the Hessian matrix that corresponds to the current label. Such
-        // Hessian calculates as `exp(x_c) * (1 + exp(x_1) + exp(x_2) + ...) / (1 + exp(x_1) + exp(x_2) + ...)^2`, or as
-        // `(exp(x_c - max) / sumExp) * (1 - exp(x_c - max) / sumExp)`
-        hessianIterator[i] = tmp * (1 - tmp);
-        i--;
-
-        // Calculate the Hessians that belong to the part of the Hessian matrix' upper triangle that corresponds to the
-        // current label. Such Hessian calculates as
-        // `-expectedScore_c * expectedScore_r * exp(x_c + x_r) / (1 + exp(x_1) + exp(x_2) + ...)^2`, or equivalently as
-        // `-expectedScore_c * expectedScore_r * (exp(x_c + x_r - max) / sumExp) * (exp(0 - max) / sumExp)`
-        for (intp r = c - 1; r >= 0; r--) {
-            uint32 trueLabel2 = labelMatrix.getValue(exampleIndex, r);
-            float64 expectedScore2 = trueLabel2 ? 1 : -1;
-            float64 x2 = gradientIterator[r];
-            hessianIterator[i] = invertedExpectedScore * expectedScore2
-                                 * divideOrZero<float64>(std::exp(x + x2 - max2), sumExp2) * zeroExp;
+            // Calculate the Hessian on the diagonal of the Hessian matrix that corresponds to the current label. Such
+            // Hessian calculates as `exp(x_c) * (1 + exp(x_1) + exp(x_2) + ...) / (1 + exp(x_1) + exp(x_2) + ...)^2`,
+            // or as `(exp(x_c - max) / sumExp) * (1 - exp(x_c - max) / sumExp)`
+            hessianIterator[i] = tmp * (1 - tmp);
             i--;
-        }
 
-        gradientIterator[c] = gradient;
+            // Calculate the Hessians that belong to the part of the Hessian matrix' upper triangle that corresponds to
+            // the current label. Such Hessian calculates as
+            // `-expectedScore_c * expectedScore_r * exp(x_c + x_r) / (1 + exp(x_1) + exp(x_2) + ...)^2`, or as
+            // `-expectedScore_c * expectedScore_r * (exp(x_c + x_r - max) / sumExp) * (exp(0 - max) / sumExp)`
+            for (intp r = c - 1; r >= 0; r--) {
+                uint32 trueLabel2 = labelMatrix.getValue(exampleIndex, r);
+                float64 expectedScore2 = trueLabel2 ? 1 : -1;
+                float64 x2 = gradientIterator[r];
+                hessianIterator[i] = invertedExpectedScore * expectedScore2
+                                     * divideOrZero<float64>(std::exp(x + x2 - max2), sumExp2) * zeroExp;
+                i--;
+            }
+
+            gradientIterator[c] = gradient;
+        }
     }
+
 }

--- a/python/boomer/boosting/cpp/losses/loss_label_wise_logistic.cpp
+++ b/python/boomer/boosting/cpp/losses/loss_label_wise_logistic.cpp
@@ -1,54 +1,57 @@
 #include "loss_label_wise_logistic.h"
 #include <cmath>
 
-using namespace boosting;
 
+namespace boosting {
 
-/**
- * Calculates and returns the logistic function `1 / (1 + exp(-x))`, given a specific value `x`.
- *
- * This implementation exploits the identity `1 / (1 + exp(-x)) = exp(x) / (1 + exp(x))` to increase numerical stability
- * (see, e.g., section "Numerically stable sigmoid function" in
- * https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/).
- *
- * @param x The value `x`
- * @return  The value that has been calculated
- */
-static inline float64 logisticFunction(float64 x) {
-    if (x >= 0) {
-        float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
-        return 1 / (1 + exponential);
-    } else {
-        float64 exponential = std::exp(x);  // Evaluates to 0 for large x, resulting in 0 ultimately
-        return exponential / (1 + exponential);
+    /**
+     * Calculates and returns the logistic function `1 / (1 + exp(-x))`, given a specific value `x`.
+     *
+     * This implementation exploits the identity `1 / (1 + exp(-x)) = exp(x) / (1 + exp(x))` to increase numerical
+     * stability (see, e.g., section "Numerically stable sigmoid function" in
+     * https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/).
+     *
+     * @param x The value `x`
+     * @return  The value that has been calculated
+     */
+    static inline float64 logisticFunction(float64 x) {
+        if (x >= 0) {
+            float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
+            return 1 / (1 + exponential);
+        } else {
+            float64 exponential = std::exp(x);  // Evaluates to 0 for large x, resulting in 0 ultimately
+            return exponential / (1 + exponential);
+        }
     }
-}
 
-/**
- * Calculates and returns the function `1 / (1 + exp(-x))^2 = exp(x)^2 / (1 + exp(x))^2`, given a specific value `x`.
- *
- * @param x The value `x`
- * @return  The value that has been calculated
- */
-static inline float64 squaredLogisticFunction(float64 x) {
-    if (x >= 0) {
-        float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
-        return 1 / ((exponential + 1) * (exponential + 1));
-    } else {
-        float64 exponential = std::exp(x);  // Evaluates to 0 for large x, resulting in 0 ultimately
-        return (exponential * exponential) / ((exponential + 1) * (exponential + 1));
+    /**
+     * Calculates and returns the function `1 / (1 + exp(-x))^2 = exp(x)^2 / (1 + exp(x))^2`, given a specific value
+     * `x`.
+     *
+     * @param x The value `x`
+     * @return  The value that has been calculated
+     */
+    static inline float64 squaredLogisticFunction(float64 x) {
+        if (x >= 0) {
+            float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
+            return 1 / ((exponential + 1) * (exponential + 1));
+        } else {
+            float64 exponential = std::exp(x);  // Evaluates to 0 for large x, resulting in 0 ultimately
+            return (exponential * exponential) / ((exponential + 1) * (exponential + 1));
+        }
     }
-}
 
-void LabelWiseLogisticLoss::updateGradientAndHessian(DenseVector<float64>::iterator gradient,
-                                                     DenseVector<float64>::iterator hessian, bool trueLabel,
-                                                     float64 predictedScore) const {
-    // The gradient calculates as `-expectedScore / (1 + exp(expectedScore * predictedScore))`, or as
-    // `1 / (1 + exp(-predictedScore)) - 1` if `trueLabel == true`, `1 / (1 + exp(-predictedScore))`, otherwise...
-    float64 logistic = logisticFunction(predictedScore);
-    *gradient = trueLabel ? logistic - 1.0 : logistic;
+    void LabelWiseLogisticLoss::updateGradientAndHessian(DenseVector<float64>::iterator gradient,
+                                                         DenseVector<float64>::iterator hessian, bool trueLabel,
+                                                         float64 predictedScore) const {
+        // The gradient computes as `-expectedScore / (1 + exp(expectedScore * predictedScore))`, or as
+        // `1 / (1 + exp(-predictedScore)) - 1` if `trueLabel == true`, `1 / (1 + exp(-predictedScore))`, otherwise...
+        float64 logistic = logisticFunction(predictedScore);
+        *gradient = trueLabel ? logistic - 1.0 : logistic;
 
-    // The Hessian calculates as `exp(expectedScore * predictedScore) / (1 + exp(expectedScore * predictedScore))^2`,
-    // or as `1 / (1 + exp(expectedScore * predictedScore)) - 1 / (1 + exp(expectedScore * predictedScore))^2`
-    *hessian = logistic - squaredLogisticFunction(predictedScore);
+        // The Hessian computes as `exp(expectedScore * predictedScore) / (1 + exp(expectedScore * predictedScore))^2`,
+        // or as `1 / (1 + exp(expectedScore * predictedScore)) - 1 / (1 + exp(expectedScore * predictedScore))^2`
+        *hessian = logistic - squaredLogisticFunction(predictedScore);
+    }
+
 }

--- a/python/boomer/boosting/cpp/losses/loss_label_wise_squared_error.cpp
+++ b/python/boomer/boosting/cpp/losses/loss_label_wise_squared_error.cpp
@@ -1,12 +1,14 @@
 #include "loss_label_wise_squared_error.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-void LabelWiseSquaredErrorLoss::updateGradientAndHessian(DenseVector<float64>::iterator gradient,
-                                                         DenseVector<float64>::iterator hessian, bool trueLabel,
-                                                         float64 predictedScore) const {
-    float64 expectedScore = trueLabel ? 1 : -1;
-    *gradient = (2 * predictedScore) - (2 * expectedScore);
-    *hessian = 2;
+    void LabelWiseSquaredErrorLoss::updateGradientAndHessian(DenseVector<float64>::iterator gradient,
+                                                             DenseVector<float64>::iterator hessian, bool trueLabel,
+                                                             float64 predictedScore) const {
+        float64 expectedScore = trueLabel ? 1 : -1;
+        *gradient = (2 * predictedScore) - (2 * expectedScore);
+        *hessian = 2;
+    }
+
 }

--- a/python/boomer/boosting/cpp/math/blas.cpp
+++ b/python/boomer/boosting/cpp/math/blas.cpp
@@ -1,29 +1,31 @@
 #include "blas.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-Blas::Blas(ddot_t ddotFunction, dspmv_t dspmvFunction)
-    : ddotFunction_(ddotFunction), dspmvFunction_(dspmvFunction) {
+    Blas::Blas(ddot_t ddotFunction, dspmv_t dspmvFunction)
+        : ddotFunction_(ddotFunction), dspmvFunction_(dspmvFunction) {
 
-}
+    }
 
-float64 Blas::ddot(float64* x, float64* y, int n) {
-    // Storage spacing between the elements of the arrays x and y
-    int inc = 1;
-    // Invoke the DDOT routine...
-    return ddotFunction_(&n, x, &inc, y, &inc);
-}
+    float64 Blas::ddot(float64* x, float64* y, int n) {
+        // Storage spacing between the elements of the arrays x and y
+        int inc = 1;
+        // Invoke the DDOT routine...
+        return ddotFunction_(&n, x, &inc, y, &inc);
+    }
 
-void Blas::dspmv(float64* a, float64* x, float64* output, int n) {
-    // "U" if the upper-right triangle of A should be used, "L" if the lower-left triangle should be used
-    char* uplo = "U";
-    // A scalar to be multiplied with the matrix A
-    double alpha = 1;
-    // The increment for the elements of x and y
-    int inc = 1;
-    // A scalar to be multiplied with vector y
-    double beta = 0;
-    // Invoke the DSPMV routine...
-    dspmvFunction_(uplo, &n, &alpha, a, x, &inc, &beta, output, &inc);
+    void Blas::dspmv(float64* a, float64* x, float64* output, int n) {
+        // "U" if the upper-right triangle of A should be used, "L" if the lower-left triangle should be used
+        char* uplo = "U";
+        // A scalar to be multiplied with the matrix A
+        double alpha = 1;
+        // The increment for the elements of x and y
+        int inc = 1;
+        // A scalar to be multiplied with vector y
+        double beta = 0;
+        // Invoke the DSPMV routine...
+        dspmvFunction_(uplo, &n, &alpha, a, x, &inc, &beta, output, &inc);
+    }
+
 }

--- a/python/boomer/boosting/cpp/math/lapack.cpp
+++ b/python/boomer/boosting/cpp/math/lapack.cpp
@@ -2,50 +2,52 @@
 #include <string>
 #include <stdexcept>
 
-using namespace boosting;
 
+namespace boosting {
 
-Lapack::Lapack(dsysv_t dsysvFunction)
-    : dsysvFunction_(dsysvFunction) {
+    Lapack::Lapack(dsysv_t dsysvFunction)
+        : dsysvFunction_(dsysvFunction) {
 
-}
-
-int Lapack::queryDsysvLworkParameter(float64* tmpArray1, float64* output, int n) {
-    // "U" if the upper-right triangle of A should be used, "L" if the lower-left triangle should be used
-    char* uplo = "U";
-    // The number of right-hand sides, i.e, the number of columns of the matrix B
-    int nrhs = 1;
-    // Set "lwork" parameter to -1, which indicates that the optimal value should be queried
-    int lwork = -1;
-    // Variable to hold the queried value
-    double worksize;
-    // Variable to hold the result of the solver. Will be 0 when terminated successfully, unlike 0 otherwise
-    int info;
-
-    // Query the optimal value for the "lwork" parameter...
-    dsysvFunction_(uplo, &n, &nrhs, tmpArray1, &n, (int*) 0, output, &n, &worksize, &lwork, &info);
-
-    if (info != 0) {
-        throw std::runtime_error(
-            std::string("DSYSV terminated with non-zero info code when querying the optimal lwork parameter: "
-            + std::to_string(info)));
     }
 
-    return (int) worksize;
-}
+    int Lapack::queryDsysvLworkParameter(float64* tmpArray1, float64* output, int n) {
+        // "U" if the upper-right triangle of A should be used, "L" if the lower-left triangle should be used
+        char* uplo = "U";
+        // The number of right-hand sides, i.e, the number of columns of the matrix B
+        int nrhs = 1;
+        // Set "lwork" parameter to -1, which indicates that the optimal value should be queried
+        int lwork = -1;
+        // Variable to hold the queried value
+        double worksize;
+        // Variable to hold the result of the solver. Will be 0 when terminated successfully, unlike 0 otherwise
+        int info;
 
-void Lapack::dsysv(float64* tmpArray1, int* tmpArray2, double* tmpArray3, float64* output, int n, int lwork) {
-    // "U" if the upper-right triangle of A should be used, "L" if the lower-left triangle should be used
-    char* uplo = "U";
-    // The number of right-hand sides, i.e, the number of columns of the matrix B
-    int nrhs = 1;
-    // Variable to hold the result of the solver. Will be 0 when terminated successfully, unlike 0 otherwise
-    int info;
+        // Query the optimal value for the "lwork" parameter...
+        dsysvFunction_(uplo, &n, &nrhs, tmpArray1, &n, (int*) 0, output, &n, &worksize, &lwork, &info);
 
-    // Run the DSYSV solver...
-    dsysvFunction_(uplo, &n, &nrhs, tmpArray1, &n, tmpArray2, output, &n, tmpArray3, &lwork, &info);
+        if (info != 0) {
+            throw std::runtime_error(
+                std::string("DSYSV terminated with non-zero info code when querying the optimal lwork parameter: "
+                + std::to_string(info)));
+        }
 
-    if (info != 0) {
-        throw std::runtime_error(std::string("DSYSV terminated with non-zero info code: " + std::to_string(info)));
+        return (int) worksize;
     }
+
+    void Lapack::dsysv(float64* tmpArray1, int* tmpArray2, double* tmpArray3, float64* output, int n, int lwork) {
+        // "U" if the upper-right triangle of A should be used, "L" if the lower-left triangle should be used
+        char* uplo = "U";
+        // The number of right-hand sides, i.e, the number of columns of the matrix B
+        int nrhs = 1;
+        // Variable to hold the result of the solver. Will be 0 when terminated successfully, unlike 0 otherwise
+        int info;
+
+        // Run the DSYSV solver...
+        dsysvFunction_(uplo, &n, &nrhs, tmpArray1, &n, tmpArray2, output, &n, tmpArray3, &lwork, &info);
+
+        if (info != 0) {
+            throw std::runtime_error(std::string("DSYSV terminated with non-zero info code: " + std::to_string(info)));
+        }
+    }
+
 }

--- a/python/boomer/boosting/cpp/model/rule_list.cpp
+++ b/python/boomer/boosting/cpp/model/rule_list.cpp
@@ -2,22 +2,24 @@
 #include "../../../common/cpp/model/body_empty.h"
 #include "../../../common/cpp/model/body_conjunctive.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-RuleListBuilder::RuleListBuilder()
-    : modelPtr_(std::make_unique<RuleModel>()) {
+    RuleListBuilder::RuleListBuilder()
+        : modelPtr_(std::make_unique<RuleModel>()) {
 
-}
+    }
 
-void RuleListBuilder::setDefaultRule(const AbstractPrediction& prediction) {
-    modelPtr_->addRule(std::make_unique<EmptyBody>(), prediction.toHead());
-}
+    void RuleListBuilder::setDefaultRule(const AbstractPrediction& prediction) {
+        modelPtr_->addRule(std::make_unique<EmptyBody>(), prediction.toHead());
+    }
 
-void RuleListBuilder::addRule(const ConditionList& conditions, const AbstractPrediction& prediction) {
-    modelPtr_->addRule(std::make_unique<ConjunctiveBody>(conditions), prediction.toHead());
-}
+    void RuleListBuilder::addRule(const ConditionList& conditions, const AbstractPrediction& prediction) {
+        modelPtr_->addRule(std::make_unique<ConjunctiveBody>(conditions), prediction.toHead());
+    }
 
-std::unique_ptr<RuleModel> RuleListBuilder::build() {
-    return std::move(modelPtr_);
+    std::unique_ptr<RuleModel> RuleListBuilder::build() {
+        return std::move(modelPtr_);
+    }
+
 }

--- a/python/boomer/boosting/cpp/output/predictor_classification.cpp
+++ b/python/boomer/boosting/cpp/output/predictor_classification.cpp
@@ -2,118 +2,120 @@
 #include "../../../common/cpp/model/head_full.h"
 #include "../../../common/cpp/model/head_partial.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-static inline void applyFullHead(const FullHead& head, CContiguousView<float64>::iterator begin,
-                                 CContiguousView<float64>::iterator end) {
-    FullHead::score_const_iterator iterator = head.scores_cbegin();
-    uint32 numElements = head.getNumElements();
+    static inline void applyFullHead(const FullHead& head, CContiguousView<float64>::iterator begin,
+                                     CContiguousView<float64>::iterator end) {
+        FullHead::score_const_iterator iterator = head.scores_cbegin();
+        uint32 numElements = head.getNumElements();
 
-    for (uint32 i = 0; i < numElements; i++) {
-        begin[i] += iterator[i];
+        for (uint32 i = 0; i < numElements; i++) {
+            begin[i] += iterator[i];
+        }
     }
-}
 
-static inline void applyPartialHead(const PartialHead& head, CContiguousView<float64>::iterator begin,
-                                    CContiguousView<float64>::iterator end) {
-    PartialHead::score_const_iterator scoreIterator = head.scores_cbegin();
-    PartialHead::index_const_iterator indexIterator = head.indices_cbegin();
-    uint32 numElements = head.getNumElements();
+    static inline void applyPartialHead(const PartialHead& head, CContiguousView<float64>::iterator begin,
+                                        CContiguousView<float64>::iterator end) {
+        PartialHead::score_const_iterator scoreIterator = head.scores_cbegin();
+        PartialHead::index_const_iterator indexIterator = head.indices_cbegin();
+        uint32 numElements = head.getNumElements();
 
-    for (uint32 i = 0; i < numElements; i++) {
-        uint32 index = indexIterator[i];
-        begin[index] += scoreIterator[i];
+        for (uint32 i = 0; i < numElements; i++) {
+            uint32 index = indexIterator[i];
+            begin[index] += scoreIterator[i];
+        }
     }
-}
 
-static inline void applyHead(const IHead& head, CContiguousView<float64>& scoreMatrix, uint32 row) {
-    auto fullHeadVisitor = [&, row](const FullHead& head) {
-        applyFullHead(head, scoreMatrix.row_begin(row), scoreMatrix.row_end(row));
-    };
-    auto partialHeadVisitor = [&, row](const PartialHead& head) {
-        applyPartialHead(head, scoreMatrix.row_begin(row), scoreMatrix.row_end(row));
-    };
-    head.visit(fullHeadVisitor, partialHeadVisitor);
-}
+    static inline void applyHead(const IHead& head, CContiguousView<float64>& scoreMatrix, uint32 row) {
+        auto fullHeadVisitor = [&, row](const FullHead& head) {
+            applyFullHead(head, scoreMatrix.row_begin(row), scoreMatrix.row_end(row));
+        };
+        auto partialHeadVisitor = [&, row](const PartialHead& head) {
+            applyPartialHead(head, scoreMatrix.row_begin(row), scoreMatrix.row_end(row));
+        };
+        head.visit(fullHeadVisitor, partialHeadVisitor);
+    }
 
-static inline void aggregatePredictions(const CContiguousFeatureMatrix& featureMatrix,
-                                        CContiguousView<float64>& scoreMatrix, const RuleModel& model) {
-    uint32 numExamples = featureMatrix.getNumRows();
+    static inline void aggregatePredictions(const CContiguousFeatureMatrix& featureMatrix,
+                                            CContiguousView<float64>& scoreMatrix, const RuleModel& model) {
+        uint32 numExamples = featureMatrix.getNumRows();
 
-    for (auto it = model.cbegin(); it != model.cend(); it++) {
-        const Rule& rule = *it;
-        const IBody& body = rule.getBody();
-        const IHead& head = rule.getHead();
+        for (auto it = model.cbegin(); it != model.cend(); it++) {
+            const Rule& rule = *it;
+            const IBody& body = rule.getBody();
+            const IHead& head = rule.getHead();
 
-        for (uint32 i = 0; i < numExamples; i++) {
-            if (body.covers(featureMatrix.row_cbegin(i), featureMatrix.row_cend(i))) {
-                applyHead(head, scoreMatrix, i);
+            for (uint32 i = 0; i < numExamples; i++) {
+                if (body.covers(featureMatrix.row_cbegin(i), featureMatrix.row_cend(i))) {
+                    applyHead(head, scoreMatrix, i);
+                }
             }
         }
     }
-}
 
-static inline void aggregatePredictions(const CsrFeatureMatrix& featureMatrix, CContiguousView<float64>& scoreMatrix,
-                                        const RuleModel& model) {
-    uint32 numExamples = featureMatrix.getNumRows();
-    uint32 numFeatures = featureMatrix.getNumCols();
-    float32 tmpArray1[numFeatures];
-    uint32 tmpArray2[numFeatures] = {};
-    uint32 n = 1;
+    static inline void aggregatePredictions(const CsrFeatureMatrix& featureMatrix,
+                                            CContiguousView<float64>& scoreMatrix, const RuleModel& model) {
+        uint32 numExamples = featureMatrix.getNumRows();
+        uint32 numFeatures = featureMatrix.getNumCols();
+        float32 tmpArray1[numFeatures];
+        uint32 tmpArray2[numFeatures] = {};
+        uint32 n = 1;
 
-    for (auto it = model.cbegin(); it != model.cend(); it++) {
-        const Rule& rule = *it;
-        const IBody& body = rule.getBody();
-        const IHead& head = rule.getHead();
+        for (auto it = model.cbegin(); it != model.cend(); it++) {
+            const Rule& rule = *it;
+            const IBody& body = rule.getBody();
+            const IHead& head = rule.getHead();
 
-        for (uint32 i = 0; i < numExamples; i++) {
-            if (body.covers(featureMatrix.row_indices_cbegin(i), featureMatrix.row_indices_cend(i),
-                            featureMatrix.row_values_cbegin(i), featureMatrix.row_values_cend(i), &tmpArray1[0],
-                            &tmpArray2[0], n)) {
-                applyHead(head, scoreMatrix, i);
+            for (uint32 i = 0; i < numExamples; i++) {
+                if (body.covers(featureMatrix.row_indices_cbegin(i), featureMatrix.row_indices_cend(i),
+                                featureMatrix.row_values_cbegin(i), featureMatrix.row_values_cend(i), &tmpArray1[0],
+                                &tmpArray2[0], n)) {
+                    applyHead(head, scoreMatrix, i);
+                }
+
+                n++;
             }
-
-            n++;
         }
     }
-}
 
-template<class I, class O>
-static inline void applyThreshold(const CContiguousView<I>& originalMatrix, CContiguousView<O>& transformedMatrix,
-                                  I threshold) {
-    typename CContiguousView<I>::const_iterator originalIterator = originalMatrix.row_cbegin(0);
-    typename CContiguousView<O>::iterator transformedIterator = transformedMatrix.row_begin(0);
-    uint32 numElements = originalMatrix.getNumRows() * originalMatrix.getNumCols();
+    template<class I, class O>
+    static inline void applyThreshold(const CContiguousView<I>& originalMatrix, CContiguousView<O>& transformedMatrix,
+                                      I threshold) {
+        typename CContiguousView<I>::const_iterator originalIterator = originalMatrix.row_cbegin(0);
+        typename CContiguousView<O>::iterator transformedIterator = transformedMatrix.row_begin(0);
+        uint32 numElements = originalMatrix.getNumRows() * originalMatrix.getNumCols();
 
-    for (uint32 i = 0; i < numElements; i++) {
-        I originalValue = originalIterator[i];
-        O transformedValue = originalValue > threshold ? 1 : 0;
-        transformedIterator[i] = transformedValue;
+        for (uint32 i = 0; i < numElements; i++) {
+            I originalValue = originalIterator[i];
+            O transformedValue = originalValue > threshold ? 1 : 0;
+            transformedIterator[i] = transformedValue;
+        }
     }
-}
 
-ClassificationPredictor::ClassificationPredictor(float64 threshold)
-    : threshold_(threshold) {
+    ClassificationPredictor::ClassificationPredictor(float64 threshold)
+        : threshold_(threshold) {
 
-}
+    }
 
-void ClassificationPredictor::predict(const CContiguousFeatureMatrix& featureMatrix,
-                                      CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
-    uint32 numExamples = predictionMatrix.getNumRows();
-    uint32 numLabels = predictionMatrix.getNumCols();
-    float64 scores[numExamples * numLabels] = {};
-    CContiguousView<float64> scoreMatrix(numExamples, numLabels, &scores[0]);
-    aggregatePredictions(featureMatrix, scoreMatrix, model);
-    applyThreshold<float64, uint8>(scoreMatrix, predictionMatrix, threshold_);
-}
+    void ClassificationPredictor::predict(const CContiguousFeatureMatrix& featureMatrix,
+                                          CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
+        uint32 numExamples = predictionMatrix.getNumRows();
+        uint32 numLabels = predictionMatrix.getNumCols();
+        float64 scores[numExamples * numLabels] = {};
+        CContiguousView<float64> scoreMatrix(numExamples, numLabels, &scores[0]);
+        aggregatePredictions(featureMatrix, scoreMatrix, model);
+        applyThreshold<float64, uint8>(scoreMatrix, predictionMatrix, threshold_);
+    }
 
-void ClassificationPredictor::predict(const CsrFeatureMatrix& featureMatrix,
-                                      CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
-    uint32 numExamples = predictionMatrix.getNumRows();
-    uint32 numLabels = predictionMatrix.getNumCols();
-    float64 scores[numExamples * numLabels] = {};
-    CContiguousView<float64> scoreMatrix(numExamples, numLabels, &scores[0]);
-    aggregatePredictions(featureMatrix, scoreMatrix, model);
-    applyThreshold<float64, uint8>(scoreMatrix, predictionMatrix, threshold_);
+    void ClassificationPredictor::predict(const CsrFeatureMatrix& featureMatrix,
+                                          CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
+        uint32 numExamples = predictionMatrix.getNumRows();
+        uint32 numLabels = predictionMatrix.getNumCols();
+        float64 scores[numExamples * numLabels] = {};
+        CContiguousView<float64> scoreMatrix(numExamples, numLabels, &scores[0]);
+        aggregatePredictions(featureMatrix, scoreMatrix, model);
+        applyThreshold<float64, uint8>(scoreMatrix, predictionMatrix, threshold_);
+    }
+
 }

--- a/python/boomer/boosting/cpp/post_processing/shrinkage_constant.cpp
+++ b/python/boomer/boosting/cpp/post_processing/shrinkage_constant.cpp
@@ -1,18 +1,20 @@
 #include "shrinkage_constant.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-ConstantShrinkage::ConstantShrinkage(float64 shrinkage)
-    : shrinkage_(shrinkage) {
+    ConstantShrinkage::ConstantShrinkage(float64 shrinkage)
+        : shrinkage_(shrinkage) {
 
-}
-
-void ConstantShrinkage::postProcess(AbstractPrediction& prediction) const {
-    uint32 numElements = prediction.getNumElements();
-    AbstractPrediction::score_iterator iterator = prediction.scores_begin();
-
-    for (uint32 i = 0; i < numElements; i++) {
-        iterator[i] *= shrinkage_;
     }
+
+    void ConstantShrinkage::postProcess(AbstractPrediction& prediction) const {
+        uint32 numElements = prediction.getNumElements();
+        AbstractPrediction::score_iterator iterator = prediction.scores_begin();
+
+        for (uint32 i = 0; i < numElements; i++) {
+            iterator[i] *= shrinkage_;
+        }
+    }
+
 }

--- a/python/boomer/boosting/cpp/rule_evaluation/rule_evaluation_example_wise_regularized.cpp
+++ b/python/boomer/boosting/cpp/rule_evaluation/rule_evaluation_example_wise_regularized.cpp
@@ -4,125 +4,132 @@
 #include "../../../common/cpp/rule_evaluation/score_vector_label_wise_dense.h"
 #include "../math/math.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-/**
- * Adds a specific L2 regularization weight to the diagonal of a coefficient matrix.
- *
- * @param output                    A pointer to an array of type `float64`, shape `(n, n)` that stores the coefficients
- * @param n                         The number of rows and columns in the coefficient matrix
- * @param l2RegularizationWeight    The L2 regularization weight to be added
- */
-static inline void addRegularizationWeight(float64* output, uint32 n, float64 l2RegularizationWeight) {
-    for (uint32 i = 0; i < n; i++) {
-        output[(i * n) + i] += l2RegularizationWeight;
+    /**
+     * Adds a specific L2 regularization weight to the diagonal of a coefficient matrix.
+     *
+     * @param output                    A pointer to an array of type `float64`, shape `(n, n)` that stores the
+     *                                  coefficients
+     * @param n                         The number of rows and columns in the coefficient matrix
+     * @param l2RegularizationWeight    The L2 regularization weight to be added
+     */
+    static inline void addRegularizationWeight(float64* output, uint32 n, float64 l2RegularizationWeight) {
+        for (uint32 i = 0; i < n; i++) {
+            output[(i * n) + i] += l2RegularizationWeight;
+        }
     }
-}
 
-/**
- * Allows to calculate the predictions of rules, as well as corresponding quality scores, based on the gradients and
- * Hessians that have been calculated according to a loss function that is applied example wise using L2 regularization.
- *
- * @tparam T The type of the vector that provides access to the labels for which predictions should be calculated
- */
-template<class T>
-class RegularizedExampleWiseRuleEvaluation final : public AbstractExampleWiseRuleEvaluation<T> {
+    /**
+     * Allows to calculate the predictions of rules, as well as corresponding quality scores, based on the gradients and
+     * Hessians that have been calculated according to a loss function that is applied example wise using L2
+     * regularization.
+     *
+     * @tparam T The type of the vector that provides access to the labels for which predictions should be calculated
+     */
+    template<class T>
+    class RegularizedExampleWiseRuleEvaluation final : public AbstractExampleWiseRuleEvaluation<T> {
 
-    private:
+        private:
 
-        float64 l2RegularizationWeight_;
+            float64 l2RegularizationWeight_;
 
-        std::shared_ptr<Blas> blasPtr_;
+            std::shared_ptr<Blas> blasPtr_;
 
-        DenseScoreVector<T>* scoreVector_;
+            DenseScoreVector<T>* scoreVector_;
 
-        DenseLabelWiseScoreVector<T>* labelWiseScoreVector_;
+            DenseLabelWiseScoreVector<T>* labelWiseScoreVector_;
 
-    public:
+        public:
 
-        /**
-         * @param labelIndices              A reference to an object of template type `T` that provides access to the
-         *                                  indices of the labels for which the rules may predict
-         * @param l2RegularizationWeight    The weight of the L2 regularization that is applied for calculating the
-         *                                  scores to be predicted by rules
-         * @param blasPtr                   A shared pointer to an object of type `Blas` that allows to execute
-         *                                  different BLAS routines
-         * @param lapackPtr                 A shared pointer to an object of type `Lapack` that allows to execute
-         *                                  different LAPACK routines
-         */
-        RegularizedExampleWiseRuleEvaluation(const T& labelIndices, float64 l2RegularizationWeight,
-                                             std::shared_ptr<Blas> blasPtr, std::shared_ptr<Lapack> lapackPtr)
-            : AbstractExampleWiseRuleEvaluation<T>(labelIndices, lapackPtr),
-              l2RegularizationWeight_(l2RegularizationWeight), blasPtr_(blasPtr), scoreVector_(nullptr),
-              labelWiseScoreVector_(nullptr) {
+            /**
+             * @param labelIndices              A reference to an object of template type `T` that provides access to
+             *                                  the indices of the labels for which the rules may predict
+             * @param l2RegularizationWeight    The weight of the L2 regularization that is applied for calculating the
+             *                                  scores to be predicted by rules
+             * @param blasPtr                   A shared pointer to an object of type `Blas` that allows to execute
+             *                                  different BLAS routines
+             * @param lapackPtr                 A shared pointer to an object of type `Lapack` that allows to execute
+             *                                  different LAPACK routines
+             */
+            RegularizedExampleWiseRuleEvaluation(const T& labelIndices, float64 l2RegularizationWeight,
+                                                 std::shared_ptr<Blas> blasPtr, std::shared_ptr<Lapack> lapackPtr)
+                : AbstractExampleWiseRuleEvaluation<T>(labelIndices, lapackPtr),
+                  l2RegularizationWeight_(l2RegularizationWeight), blasPtr_(blasPtr), scoreVector_(nullptr),
+                  labelWiseScoreVector_(nullptr) {
 
-        }
-
-        const ILabelWiseScoreVector& calculateLabelWisePrediction(
-                const DenseExampleWiseStatisticVector& statisticVector) override {
-            if (labelWiseScoreVector_ == nullptr) {
-                labelWiseScoreVector_ = new DenseLabelWiseScoreVector<T>(this->labelIndices_);
             }
 
-            labelWiseScoreVector_->overallQualityScore = calculateLabelWisePredictionInternally<
-                    typename DenseLabelWiseScoreVector<T>::score_iterator,
-                    typename DenseLabelWiseScoreVector<T>::quality_score_iterator,
-                    DenseExampleWiseStatisticVector::gradient_const_iterator,
-                    DenseExampleWiseStatisticVector::hessian_diagonal_const_iterator>(
-                labelWiseScoreVector_->getNumElements(), labelWiseScoreVector_->scores_begin(),
-                labelWiseScoreVector_->quality_scores_begin(), statisticVector.gradients_cbegin(),
-                statisticVector.hessians_diagonal_cbegin(), l2RegularizationWeight_);
-            return *labelWiseScoreVector_;
-        }
+            const ILabelWiseScoreVector& calculateLabelWisePrediction(
+                    const DenseExampleWiseStatisticVector& statisticVector) override {
+                if (labelWiseScoreVector_ == nullptr) {
+                    labelWiseScoreVector_ = new DenseLabelWiseScoreVector<T>(this->labelIndices_);
+                }
 
-        const IScoreVector& calculateExampleWisePrediction(DenseExampleWiseStatisticVector& statisticVector) override {
-            uint32 numPredictions = this->labelIndices_.getNumElements();
-
-            if (scoreVector_ == nullptr) {
-                scoreVector_ = new DenseScoreVector<T>(this->labelIndices_);
-                this->initializeTmpArrays(numPredictions);
+                labelWiseScoreVector_->overallQualityScore = calculateLabelWisePredictionInternally<
+                        typename DenseLabelWiseScoreVector<T>::score_iterator,
+                        typename DenseLabelWiseScoreVector<T>::quality_score_iterator,
+                        DenseExampleWiseStatisticVector::gradient_const_iterator,
+                        DenseExampleWiseStatisticVector::hessian_diagonal_const_iterator>(
+                    labelWiseScoreVector_->getNumElements(), labelWiseScoreVector_->scores_begin(),
+                    labelWiseScoreVector_->quality_scores_begin(), statisticVector.gradients_cbegin(),
+                    statisticVector.hessians_diagonal_cbegin(), l2RegularizationWeight_);
+                return *labelWiseScoreVector_;
             }
 
-            typename DenseScoreVector<T>::score_iterator scoreIterator = scoreVector_->scores_begin();
-            copyCoefficients<DenseExampleWiseStatisticVector::hessian_const_iterator>(
-                statisticVector.hessians_cbegin(), this->dsysvTmpArray1_, numPredictions);
-            addRegularizationWeight(this->dsysvTmpArray1_, numPredictions, l2RegularizationWeight_);
-            copyOrdinates<DenseExampleWiseStatisticVector::gradient_const_iterator>(
-                statisticVector.gradients_cbegin(), scoreIterator, numPredictions);
+            const IScoreVector& calculateExampleWisePrediction(
+                    DenseExampleWiseStatisticVector& statisticVector) override {
+                uint32 numPredictions = this->labelIndices_.getNumElements();
 
-            // Calculate the scores to be predicted for the individual labels by solving a system of linear equations...
-            this->lapackPtr_->dsysv(this->dsysvTmpArray1_, this->dsysvTmpArray2_, this->dsysvTmpArray3_, scoreIterator,
-                                    numPredictions, this->dsysvLwork_);
+                if (scoreVector_ == nullptr) {
+                    scoreVector_ = new DenseScoreVector<T>(this->labelIndices_);
+                    this->initializeTmpArrays(numPredictions);
+                }
 
-            // Calculate the overall quality score...
-            float64 qualityScore = calculateExampleWiseQualityScore(numPredictions, scoreIterator,
-                                                                    statisticVector.gradients_begin(),
-                                                                    statisticVector.hessians_begin(), *blasPtr_,
-                                                                    this->dspmvTmpArray_);
-            qualityScore += 0.5 * l2RegularizationWeight_ * l2NormPow<typename DenseScoreVector<T>::score_iterator>(
-                scoreIterator, numPredictions);
-            scoreVector_->overallQualityScore = qualityScore;
-            return *scoreVector_;
-        }
+                typename DenseScoreVector<T>::score_iterator scoreIterator = scoreVector_->scores_begin();
+                copyCoefficients<DenseExampleWiseStatisticVector::hessian_const_iterator>(
+                    statisticVector.hessians_cbegin(), this->dsysvTmpArray1_, numPredictions);
+                addRegularizationWeight(this->dsysvTmpArray1_, numPredictions, l2RegularizationWeight_);
+                copyOrdinates<DenseExampleWiseStatisticVector::gradient_const_iterator>(
+                    statisticVector.gradients_cbegin(), scoreIterator, numPredictions);
 
-};
+                // Calculate the scores to be predicted for the individual labels by solving a system of linear
+                // equations...
+                this->lapackPtr_->dsysv(this->dsysvTmpArray1_, this->dsysvTmpArray2_, this->dsysvTmpArray3_,
+                                        scoreIterator, numPredictions, this->dsysvLwork_);
 
-RegularizedExampleWiseRuleEvaluationFactory::RegularizedExampleWiseRuleEvaluationFactory(
-        float64 l2RegularizationWeight, std::shared_ptr<Blas> blasPtr, std::shared_ptr<Lapack> lapackPtr)
-    : l2RegularizationWeight_(l2RegularizationWeight), blasPtr_(blasPtr), lapackPtr_(lapackPtr) {
+                // Calculate the overall quality score...
+                float64 qualityScore = calculateExampleWiseQualityScore(numPredictions, scoreIterator,
+                                                                        statisticVector.gradients_begin(),
+                                                                        statisticVector.hessians_begin(), *blasPtr_,
+                                                                        this->dspmvTmpArray_);
+                qualityScore += 0.5 * l2RegularizationWeight_ * l2NormPow<typename DenseScoreVector<T>::score_iterator>(
+                    scoreIterator, numPredictions);
+                scoreVector_->overallQualityScore = qualityScore;
+                return *scoreVector_;
+            }
 
-}
+    };
 
-std::unique_ptr<IExampleWiseRuleEvaluation> RegularizedExampleWiseRuleEvaluationFactory::create(
-        const FullIndexVector& indexVector) const {
-    return std::make_unique<RegularizedExampleWiseRuleEvaluation<FullIndexVector>>(indexVector, l2RegularizationWeight_,
-                                                                                   blasPtr_, lapackPtr_);
-}
+    RegularizedExampleWiseRuleEvaluationFactory::RegularizedExampleWiseRuleEvaluationFactory(
+            float64 l2RegularizationWeight, std::shared_ptr<Blas> blasPtr, std::shared_ptr<Lapack> lapackPtr)
+        : l2RegularizationWeight_(l2RegularizationWeight), blasPtr_(blasPtr), lapackPtr_(lapackPtr) {
 
-std::unique_ptr<IExampleWiseRuleEvaluation> RegularizedExampleWiseRuleEvaluationFactory::create(
-        const PartialIndexVector& indexVector) const {
-    return std::make_unique<RegularizedExampleWiseRuleEvaluation<PartialIndexVector>>(indexVector,
-                                                                                      l2RegularizationWeight_, blasPtr_,
-                                                                                      lapackPtr_);
+    }
+
+    std::unique_ptr<IExampleWiseRuleEvaluation> RegularizedExampleWiseRuleEvaluationFactory::create(
+            const FullIndexVector& indexVector) const {
+        return std::make_unique<RegularizedExampleWiseRuleEvaluation<FullIndexVector>>(indexVector,
+                                                                                       l2RegularizationWeight_,
+                                                                                       blasPtr_, lapackPtr_);
+    }
+
+    std::unique_ptr<IExampleWiseRuleEvaluation> RegularizedExampleWiseRuleEvaluationFactory::create(
+            const PartialIndexVector& indexVector) const {
+        return std::make_unique<RegularizedExampleWiseRuleEvaluation<PartialIndexVector>>(indexVector,
+                                                                                          l2RegularizationWeight_,
+                                                                                          blasPtr_, lapackPtr_);
+    }
+
 }

--- a/python/boomer/boosting/cpp/rule_evaluation/rule_evaluation_label_wise_regularized.cpp
+++ b/python/boomer/boosting/cpp/rule_evaluation/rule_evaluation_label_wise_regularized.cpp
@@ -2,64 +2,68 @@
 #include "rule_evaluation_label_wise_regularized_common.h"
 #include "../../../common/cpp/rule_evaluation/score_vector_label_wise_dense.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-/**
- * Allows to calculate the predictions of rules, as well as corresponding quality scores, based on the gradients and
- * Hessians that have been calculated according to a loss function that is applied label-wise using L2 regularization.
- *
- * @tparam T The type of the vector that provides access to the labels for which predictions should be calculated
- */
-template<class T>
-class RegularizedLabelWiseRuleEvaluation final : public ILabelWiseRuleEvaluation {
+    /**
+     * Allows to calculate the predictions of rules, as well as corresponding quality scores, based on the gradients and
+     * Hessians that have been calculated according to a loss function that is applied label-wise using L2
+     * regularization.
+     *
+     * @tparam T The type of the vector that provides access to the labels for which predictions should be calculated
+     */
+    template<class T>
+    class RegularizedLabelWiseRuleEvaluation final : public ILabelWiseRuleEvaluation {
 
-    private:
+        private:
 
-        float64 l2RegularizationWeight_;
+            float64 l2RegularizationWeight_;
 
-        DenseLabelWiseScoreVector<T> scoreVector_;
+            DenseLabelWiseScoreVector<T> scoreVector_;
 
-    public:
+        public:
 
-        /**
-         * @param labelIndices              A reference to an object of template type `T` that provides access to
-         *                                  the indices of the labels for which the rules may predict
-         * @param l2RegularizationWeight    The weight of the L2 regularization that is applied for calculating the
-         *                                  scores to be predicted by rules
-         */
-        RegularizedLabelWiseRuleEvaluation(const T& labelIndices, float64 l2RegularizationWeight)
-            : l2RegularizationWeight_(l2RegularizationWeight),
-              scoreVector_(DenseLabelWiseScoreVector<T>(labelIndices)) {
+            /**
+             * @param labelIndices              A reference to an object of template type `T` that provides access to
+             *                                  the indices of the labels for which the rules may predict
+             * @param l2RegularizationWeight    The weight of the L2 regularization that is applied for calculating the
+             *                                  scores to be predicted by rules
+             */
+            RegularizedLabelWiseRuleEvaluation(const T& labelIndices, float64 l2RegularizationWeight)
+                : l2RegularizationWeight_(l2RegularizationWeight),
+                  scoreVector_(DenseLabelWiseScoreVector<T>(labelIndices)) {
 
-        }
+            }
 
-        const ILabelWiseScoreVector& calculateLabelWisePrediction(
-                const DenseLabelWiseStatisticVector& statisticVector) override {
-            scoreVector_.overallQualityScore = calculateLabelWisePredictionInternally<
-                    typename DenseLabelWiseScoreVector<T>::score_iterator,
-                    typename DenseLabelWiseScoreVector<T>::quality_score_iterator,
-                    DenseLabelWiseStatisticVector::gradient_const_iterator,
-                    DenseLabelWiseStatisticVector::hessian_const_iterator>(
-                scoreVector_.getNumElements(), scoreVector_.scores_begin(), scoreVector_.quality_scores_begin(),
-                statisticVector.gradients_cbegin(), statisticVector.hessians_cbegin(), l2RegularizationWeight_);
-            return scoreVector_;
-        }
+            const ILabelWiseScoreVector& calculateLabelWisePrediction(
+                    const DenseLabelWiseStatisticVector& statisticVector) override {
+                scoreVector_.overallQualityScore = calculateLabelWisePredictionInternally<
+                        typename DenseLabelWiseScoreVector<T>::score_iterator,
+                        typename DenseLabelWiseScoreVector<T>::quality_score_iterator,
+                        DenseLabelWiseStatisticVector::gradient_const_iterator,
+                        DenseLabelWiseStatisticVector::hessian_const_iterator>(
+                    scoreVector_.getNumElements(), scoreVector_.scores_begin(), scoreVector_.quality_scores_begin(),
+                    statisticVector.gradients_cbegin(), statisticVector.hessians_cbegin(), l2RegularizationWeight_);
+                return scoreVector_;
+            }
 
-};
+    };
 
-RegularizedLabelWiseRuleEvaluationFactory::RegularizedLabelWiseRuleEvaluationFactory(float64 l2RegularizationWeight)
-    : l2RegularizationWeight_(l2RegularizationWeight) {
+    RegularizedLabelWiseRuleEvaluationFactory::RegularizedLabelWiseRuleEvaluationFactory(float64 l2RegularizationWeight)
+        : l2RegularizationWeight_(l2RegularizationWeight) {
 
-}
+    }
 
-std::unique_ptr<ILabelWiseRuleEvaluation> RegularizedLabelWiseRuleEvaluationFactory::create(
-        const FullIndexVector& indexVector) const {
-    return std::make_unique<RegularizedLabelWiseRuleEvaluation<FullIndexVector>>(indexVector, l2RegularizationWeight_);
-}
+    std::unique_ptr<ILabelWiseRuleEvaluation> RegularizedLabelWiseRuleEvaluationFactory::create(
+            const FullIndexVector& indexVector) const {
+        return std::make_unique<RegularizedLabelWiseRuleEvaluation<FullIndexVector>>(indexVector,
+                                                                                     l2RegularizationWeight_);
+    }
 
-std::unique_ptr<ILabelWiseRuleEvaluation> RegularizedLabelWiseRuleEvaluationFactory::create(
-        const PartialIndexVector& indexVector) const {
-    return std::make_unique<RegularizedLabelWiseRuleEvaluation<PartialIndexVector>>(indexVector,
-                                                                                    l2RegularizationWeight_);
+    std::unique_ptr<ILabelWiseRuleEvaluation> RegularizedLabelWiseRuleEvaluationFactory::create(
+            const PartialIndexVector& indexVector) const {
+        return std::make_unique<RegularizedLabelWiseRuleEvaluation<PartialIndexVector>>(indexVector,
+                                                                                        l2RegularizationWeight_);
+    }
+
 }

--- a/python/boomer/boosting/cpp/statistics/statistics_example_wise_common.h
+++ b/python/boomer/boosting/cpp/statistics/statistics_example_wise_common.h
@@ -1,413 +1,424 @@
 #include "statistics_example_wise.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-/**
- * An abstract base class for all statistics that provide access to gradients and Hessians that are calculated according
- * to a differentiable loss function that is applied example-wise.
- *
- * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
- * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
- * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
- */
-template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
-class AbstractExampleWiseStatistics : virtual public IImmutableStatistics {
+    /**
+     * An abstract base class for all statistics that provide access to gradients and Hessians that are calculated
+     * according to a differentiable loss function that is applied example-wise.
+     *
+     * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
+     * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
+     * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
+     */
+    template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
+    class AbstractExampleWiseStatistics : virtual public IImmutableStatistics {
 
-    protected:
-
-        /**
-         * Provides access to a subset of the gradients and Hessians that are stored by an instance of the class
-         * `ExampleWiseStatistics`.
-         *
-         * @tparam T The type of the vector that provides access to the indices of the labels that are included in the
-         *           subset
-         */
-        template<class T>
-        class StatisticsSubset final : public IStatisticsSubset {
-
-            private:
-
-                const AbstractExampleWiseStatistics& statistics_;
-
-                const StatisticVector* totalSumVector_;
-
-                std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr_;
-
-                const T& labelIndices_;
-
-                StatisticVector sumVector_;
-
-                StatisticVector* accumulatedSumVector_;
-
-                StatisticVector* totalCoverableSumVector_;
-
-                StatisticVector tmpVector_;
-
-            public:
-
-                /**
-                 * @param statistics        A reference to an object of type `AbstractExampleWiseStatistics` that stores
-                 *                          the gradients and Hessians
-                 * @param ruleEvaluationPtr An unique pointer to an object of type `IExampleWiseRuleEvaluation` that
-                 *                          should be used to calculate the predictions, as well as corresponding
-                 *                          quality scores, of rules
-                 * @param labelIndices      A reference to an object of template type `T` that provides access to the
-                 *                          indices of the labels that are included in the subset
-                 */
-                StatisticsSubset(const AbstractExampleWiseStatistics& statistics, const StatisticVector* totalSumVector,
-                                 std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr, const T& labelIndices)
-                    : statistics_(statistics), totalSumVector_(totalSumVector),
-                      ruleEvaluationPtr_(std::move(ruleEvaluationPtr)), labelIndices_(labelIndices),
-                      sumVector_(StatisticVector(labelIndices.getNumElements(), true)), accumulatedSumVector_(nullptr),
-                      totalCoverableSumVector_(nullptr), tmpVector_(StatisticVector(labelIndices.getNumElements())) {
-
-                }
-
-                ~StatisticsSubset() {
-                    delete accumulatedSumVector_;
-                    delete totalCoverableSumVector_;
-                }
-
-                void addToMissing(uint32 statisticIndex, uint32 weight) override {
-                    // Create a vector for storing the totals sums of gradients and Hessians, if necessary...
-                    if (totalCoverableSumVector_ == nullptr) {
-                        totalCoverableSumVector_ = new StatisticVector(*totalSumVector_);
-                        totalSumVector_ = totalCoverableSumVector_;
-                    }
-
-                    // Subtract the gradients and Hessians of the example at the given index (weighted by the given
-                    // weight) from the total sums of gradients and Hessians...
-                    totalCoverableSumVector_->subtract(
-                        statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                        statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                        statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                        statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), weight);
-                }
-
-                void addToSubset(uint32 statisticIndex, uint32 weight) override {
-                    sumVector_.addToSubset(statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                                           statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                                           statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                                           statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex),
-                                           labelIndices_, weight);
-                }
-
-                void resetSubset() override {
-                    // Create a vector for storing the accumulated sums of gradients and Hessians, if necessary...
-                    if (accumulatedSumVector_ == nullptr) {
-                        uint32 numPredictions = labelIndices_.getNumElements();
-                        accumulatedSumVector_ = new StatisticVector(numPredictions, true);
-                    }
-
-                    // Reset the sum of gradients and Hessians to zero and add it to the accumulated sums of gradients
-                    // and Hessians...
-                    accumulatedSumVector_->add(sumVector_.gradients_cbegin(), sumVector_.gradients_cend(),
-                                               sumVector_.hessians_cbegin(), sumVector_.hessians_cend());
-                    sumVector_.setAllToZero();
-                }
-
-                const ILabelWiseScoreVector& calculateLabelWisePrediction(bool uncovered, bool accumulated) override {
-                    const StatisticVector& sumsOfStatistics = accumulated ? *accumulatedSumVector_ : sumVector_;
-
-                    if (uncovered) {
-                        tmpVector_.difference(totalSumVector_->gradients_cbegin(), totalSumVector_->gradients_cend(),
-                                              totalSumVector_->hessians_cbegin(), totalSumVector_->hessians_cend(),
-                                              labelIndices_, sumsOfStatistics.gradients_cbegin(),
-                                              sumsOfStatistics.gradients_cend(), sumsOfStatistics.hessians_cbegin(),
-                                              sumsOfStatistics.hessians_cend());
-                        return ruleEvaluationPtr_->calculateLabelWisePrediction(tmpVector_);
-                    }
-
-                    return ruleEvaluationPtr_->calculateLabelWisePrediction(sumsOfStatistics);
-                }
-
-                const IScoreVector& calculateExampleWisePrediction(bool uncovered, bool accumulated) override {
-                    StatisticVector& sumsOfStatistics = accumulated ? *accumulatedSumVector_ : sumVector_;
-
-                    if (uncovered) {
-                        tmpVector_.difference(totalSumVector_->gradients_cbegin(), totalSumVector_->gradients_cend(),
-                                              totalSumVector_->hessians_cbegin(), totalSumVector_->hessians_cend(),
-                                              labelIndices_, sumsOfStatistics.gradients_cbegin(),
-                                              sumsOfStatistics.gradients_cend(), sumsOfStatistics.hessians_cbegin(),
-                                              sumsOfStatistics.hessians_cend());
-                        return ruleEvaluationPtr_->calculateExampleWisePrediction(tmpVector_);
-                    }
-
-                    return ruleEvaluationPtr_->calculateExampleWisePrediction(sumsOfStatistics);
-                }
-
-        };
-
-        typedef StatisticsSubset<FullIndexVector> FullSubset;
-
-        typedef StatisticsSubset<PartialIndexVector> PartialSubset;
-
-    private:
-
-        uint32 numStatistics_;
-
-        uint32 numLabels_;
-
-    protected:
-
-        std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
-
-        std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr_;
-
-    public:
-
-        /**
-         * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
-         *                                  stores the gradients and Hessians
-         * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `IExampleWiseRuleEvaluationFactory`,
-         *                                  to be used for calculating the predictions, as well as corresponding quality
-         *                                  scores, of rules
-         */
-        AbstractExampleWiseStatistics(std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
-                                      std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
-            : numStatistics_(statisticMatrixPtr->getNumRows()), numLabels_(statisticMatrixPtr->getNumCols()),
-              statisticMatrixPtr_(std::move(statisticMatrixPtr)), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr) {
-
-        }
-
-        uint32 getNumStatistics() const override final {
-            return numStatistics_;
-        }
-
-        uint32 getNumLabels() const override final {
-            return numLabels_;
-        }
-
-};
-
-/**
- * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
- * applied example-wise and are organized as a histogram.
- *
- * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
- * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
- * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
- */
-template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
-class ExampleWiseHistogram final : public AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
-                                   virtual public IHistogram {
-
-    private:
-
-        const StatisticMatrix& originalStatisticMatrix_;
-
-        const StatisticVector* totalSumVector_;
-
-    public:
-
-        /**
-         * @param originalStatisticMatrix   A reference to an object of template type `StatisticMatrix` that stores the
-         *                                  original gradients and Hessians, the histogram was created from
-         * @param totalSumVector            A pointer to an object of template type `StatisticVector` that stores the
-         *                                  total sums of gradients and Hessians
-         * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
-         *                                  stores the gradients and Hessians
-         * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `IExampleWiseRuleEvaluationFactory`,
-         *                                  to be used for calculating the predictions, as well as corresponding quality
-         *                                  scores, of rules
-         */
-        ExampleWiseHistogram(const StatisticMatrix& originalStatisticMatrix, const StatisticVector* totalSumVector,
-                             std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
-                             std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
-            : AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
-                  std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
-              originalStatisticMatrix_(originalStatisticMatrix), totalSumVector_(totalSumVector) {
-
-        }
-
-        void removeFromBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
-            this->statisticMatrixPtr_->subtractFromRow(binIndex,
-                                                       originalStatisticMatrix_.gradients_row_cbegin(statisticIndex),
-                                                       originalStatisticMatrix_.gradients_row_cend(statisticIndex),
-                                                       originalStatisticMatrix_.hessians_row_cbegin(statisticIndex),
-                                                       originalStatisticMatrix_.hessians_row_cend(statisticIndex),
-                                                       weight);
-        }
-
-        std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override final {
-            std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename ExampleWiseHistogram::FullSubset>(*this, totalSumVector_,
-                                                                               std::move(ruleEvaluationPtr),
-                                                                               labelIndices);
-        }
-
-        std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override final {
-            std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename ExampleWiseHistogram::PartialSubset>(*this, totalSumVector_,
-                                                                                  std::move(ruleEvaluationPtr),
-                                                                                  labelIndices);
-        }
-
-};
-
-/**
- * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
- * applied example-wise and allows to update the gradients and Hessians after a new rule has been learned.
- *
- * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
- * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
- * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
- */
-template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
-class ExampleWiseStatistics final : public AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
-                                    virtual public IExampleWiseStatistics {
-
-    private:
-
-        /**
-         * Allows to build a histogram based on the gradients and Hessians that are stored by an instance of the class
-         * `ExampleWiseStatistics`.
-         */
-        class HistogramBuilder final : public IHistogramBuilder {
-
-            private:
-
-                const ExampleWiseStatistics& statistics_;
-
-                std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
-
-            public:
+        protected:
 
             /**
-             * @param statistics    A reference to an object of type `ExampleWiseStatistics` that stores the gradients
-             *                      and Hessians
-             * @param numBins       The number of bins, the histogram should consist of
+             * Provides access to a subset of the gradients and Hessians that are stored by an instance of the class
+             * `ExampleWiseStatistics`.
+             *
+             * @tparam T The type of the vector that provides access to the indices of the labels that are included in
+             *           the subset
              */
-            HistogramBuilder(const ExampleWiseStatistics& statistics, uint32 numBins)
-                : statistics_(statistics),
-                  statisticMatrixPtr_(std::make_unique<StatisticMatrix>(numBins, statistics.getNumLabels(), true)) {
+            template<class T>
+            class StatisticsSubset final : public IStatisticsSubset {
+
+                private:
+
+                    const AbstractExampleWiseStatistics& statistics_;
+
+                    const StatisticVector* totalSumVector_;
+
+                    std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr_;
+
+                    const T& labelIndices_;
+
+                    StatisticVector sumVector_;
+
+                    StatisticVector* accumulatedSumVector_;
+
+                    StatisticVector* totalCoverableSumVector_;
+
+                    StatisticVector tmpVector_;
+
+                public:
+
+                    /**
+                     * @param statistics        A reference to an object of type `AbstractExampleWiseStatistics` that
+                     *                          stores the gradients and Hessians
+                     * @param ruleEvaluationPtr An unique pointer to an object of type `IExampleWiseRuleEvaluation` that
+                     *                          should be used to calculate the predictions, as well as corresponding
+                     *                          quality scores, of rules
+                     * @param labelIndices      A reference to an object of template type `T` that provides access to
+                     *                          the indices of the labels that are included in the subset
+                     */
+                    StatisticsSubset(const AbstractExampleWiseStatistics& statistics,
+                                     const StatisticVector* totalSumVector,
+                                     std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr,
+                                     const T& labelIndices)
+                        : statistics_(statistics), totalSumVector_(totalSumVector),
+                          ruleEvaluationPtr_(std::move(ruleEvaluationPtr)), labelIndices_(labelIndices),
+                          sumVector_(StatisticVector(labelIndices.getNumElements(), true)),
+                          accumulatedSumVector_(nullptr), totalCoverableSumVector_(nullptr),
+                          tmpVector_(StatisticVector(labelIndices.getNumElements())) {
+
+                    }
+
+                    ~StatisticsSubset() {
+                        delete accumulatedSumVector_;
+                        delete totalCoverableSumVector_;
+                    }
+
+                    void addToMissing(uint32 statisticIndex, uint32 weight) override {
+                        // Create a vector for storing the totals sums of gradients and Hessians, if necessary...
+                        if (totalCoverableSumVector_ == nullptr) {
+                            totalCoverableSumVector_ = new StatisticVector(*totalSumVector_);
+                            totalSumVector_ = totalCoverableSumVector_;
+                        }
+
+                        // Subtract the gradients and Hessians of the example at the given index (weighted by the given
+                        // weight) from the total sums of gradients and Hessians...
+                        totalCoverableSumVector_->subtract(
+                            statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                            statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                            statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                            statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), weight);
+                    }
+
+                    void addToSubset(uint32 statisticIndex, uint32 weight) override {
+                        sumVector_.addToSubset(statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                                               statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                                               statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                                               statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex),
+                                               labelIndices_, weight);
+                    }
+
+                    void resetSubset() override {
+                        // Create a vector for storing the accumulated sums of gradients and Hessians, if necessary...
+                        if (accumulatedSumVector_ == nullptr) {
+                            uint32 numPredictions = labelIndices_.getNumElements();
+                            accumulatedSumVector_ = new StatisticVector(numPredictions, true);
+                        }
+
+                        // Reset the sum of gradients and Hessians to zero and add it to the accumulated sums of
+                        // gradients and Hessians...
+                        accumulatedSumVector_->add(sumVector_.gradients_cbegin(), sumVector_.gradients_cend(),
+                                                   sumVector_.hessians_cbegin(), sumVector_.hessians_cend());
+                        sumVector_.setAllToZero();
+                    }
+
+                    const ILabelWiseScoreVector& calculateLabelWisePrediction(bool uncovered,
+                                                                              bool accumulated) override {
+                        const StatisticVector& sumsOfStatistics = accumulated ? *accumulatedSumVector_ : sumVector_;
+
+                        if (uncovered) {
+                            tmpVector_.difference(totalSumVector_->gradients_cbegin(),
+                                                  totalSumVector_->gradients_cend(), totalSumVector_->hessians_cbegin(),
+                                                  totalSumVector_->hessians_cend(), labelIndices_,
+                                                  sumsOfStatistics.gradients_cbegin(),
+                                                  sumsOfStatistics.gradients_cend(), sumsOfStatistics.hessians_cbegin(),
+                                                  sumsOfStatistics.hessians_cend());
+                            return ruleEvaluationPtr_->calculateLabelWisePrediction(tmpVector_);
+                        }
+
+                        return ruleEvaluationPtr_->calculateLabelWisePrediction(sumsOfStatistics);
+                    }
+
+                    const IScoreVector& calculateExampleWisePrediction(bool uncovered, bool accumulated) override {
+                        StatisticVector& sumsOfStatistics = accumulated ? *accumulatedSumVector_ : sumVector_;
+
+                        if (uncovered) {
+                            tmpVector_.difference(totalSumVector_->gradients_cbegin(),
+                                                  totalSumVector_->gradients_cend(), totalSumVector_->hessians_cbegin(),
+                                                  totalSumVector_->hessians_cend(), labelIndices_,
+                                                  sumsOfStatistics.gradients_cbegin(),
+                                                  sumsOfStatistics.gradients_cend(), sumsOfStatistics.hessians_cbegin(),
+                                                  sumsOfStatistics.hessians_cend());
+                            return ruleEvaluationPtr_->calculateExampleWisePrediction(tmpVector_);
+                        }
+
+                        return ruleEvaluationPtr_->calculateExampleWisePrediction(sumsOfStatistics);
+                    }
+
+            };
+
+            typedef StatisticsSubset<FullIndexVector> FullSubset;
+
+            typedef StatisticsSubset<PartialIndexVector> PartialSubset;
+
+        private:
+
+            uint32 numStatistics_;
+
+            uint32 numLabels_;
+
+        protected:
+
+            std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
+
+            std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr_;
+
+        public:
+
+            /**
+             * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
+             *                                  stores the gradients and Hessians
+             * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type
+             *                                  `IExampleWiseRuleEvaluationFactory`, to be used for calculating the
+             *                                  predictions, as well as corresponding quality scores, of rules
+             */
+            AbstractExampleWiseStatistics(std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
+                                          std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
+                : numStatistics_(statisticMatrixPtr->getNumRows()), numLabels_(statisticMatrixPtr->getNumCols()),
+                  statisticMatrixPtr_(std::move(statisticMatrixPtr)),
+                  ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr) {
 
             }
 
-            uint32 getNumBins() const {
-                return statisticMatrixPtr_->getNumRows();
+            uint32 getNumStatistics() const override final {
+                return numStatistics_;
             }
 
-            void addToBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
-                statisticMatrixPtr_->addToRow(binIndex,
-                                              statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                                              statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                                              statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                                              statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex),
-                                              weight);
+            uint32 getNumLabels() const override final {
+                return numLabels_;
             }
 
-            std::unique_ptr<IHistogram> build() override {
-                return std::make_unique<ExampleWiseHistogram<StatisticVector, StatisticMatrix, ScoreMatrix>>(
-                    *statistics_.statisticMatrixPtr_, statistics_.totalSumVectorPtr_.get(),
-                    std::move(statisticMatrixPtr_), statistics_.ruleEvaluationFactoryPtr_);
+    };
+
+    /**
+     * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
+     * applied example-wise and are organized as a histogram.
+     *
+     * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
+     * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
+     * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
+     */
+    template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
+    class ExampleWiseHistogram final : public AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
+                                       virtual public IHistogram {
+
+        private:
+
+            const StatisticMatrix& originalStatisticMatrix_;
+
+            const StatisticVector* totalSumVector_;
+
+        public:
+
+            /**
+             * @param originalStatisticMatrix   A reference to an object of template type `StatisticMatrix` that stores
+             *                                  the original gradients and Hessians, the histogram was created from
+             * @param totalSumVector            A pointer to an object of template type `StatisticVector` that stores
+             *                                  the total sums of gradients and Hessians
+             * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
+             *                                  stores the gradients and Hessians
+             * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type
+             *                                  `IExampleWiseRuleEvaluationFactory`, to be used for calculating the
+             *                                  predictions, as well as corresponding quality scores, of rules
+             */
+            ExampleWiseHistogram(const StatisticMatrix& originalStatisticMatrix, const StatisticVector* totalSumVector,
+                                 std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
+                                 std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
+                : AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
+                      std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
+                  originalStatisticMatrix_(originalStatisticMatrix), totalSumVector_(totalSumVector) {
+
             }
 
-        };
+            void removeFromBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
+                this->statisticMatrixPtr_->subtractFromRow(
+                    binIndex, originalStatisticMatrix_.gradients_row_cbegin(statisticIndex),
+                    originalStatisticMatrix_.gradients_row_cend(statisticIndex),
+                    originalStatisticMatrix_.hessians_row_cbegin(statisticIndex),
+                    originalStatisticMatrix_.hessians_row_cend(statisticIndex), weight);
+            }
 
-        std::unique_ptr<StatisticVector> totalSumVectorPtr_;
-
-        std::shared_ptr<IExampleWiseLoss> lossFunctionPtr_;
-
-        std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr_;
-
-        std::unique_ptr<ScoreMatrix> scoreMatrixPtr_;
-
-        template<class T>
-        void applyPredictionInternally(uint32 statisticIndex, const T& prediction) {
-            // Update the scores that are currently predicted for the example at the given index...
-            scoreMatrixPtr_->addToRowFromSubset(statisticIndex, prediction.scores_cbegin(), prediction.scores_cend(),
-                                                prediction.indices_cbegin(), prediction.indices_cend());
-
-            // Update the gradients and Hessians for the example at the given index...
-            lossFunctionPtr_->updateExampleWiseStatistics(statisticIndex, *labelMatrixPtr_, *scoreMatrixPtr_,
-                                                          *this->statisticMatrixPtr_);
-        }
-
-    public:
-
-        /**
-         * @param lossFunctionPtr           A shared pointer to an object of type `IExampleWiseLoss`, representing the
-         *                                  loss function to be used for calculating gradients and Hessians
-         * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `IExampleWiseRuleEvaluationFactory`,
-         *                                  to be used for calculating the predictions, as well as corresponding quality
-         *                                  scores, of rules
-         * @param labelMatrixPtr            A shared pointer to an object of type `IRandomAccessLabelMatrix` that
-         *                                  provides random access to the labels of the training examples
-         * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
-         *                                  stores the gradients and Hessians
-         * @param scoreMatrixPtr            An unique pointer to an object of template type `ScoreMatrix` that stores
-         *                                  the currently predicted scores
-         */
-        ExampleWiseStatistics(std::shared_ptr<IExampleWiseLoss> lossFunctionPtr,
-                              std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
-                              std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr,
-                              std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
-                              std::unique_ptr<ScoreMatrix> scoreMatrixPtr)
-            : AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
-                  std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
-              totalSumVectorPtr_(std::make_unique<StatisticVector>(this->statisticMatrixPtr_->getNumCols())),
-              lossFunctionPtr_(lossFunctionPtr), labelMatrixPtr_(labelMatrixPtr),
-              scoreMatrixPtr_(std::move(scoreMatrixPtr)) {
-
-        }
-
-        void setRuleEvaluationFactory(
-                std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr) override {
-            this->ruleEvaluationFactoryPtr_ = ruleEvaluationFactoryPtr;
-        }
-
-        void resetSampledStatistics() override {
-            // This function is equivalent to the function `resetCoveredStatistics`...
-            this->resetCoveredStatistics();
-        }
-
-        void addSampledStatistic(uint32 statisticIndex, uint32 weight) override {
-            // This function is equivalent to the function `updateCoveredStatistic`...
-            this->updateCoveredStatistic(statisticIndex, weight, false);
-        }
-
-        void resetCoveredStatistics() override {
-            totalSumVectorPtr_->setAllToZero();
-        }
-
-        void updateCoveredStatistic(uint32 statisticIndex, uint32 weight, bool remove) override {
-            float64 signedWeight = remove ? -((float64) weight) : weight;
-            totalSumVectorPtr_->add(this->statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                                    this->statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                                    this->statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                                    this->statisticMatrixPtr_->hessians_row_cend(statisticIndex), signedWeight);
-        }
-
-        void applyPrediction(uint32 statisticIndex, const FullPrediction& prediction) override {
-            this->applyPredictionInternally<FullPrediction>(statisticIndex, prediction);
-        }
-
-        void applyPrediction(uint32 statisticIndex, const PartialPrediction& prediction) override {
-            this->applyPredictionInternally<PartialPrediction>(statisticIndex, prediction);
-        }
-
-        std::unique_ptr<IHistogramBuilder> createHistogramBuilder(uint32 numBins) const override {
-            return std::make_unique<HistogramBuilder>(*this, numBins);
-        }
-
-        std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override final {
-            std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename ExampleWiseStatistics::FullSubset>(*this, totalSumVectorPtr_.get(),
-                                                                                std::move(ruleEvaluationPtr),
-                                                                                labelIndices);
-        }
-
-        std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override final {
-            std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename ExampleWiseStatistics::PartialSubset>(*this, totalSumVectorPtr_.get(),
+            std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override final {
+                std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename ExampleWiseHistogram::FullSubset>(*this, totalSumVector_,
                                                                                    std::move(ruleEvaluationPtr),
                                                                                    labelIndices);
-        }
+            }
 
-};
+            std::unique_ptr<IStatisticsSubset> createSubset(
+                    const PartialIndexVector& labelIndices) const override final {
+                std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename ExampleWiseHistogram::PartialSubset>(*this, totalSumVector_,
+                                                                                      std::move(ruleEvaluationPtr),
+                                                                                      labelIndices);
+            }
+
+    };
+
+    /**
+     * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
+     * applied example-wise and allows to update the gradients and Hessians after a new rule has been learned.
+     *
+     * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
+     * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
+     * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
+     */
+    template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
+    class ExampleWiseStatistics final : public AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
+                                        virtual public IExampleWiseStatistics {
+
+        private:
+
+            /**
+             * Allows to build a histogram based on the gradients and Hessians that are stored by an instance of the
+             * class `ExampleWiseStatistics`.
+             */
+            class HistogramBuilder final : public IHistogramBuilder {
+
+                private:
+
+                    const ExampleWiseStatistics& statistics_;
+
+                    std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
+
+                public:
+
+                /**
+                 * @param statistics    A reference to an object of type `ExampleWiseStatistics` that stores the
+                 *                      gradients and Hessians
+                 * @param numBins       The number of bins, the histogram should consist of
+                 */
+                HistogramBuilder(const ExampleWiseStatistics& statistics, uint32 numBins)
+                    : statistics_(statistics),
+                      statisticMatrixPtr_(std::make_unique<StatisticMatrix>(numBins, statistics.getNumLabels(), true)) {
+
+                }
+
+                uint32 getNumBins() const {
+                    return statisticMatrixPtr_->getNumRows();
+                }
+
+                void addToBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
+                    statisticMatrixPtr_->addToRow(binIndex,
+                                                  statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                                                  statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                                                  statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                                                  statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex),
+                                                  weight);
+                }
+
+                std::unique_ptr<IHistogram> build() override {
+                    return std::make_unique<ExampleWiseHistogram<StatisticVector, StatisticMatrix, ScoreMatrix>>(
+                        *statistics_.statisticMatrixPtr_, statistics_.totalSumVectorPtr_.get(),
+                        std::move(statisticMatrixPtr_), statistics_.ruleEvaluationFactoryPtr_);
+                }
+
+            };
+
+            std::unique_ptr<StatisticVector> totalSumVectorPtr_;
+
+            std::shared_ptr<IExampleWiseLoss> lossFunctionPtr_;
+
+            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr_;
+
+            std::unique_ptr<ScoreMatrix> scoreMatrixPtr_;
+
+            template<class T>
+            void applyPredictionInternally(uint32 statisticIndex, const T& prediction) {
+                // Update the scores that are currently predicted for the example at the given index...
+                scoreMatrixPtr_->addToRowFromSubset(statisticIndex, prediction.scores_cbegin(),
+                                                    prediction.scores_cend(), prediction.indices_cbegin(),
+                                                    prediction.indices_cend());
+
+                // Update the gradients and Hessians for the example at the given index...
+                lossFunctionPtr_->updateExampleWiseStatistics(statisticIndex, *labelMatrixPtr_, *scoreMatrixPtr_,
+                                                              *this->statisticMatrixPtr_);
+            }
+
+        public:
+
+            /**
+             * @param lossFunctionPtr           A shared pointer to an object of type `IExampleWiseLoss`, representing
+             *                                  the loss function to be used for calculating gradients and Hessians
+             * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type
+             *                                  `IExampleWiseRuleEvaluationFactory`, to be used for calculating the
+             *                                  predictions, as well as corresponding quality scores, of rules
+             * @param labelMatrixPtr            A shared pointer to an object of type `IRandomAccessLabelMatrix` that
+             *                                  provides random access to the labels of the training examples
+             * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
+             *                                  stores the gradients and Hessians
+             * @param scoreMatrixPtr            An unique pointer to an object of template type `ScoreMatrix` that
+             *                                  stores the currently predicted scores
+             */
+            ExampleWiseStatistics(std::shared_ptr<IExampleWiseLoss> lossFunctionPtr,
+                                  std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
+                                  std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr,
+                                  std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
+                                  std::unique_ptr<ScoreMatrix> scoreMatrixPtr)
+                : AbstractExampleWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
+                      std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
+                  totalSumVectorPtr_(std::make_unique<StatisticVector>(this->statisticMatrixPtr_->getNumCols())),
+                  lossFunctionPtr_(lossFunctionPtr), labelMatrixPtr_(labelMatrixPtr),
+                  scoreMatrixPtr_(std::move(scoreMatrixPtr)) {
+
+            }
+
+            void setRuleEvaluationFactory(
+                    std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr) override {
+                this->ruleEvaluationFactoryPtr_ = ruleEvaluationFactoryPtr;
+            }
+
+            void resetSampledStatistics() override {
+                // This function is equivalent to the function `resetCoveredStatistics`...
+                this->resetCoveredStatistics();
+            }
+
+            void addSampledStatistic(uint32 statisticIndex, uint32 weight) override {
+                // This function is equivalent to the function `updateCoveredStatistic`...
+                this->updateCoveredStatistic(statisticIndex, weight, false);
+            }
+
+            void resetCoveredStatistics() override {
+                totalSumVectorPtr_->setAllToZero();
+            }
+
+            void updateCoveredStatistic(uint32 statisticIndex, uint32 weight, bool remove) override {
+                float64 signedWeight = remove ? -((float64) weight) : weight;
+                totalSumVectorPtr_->add(this->statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                                        this->statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                                        this->statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                                        this->statisticMatrixPtr_->hessians_row_cend(statisticIndex), signedWeight);
+            }
+
+            void applyPrediction(uint32 statisticIndex, const FullPrediction& prediction) override {
+                this->applyPredictionInternally<FullPrediction>(statisticIndex, prediction);
+            }
+
+            void applyPrediction(uint32 statisticIndex, const PartialPrediction& prediction) override {
+                this->applyPredictionInternally<PartialPrediction>(statisticIndex, prediction);
+            }
+
+            std::unique_ptr<IHistogramBuilder> createHistogramBuilder(uint32 numBins) const override {
+                return std::make_unique<HistogramBuilder>(*this, numBins);
+            }
+
+            std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override final {
+                std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename ExampleWiseStatistics::FullSubset>(*this, totalSumVectorPtr_.get(),
+                                                                                    std::move(ruleEvaluationPtr),
+                                                                                    labelIndices);
+            }
+
+            std::unique_ptr<IStatisticsSubset> createSubset(
+                    const PartialIndexVector& labelIndices) const override final {
+                std::unique_ptr<IExampleWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename ExampleWiseStatistics::PartialSubset>(*this, totalSumVectorPtr_.get(),
+                                                                                       std::move(ruleEvaluationPtr),
+                                                                                       labelIndices);
+            }
+
+    };
+
+}

--- a/python/boomer/boosting/cpp/statistics/statistics_example_wise_dense.cpp
+++ b/python/boomer/boosting/cpp/statistics/statistics_example_wise_dense.cpp
@@ -4,31 +4,33 @@
 #include "../data/matrix_dense_example_wise.h"
 #include "../data/vector_dense_example_wise.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-DenseExampleWiseStatisticsFactory::DenseExampleWiseStatisticsFactory(
-        std::shared_ptr<IExampleWiseLoss> lossFunctionPtr,
-        std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
-        std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr)
-    : lossFunctionPtr_(lossFunctionPtr), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr),
-      labelMatrixPtr_(labelMatrixPtr) {
+    DenseExampleWiseStatisticsFactory::DenseExampleWiseStatisticsFactory(
+            std::shared_ptr<IExampleWiseLoss> lossFunctionPtr,
+            std::shared_ptr<IExampleWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
+            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr)
+        : lossFunctionPtr_(lossFunctionPtr), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr),
+          labelMatrixPtr_(labelMatrixPtr) {
 
-}
-
-std::unique_ptr<IExampleWiseStatistics> DenseExampleWiseStatisticsFactory::create() const {
-    uint32 numExamples = labelMatrixPtr_->getNumRows();
-    uint32 numLabels = labelMatrixPtr_->getNumCols();
-    std::unique_ptr<DenseExampleWiseStatisticMatrix> statisticMatrixPtr =
-        std::make_unique<DenseExampleWiseStatisticMatrix>(numExamples, numLabels);
-    std::unique_ptr<DenseNumericMatrix<float64>> scoreMatrixPtr =
-        std::make_unique<DenseNumericMatrix<float64>>(numExamples, numLabels, true);
-
-    for (uint32 r = 0; r < numExamples; r++) {
-        lossFunctionPtr_->updateExampleWiseStatistics(r, *labelMatrixPtr_, *scoreMatrixPtr, *statisticMatrixPtr);
     }
 
-    return std::make_unique<ExampleWiseStatistics<DenseExampleWiseStatisticVector, DenseExampleWiseStatisticMatrix, DenseNumericMatrix<float64>>>(
-        lossFunctionPtr_, ruleEvaluationFactoryPtr_, labelMatrixPtr_, std::move(statisticMatrixPtr),
-        std::move(scoreMatrixPtr));
+    std::unique_ptr<IExampleWiseStatistics> DenseExampleWiseStatisticsFactory::create() const {
+        uint32 numExamples = labelMatrixPtr_->getNumRows();
+        uint32 numLabels = labelMatrixPtr_->getNumCols();
+        std::unique_ptr<DenseExampleWiseStatisticMatrix> statisticMatrixPtr =
+            std::make_unique<DenseExampleWiseStatisticMatrix>(numExamples, numLabels);
+        std::unique_ptr<DenseNumericMatrix<float64>> scoreMatrixPtr =
+            std::make_unique<DenseNumericMatrix<float64>>(numExamples, numLabels, true);
+
+        for (uint32 r = 0; r < numExamples; r++) {
+            lossFunctionPtr_->updateExampleWiseStatistics(r, *labelMatrixPtr_, *scoreMatrixPtr, *statisticMatrixPtr);
+        }
+
+        return std::make_unique<ExampleWiseStatistics<DenseExampleWiseStatisticVector, DenseExampleWiseStatisticMatrix, DenseNumericMatrix<float64>>>(
+            lossFunctionPtr_, ruleEvaluationFactoryPtr_, labelMatrixPtr_, std::move(statisticMatrixPtr),
+            std::move(scoreMatrixPtr));
+    }
+
 }

--- a/python/boomer/boosting/cpp/statistics/statistics_label_wise_common.h
+++ b/python/boomer/boosting/cpp/statistics/statistics_label_wise_common.h
@@ -1,402 +1,412 @@
 #include "statistics_label_wise.h"
 #include "../../../common/cpp/statistics/statistics_subset_decomposable.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-/**
- * An abstract base class for all statistics that provide access to gradients and Hessians that are calculated according
- * to a differentiable loss function that is applied label-wise.
- *
- * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
- * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
- * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
- */
-template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
-class AbstractLabelWiseStatistics : virtual public IImmutableStatistics {
+    /**
+     * An abstract base class for all statistics that provide access to gradients and Hessians that are calculated
+     * according to a differentiable loss function that is applied label-wise.
+     *
+     * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
+     * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
+     * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
+     */
+    template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
+    class AbstractLabelWiseStatistics : virtual public IImmutableStatistics {
 
-    protected:
+        protected:
 
-        /**
-         * Provides access to a subset of the gradients and Hessians that are stored by an instance of the class
-         * `AbstractLabelWiseStatistics`.
-         *
-         * @tparam T The type of the vector that provides access to the indices of the labels that are included in the
-         *           subset
-         */
-        template<class T>
-        class StatisticsSubset final : public AbstractDecomposableStatisticsSubset {
+            /**
+             * Provides access to a subset of the gradients and Hessians that are stored by an instance of the class
+             * `AbstractLabelWiseStatistics`.
+             *
+             * @tparam T The type of the vector that provides access to the indices of the labels that are included in
+             *           the subset
+             */
+            template<class T>
+            class StatisticsSubset final : public AbstractDecomposableStatisticsSubset {
 
-            private:
+                private:
 
-                const AbstractLabelWiseStatistics& statistics_;
+                    const AbstractLabelWiseStatistics& statistics_;
 
-                const StatisticVector* totalSumVector_;
+                    const StatisticVector* totalSumVector_;
 
-                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr_;
+                    std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr_;
 
-                const T& labelIndices_;
+                    const T& labelIndices_;
 
-                StatisticVector sumVector_;
+                    StatisticVector sumVector_;
 
-                StatisticVector* accumulatedSumVector_;
+                    StatisticVector* accumulatedSumVector_;
 
-                StatisticVector* totalCoverableSumVector_;
+                    StatisticVector* totalCoverableSumVector_;
 
-                StatisticVector tmpVector_;
+                    StatisticVector tmpVector_;
 
-            public:
+                public:
 
-                /**
-                 * @param statistics        A reference to an object of type `AbstractLabelWiseStatistics` that stores
-                 *                          the gradients and Hessians
-                 * @param totalSumVector    A pointer to an object of template type `StatisticVector` that stores the 
-                 *                          total sums of gradients and Hessians
-                 * @param ruleEvaluationPtr An unique pointer to an object of type `ILabelWiseRuleEvaluation` that
-                 *                          should be used to calculate the predictions, as well as corresponding
-                 *                          quality scores, of rules
-                 * @param labelIndices      A reference to an object of template type `T` that provides access to the
-                 *                          indices of the labels that are included in the subset
-                 */
-                StatisticsSubset(const AbstractLabelWiseStatistics& statistics, const StatisticVector* totalSumVector,
-                                 std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr, const T& labelIndices)
-                    : statistics_(statistics), totalSumVector_(totalSumVector),
-                      ruleEvaluationPtr_(std::move(ruleEvaluationPtr)), labelIndices_(labelIndices),
-                      sumVector_(StatisticVector(labelIndices.getNumElements(), true)), accumulatedSumVector_(nullptr),
-                      totalCoverableSumVector_(nullptr), tmpVector_(StatisticVector(labelIndices.getNumElements())) {
+                    /**
+                     * @param statistics        A reference to an object of type `AbstractLabelWiseStatistics` that
+                     *                          stores the gradients and Hessians
+                     * @param totalSumVector    A pointer to an object of template type `StatisticVector` that stores
+                     *                          the total sums of gradients and Hessians
+                     * @param ruleEvaluationPtr An unique pointer to an object of type `ILabelWiseRuleEvaluation` that
+                     *                          should be used to calculate the predictions, as well as corresponding
+                     *                          quality scores, of rules
+                     * @param labelIndices      A reference to an object of template type `T` that provides access to
+                     *                          the indices of the labels that are included in the subset
+                     */
+                    StatisticsSubset(const AbstractLabelWiseStatistics& statistics,
+                                     const StatisticVector* totalSumVector,
+                                     std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr, const T& labelIndices)
+                        : statistics_(statistics), totalSumVector_(totalSumVector),
+                          ruleEvaluationPtr_(std::move(ruleEvaluationPtr)), labelIndices_(labelIndices),
+                          sumVector_(StatisticVector(labelIndices.getNumElements(), true)),
+                          accumulatedSumVector_(nullptr), totalCoverableSumVector_(nullptr),
+                          tmpVector_(StatisticVector(labelIndices.getNumElements())) {
 
-                }
-
-                ~StatisticsSubset() {
-                    delete accumulatedSumVector_;
-                    delete totalCoverableSumVector_;
-                }
-
-                void addToMissing(uint32 statisticIndex, uint32 weight) override {
-                    // Create a vector for storing the totals sums of gradients and Hessians, if necessary...
-                    if (totalCoverableSumVector_ == nullptr) {
-                        totalCoverableSumVector_ = new StatisticVector(*totalSumVector_);
-                        totalSumVector_ = totalCoverableSumVector_;
                     }
 
-                    // Subtract the gradients and Hessians of the example at the given index (weighted by the given
-                    // weight) from the total sums of gradients and Hessians...
-                    totalCoverableSumVector_->subtract(
-                        statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                        statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                        statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                        statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), weight);
-                }
-
-                void addToSubset(uint32 statisticIndex, uint32 weight) override {
-                    sumVector_.addToSubset(statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                                           statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                                           statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                                           statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex),
-                                           labelIndices_, weight);
-                }
-
-                void resetSubset() override {
-                    // Create a vector for storing the accumulated sums of gradients and Hessians, if necessary...
-                    if (accumulatedSumVector_ == nullptr) {
-                        uint32 numPredictions = labelIndices_.getNumElements();
-                        accumulatedSumVector_ = new StatisticVector(numPredictions, true);
+                    ~StatisticsSubset() {
+                        delete accumulatedSumVector_;
+                        delete totalCoverableSumVector_;
                     }
 
-                    // Reset the sums of gradients and Hessians to zero and add it to the accumulated sums of gradients
-                    // and Hessians...
-                    accumulatedSumVector_->add(sumVector_.gradients_cbegin(), sumVector_.gradients_cend(),
-                                               sumVector_.hessians_cbegin(), sumVector_.hessians_cend());
-                    sumVector_.setAllToZero();
-                }
+                    void addToMissing(uint32 statisticIndex, uint32 weight) override {
+                        // Create a vector for storing the totals sums of gradients and Hessians, if necessary...
+                        if (totalCoverableSumVector_ == nullptr) {
+                            totalCoverableSumVector_ = new StatisticVector(*totalSumVector_);
+                            totalSumVector_ = totalCoverableSumVector_;
+                        }
 
-                const ILabelWiseScoreVector& calculateLabelWisePrediction(bool uncovered, bool accumulated) override {
-                    const StatisticVector& sumsOfStatistics = accumulated ? *accumulatedSumVector_ : sumVector_;
-
-                    if (uncovered) {
-                        tmpVector_.difference(totalSumVector_->gradients_cbegin(), totalSumVector_->gradients_cend(),
-                                              totalSumVector_->hessians_cbegin(), totalSumVector_->hessians_cend(),
-                                              labelIndices_, sumsOfStatistics.gradients_cbegin(),
-                                              sumsOfStatistics.gradients_cend(), sumsOfStatistics.hessians_cbegin(),
-                                              sumsOfStatistics.hessians_cend());
-                        return ruleEvaluationPtr_->calculateLabelWisePrediction(tmpVector_);
+                        // Subtract the gradients and Hessians of the example at the given index (weighted by the given
+                        // weight) from the total sums of gradients and Hessians...
+                        totalCoverableSumVector_->subtract(
+                            statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                            statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                            statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                            statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), weight);
                     }
 
-                    return ruleEvaluationPtr_->calculateLabelWisePrediction(sumsOfStatistics);
-                }
+                    void addToSubset(uint32 statisticIndex, uint32 weight) override {
+                        sumVector_.addToSubset(statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                                               statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                                               statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                                               statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex),
+                                               labelIndices_, weight);
+                    }
 
-        };
+                    void resetSubset() override {
+                        // Create a vector for storing the accumulated sums of gradients and Hessians, if necessary...
+                        if (accumulatedSumVector_ == nullptr) {
+                            uint32 numPredictions = labelIndices_.getNumElements();
+                            accumulatedSumVector_ = new StatisticVector(numPredictions, true);
+                        }
 
-        typedef StatisticsSubset<FullIndexVector> FullSubset;
+                        // Reset the sums of gradients and Hessians to zero and add it to the accumulated sums of
+                        // gradients and Hessians...
+                        accumulatedSumVector_->add(sumVector_.gradients_cbegin(), sumVector_.gradients_cend(),
+                                                   sumVector_.hessians_cbegin(), sumVector_.hessians_cend());
+                        sumVector_.setAllToZero();
+                    }
 
-        typedef StatisticsSubset<PartialIndexVector> PartialSubset;
+                    const ILabelWiseScoreVector& calculateLabelWisePrediction(bool uncovered,
+                                                                              bool accumulated) override {
+                        const StatisticVector& sumsOfStatistics = accumulated ? *accumulatedSumVector_ : sumVector_;
 
-    private:
+                        if (uncovered) {
+                            tmpVector_.difference(totalSumVector_->gradients_cbegin(),
+                                                  totalSumVector_->gradients_cend(), totalSumVector_->hessians_cbegin(),
+                                                  totalSumVector_->hessians_cend(), labelIndices_,
+                                                  sumsOfStatistics.gradients_cbegin(),
+                                                  sumsOfStatistics.gradients_cend(), sumsOfStatistics.hessians_cbegin(),
+                                                  sumsOfStatistics.hessians_cend());
+                            return ruleEvaluationPtr_->calculateLabelWisePrediction(tmpVector_);
+                        }
 
-        uint32 numStatistics_;
+                        return ruleEvaluationPtr_->calculateLabelWisePrediction(sumsOfStatistics);
+                    }
 
-        uint32 numLabels_;
+            };
 
-    protected:
+            typedef StatisticsSubset<FullIndexVector> FullSubset;
 
-        std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
+            typedef StatisticsSubset<PartialIndexVector> PartialSubset;
 
-        std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr_;
+        private:
 
-    public:
+            uint32 numStatistics_;
 
-        /**
-         * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
-         *                                  stores the gradients and Hessians
-         * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory`,
-         *                                  that allows to create instances of the class that is used for calculating
-         *                                  the predictions, as well as corresponding quality scores, of rules
-         */
-        AbstractLabelWiseStatistics(std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
-                                    std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
-            : numStatistics_(statisticMatrixPtr->getNumRows()), numLabels_(statisticMatrixPtr->getNumCols()),
-              statisticMatrixPtr_(std::move(statisticMatrixPtr)), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr) {
+            uint32 numLabels_;
 
-        }
+        protected:
 
-        uint32 getNumStatistics() const override final {
-            return numStatistics_;
-        }
+            std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
 
-        uint32 getNumLabels() const override final {
-            return numLabels_;
-        }
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr_;
 
-};
+        public:
 
-/**
- * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
- * applied label-wise and are organized as a histogram.
- *
- * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
- * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
- * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
- */
-template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
-class LabelWiseHistogram final : public AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
-                                 virtual public IHistogram {
+            /**
+             * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
+             *                                  stores the gradients and Hessians
+             * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory`,
+             *                                  that allows to create instances of the class that is used for
+             *                                  calculating the predictions, as well as corresponding quality scores, of
+             *                                  rules
+             */
+            AbstractLabelWiseStatistics(std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
+                                        std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
+                : numStatistics_(statisticMatrixPtr->getNumRows()), numLabels_(statisticMatrixPtr->getNumCols()),
+                  statisticMatrixPtr_(std::move(statisticMatrixPtr)),
+                  ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr) {
 
-    private:
+            }
 
-        const StatisticMatrix& originalStatisticMatrix_;
+            uint32 getNumStatistics() const override final {
+                return numStatistics_;
+            }
 
-        const StatisticVector* totalSumVector_;
+            uint32 getNumLabels() const override final {
+                return numLabels_;
+            }
 
-    public:
+    };
 
-        /**
-         * @param originalStatisticMatrix   A reference to an object of template type `StatisticMatrix` that stores the
-         *                                  original gradients and Hessians, the histogram was created from
-         * @param totalSumVector            A pointer to an object of template type `StatisticVector` that stores the
-         *                                  total sums of gradients and Hessians
-         * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
-         *                                  stores the gradients and Hessians
-         * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory`,
-         *                                  that allows to create instances of the class that is used for calculating
-         *                                  the predictions, as well as corresponding quality scores, of rules
-         */
-        LabelWiseHistogram(const StatisticMatrix& originalStatisticMatrix, const StatisticVector* totalSumVector,
-                           std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
-                           std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
-            : AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
-                  std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
-              originalStatisticMatrix_(originalStatisticMatrix), totalSumVector_(totalSumVector) {
+    /**
+     * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
+     * applied label-wise and are organized as a histogram.
+     *
+     * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
+     * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
+     * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
+     */
+    template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
+    class LabelWiseHistogram final : public AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
+                                     virtual public IHistogram {
 
-        }
+        private:
 
-        void removeFromBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
-            this->statisticMatrixPtr_->subtractFromRow(binIndex,
-                                                       originalStatisticMatrix_.gradients_row_cbegin(statisticIndex),
-                                                       originalStatisticMatrix_.gradients_row_cend(statisticIndex),
-                                                       originalStatisticMatrix_.hessians_row_cbegin(statisticIndex),
-                                                       originalStatisticMatrix_.hessians_row_cend(statisticIndex),
-                                                       weight);
-        }
+            const StatisticMatrix& originalStatisticMatrix_;
 
-        std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override {
-            std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename LabelWiseHistogram::FullSubset>(*this, totalSumVector_,
-                                                                             std::move(ruleEvaluationPtr),
-                                                                             labelIndices);
-        }
+            const StatisticVector* totalSumVector_;
 
-        std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override {
-            std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename LabelWiseHistogram::PartialSubset>(*this, totalSumVector_,
-                                                                                std::move(ruleEvaluationPtr),
-                                                                                labelIndices);
-        }
+        public:
 
-};
+            /**
+             * @param originalStatisticMatrix   A reference to an object of template type `StatisticMatrix` that stores
+             *                                  the original gradients and Hessians, the histogram was created from
+             * @param totalSumVector            A pointer to an object of template type `StatisticVector` that stores
+             *                                  the total sums of gradients and Hessians
+             * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
+             *                                  stores the gradients and Hessians
+             * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory`,
+             *                                  that allows to create instances of the class that is used for
+             *                                  calculating the predictions, as well as corresponding quality scores, of
+             *                                  rules
+             */
+            LabelWiseHistogram(const StatisticMatrix& originalStatisticMatrix, const StatisticVector* totalSumVector,
+                               std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
+                               std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr)
+                : AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
+                      std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
+                  originalStatisticMatrix_(originalStatisticMatrix), totalSumVector_(totalSumVector) {
 
-/**
- * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
- * applied label-wise and allows to update the gradients and Hessians after a new rule has been learned.
- *
- * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
- * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
- * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
- */
-template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
-class LabelWiseStatistics final : public AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
-                                  virtual public ILabelWiseStatistics {
+            }
 
-    private:
+            void removeFromBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
+                this->statisticMatrixPtr_->subtractFromRow(
+                    binIndex, originalStatisticMatrix_.gradients_row_cbegin(statisticIndex),
+                    originalStatisticMatrix_.gradients_row_cend(statisticIndex),
+                    originalStatisticMatrix_.hessians_row_cbegin(statisticIndex),
+                    originalStatisticMatrix_.hessians_row_cend(statisticIndex), weight);
+            }
 
-        /**
-         * Allows to build a histogram based on the gradients and Hessians that are stored by an instance of the class
-         * `LabelWiseStatistics`.
-         */
-        class HistogramBuilder final : public IHistogramBuilder {
-
-            private:
-
-                const LabelWiseStatistics& statistics_;
-
-                std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
-
-            public:
-
-                /**
-                 * @param statistics    A reference to an object of type `LabelWiseStatistics` that stores the gradients
-                 *                      and Hessians
-                 * @param numBins       The number of bins, the histogram should consist of
-                 */
-                HistogramBuilder(const LabelWiseStatistics& statistics, uint32 numBins)
-                    : statistics_(statistics),
-                      statisticMatrixPtr_(std::make_unique<StatisticMatrix>(numBins, statistics.getNumLabels(), true)) {
-
-                }
-
-                uint32 getNumBins() const override {
-                    return statisticMatrixPtr_->getNumRows();
-                }
-
-                void addToBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
-                    statisticMatrixPtr_->addToRow(binIndex,
-                                                  statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                                                  statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                                                  statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                                                  statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex),
-                                                  weight);
-                }
-
-                std::unique_ptr<IHistogram> build() override {
-                    return std::make_unique<LabelWiseHistogram<StatisticVector, StatisticMatrix, ScoreMatrix>>(
-                        *statistics_.statisticMatrixPtr_, statistics_.totalSumVectorPtr_.get(),
-                        std::move(statisticMatrixPtr_), statistics_.ruleEvaluationFactoryPtr_);
-                }
-
-        };
-
-        std::unique_ptr<StatisticVector> totalSumVectorPtr_;
-
-        std::shared_ptr<ILabelWiseLoss> lossFunctionPtr_;
-
-        std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr_;
-
-        std::unique_ptr<ScoreMatrix> scoreMatrixPtr_;
-
-        template<class T>
-        void applyPredictionInternally(uint32 statisticIndex, const T& prediction) {
-            // Update the scores that are currently predicted for the example at the given index...
-            scoreMatrixPtr_->addToRowFromSubset(statisticIndex, prediction.scores_cbegin(), prediction.scores_cend(),
-                                                prediction.indices_cbegin(), prediction.indices_cend());
-
-            // Update the gradients and Hessians of the example at the given index...
-            lossFunctionPtr_->updateLabelWiseStatistics(statisticIndex, *labelMatrixPtr_, *scoreMatrixPtr_,
-                                                        prediction.indices_cbegin(), prediction.indices_cend(),
-                                                        *this->statisticMatrixPtr_);
-        }
-
-    public:
-
-        /**
-         * @param lossFunctionPtr           A shared pointer to an object of type `ILabelWiseLoss`, representing the
-         *                                  loss function to be used for calculating gradients and Hessians
-         * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory`,
-         *                                  that allows to create instances of the class that is used for calculating
-         *                                  the predictions, as well as corresponding quality scores, of rules
-         * @param labelMatrixPtr            A shared pointer to an object of type `IRandomAccessLabelMatrix` that
-         *                                  provides random access to the labels of the training examples
-         * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
-         *                                  stores the gradients and Hessians
-         * @param scoreMatrixPtr            An unique pointer to an object of template type `ScoreMatrix` that stores
-         *                                  the currently predicted scores
-         */
-        LabelWiseStatistics(std::shared_ptr<ILabelWiseLoss> lossFunctionPtr,
-                            std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
-                            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr,
-                            std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
-                            std::unique_ptr<ScoreMatrix> scoreMatrixPtr)
-            : AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
-                  std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
-              totalSumVectorPtr_(std::make_unique<StatisticVector>(this->statisticMatrixPtr_->getNumCols())),
-              lossFunctionPtr_(lossFunctionPtr), labelMatrixPtr_(labelMatrixPtr),
-              scoreMatrixPtr_(std::move(scoreMatrixPtr)) {
-
-        }
-
-        void setRuleEvaluationFactory(
-                std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr) override {
-            this->ruleEvaluationFactoryPtr_ = ruleEvaluationFactoryPtr;
-        }
-
-        void resetSampledStatistics() override {
-            // This function is equivalent to the function `resetCoveredStatistics`...
-            this->resetCoveredStatistics();
-        }
-
-        void addSampledStatistic(uint32 statisticIndex, uint32 weight) override {
-            // This function is equivalent to the function `updateCoveredStatistic`...
-            this->updateCoveredStatistic(statisticIndex, weight, false);
-        }
-
-        void resetCoveredStatistics() override {
-            totalSumVectorPtr_->setAllToZero();
-        }
-
-        void updateCoveredStatistic(uint32 statisticIndex, uint32 weight, bool remove) override {
-            float64 signedWeight = remove ? -((float64) weight) : weight;
-            totalSumVectorPtr_->add(this->statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
-                                    this->statisticMatrixPtr_->gradients_row_cend(statisticIndex),
-                                    this->statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                                    this->statisticMatrixPtr_->hessians_row_cend(statisticIndex), signedWeight);
-        }
-
-        void applyPrediction(uint32 statisticIndex, const FullPrediction& prediction) override {
-            this->applyPredictionInternally<FullPrediction>(statisticIndex, prediction);
-        }
-
-        void applyPrediction(uint32 statisticIndex, const PartialPrediction& prediction) override {
-            this->applyPredictionInternally<PartialPrediction>(statisticIndex, prediction);
-        }
-
-        std::unique_ptr<IHistogramBuilder> createHistogramBuilder(uint32 numBins) const override {
-            return std::make_unique<HistogramBuilder>(*this, numBins);
-        }
-
-        std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override {
-            std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename LabelWiseStatistics::FullSubset>(*this, totalSumVectorPtr_.get(),
-                                                                              std::move(ruleEvaluationPtr),
-                                                                              labelIndices);
-        }
-
-        std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override {
-            std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
-                this->ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<typename LabelWiseStatistics::PartialSubset>(*this, totalSumVectorPtr_.get(),
+            std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override {
+                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename LabelWiseHistogram::FullSubset>(*this, totalSumVector_,
                                                                                  std::move(ruleEvaluationPtr),
                                                                                  labelIndices);
-        }
+            }
 
-};
+            std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override {
+                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename LabelWiseHistogram::PartialSubset>(*this, totalSumVector_,
+                                                                                    std::move(ruleEvaluationPtr),
+                                                                                    labelIndices);
+            }
+
+    };
+
+    /**
+     * Provides access to gradients and Hessians that are calculated according to a differentiable loss function that is
+     * applied label-wise and allows to update the gradients and Hessians after a new rule has been learned.
+     *
+     * @tparam StatisticVector  The type of the vectors that are used to store gradients and Hessians
+     * @tparam StatisticMatrix  The type of the matrices that are used to store gradients and Hessians
+     * @tparam ScoreMatrix      The type of the matrices that are used to store predicted scores
+     */
+    template<class StatisticVector, class StatisticMatrix, class ScoreMatrix>
+    class LabelWiseStatistics final : public AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>,
+                                      virtual public ILabelWiseStatistics {
+
+        private:
+
+            /**
+             * Allows to build a histogram based on the gradients and Hessians that are stored by an instance of the
+             * class `LabelWiseStatistics`.
+             */
+            class HistogramBuilder final : public IHistogramBuilder {
+
+                private:
+
+                    const LabelWiseStatistics& statistics_;
+
+                    std::unique_ptr<StatisticMatrix> statisticMatrixPtr_;
+
+                public:
+
+                    /**
+                     * @param statistics    A reference to an object of type `LabelWiseStatistics` that stores the
+                     *                      gradients and Hessians
+                     * @param numBins       The number of bins, the histogram should consist of
+                     */
+                    HistogramBuilder(const LabelWiseStatistics& statistics, uint32 numBins)
+                        : statistics_(statistics),
+                          statisticMatrixPtr_(std::make_unique<StatisticMatrix>(numBins, statistics.getNumLabels(),
+                                                                                true)) {
+
+                    }
+
+                    uint32 getNumBins() const override {
+                        return statisticMatrixPtr_->getNumRows();
+                    }
+
+                    void addToBin(uint32 binIndex, uint32 statisticIndex, uint32 weight) override {
+                        statisticMatrixPtr_->addToRow(
+                            binIndex, statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                            statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                            statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                            statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), weight);
+                    }
+
+                    std::unique_ptr<IHistogram> build() override {
+                        return std::make_unique<LabelWiseHistogram<StatisticVector, StatisticMatrix, ScoreMatrix>>(
+                            *statistics_.statisticMatrixPtr_, statistics_.totalSumVectorPtr_.get(),
+                            std::move(statisticMatrixPtr_), statistics_.ruleEvaluationFactoryPtr_);
+                    }
+
+            };
+
+            std::unique_ptr<StatisticVector> totalSumVectorPtr_;
+
+            std::shared_ptr<ILabelWiseLoss> lossFunctionPtr_;
+
+            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr_;
+
+            std::unique_ptr<ScoreMatrix> scoreMatrixPtr_;
+
+            template<class T>
+            void applyPredictionInternally(uint32 statisticIndex, const T& prediction) {
+                // Update the scores that are currently predicted for the example at the given index...
+                scoreMatrixPtr_->addToRowFromSubset(statisticIndex, prediction.scores_cbegin(),
+                                                    prediction.scores_cend(), prediction.indices_cbegin(),
+                                                    prediction.indices_cend());
+
+                // Update the gradients and Hessians of the example at the given index...
+                lossFunctionPtr_->updateLabelWiseStatistics(statisticIndex, *labelMatrixPtr_, *scoreMatrixPtr_,
+                                                            prediction.indices_cbegin(), prediction.indices_cend(),
+                                                            *this->statisticMatrixPtr_);
+            }
+
+        public:
+
+            /**
+             * @param lossFunctionPtr           A shared pointer to an object of type `ILabelWiseLoss`, representing the
+             *                                  loss function to be used for calculating gradients and Hessians
+             * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory`,
+             *                                  that allows to create instances of the class that is used for
+             *                                  calculating the predictions, as well as corresponding quality scores, of
+             *                                  rules
+             * @param labelMatrixPtr            A shared pointer to an object of type `IRandomAccessLabelMatrix` that
+             *                                  provides random access to the labels of the training examples
+             * @param statisticMatrixPtr        An unique pointer to an object of template type `StatisticMatrix` that
+             *                                  stores the gradients and Hessians
+             * @param scoreMatrixPtr            An unique pointer to an object of template type `ScoreMatrix` that
+             *                                  stores the currently predicted scores
+             */
+            LabelWiseStatistics(std::shared_ptr<ILabelWiseLoss> lossFunctionPtr,
+                                std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
+                                std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr,
+                                std::unique_ptr<StatisticMatrix> statisticMatrixPtr,
+                                std::unique_ptr<ScoreMatrix> scoreMatrixPtr)
+                : AbstractLabelWiseStatistics<StatisticVector, StatisticMatrix, ScoreMatrix>(
+                      std::move(statisticMatrixPtr), ruleEvaluationFactoryPtr),
+                  totalSumVectorPtr_(std::make_unique<StatisticVector>(this->statisticMatrixPtr_->getNumCols())),
+                  lossFunctionPtr_(lossFunctionPtr), labelMatrixPtr_(labelMatrixPtr),
+                  scoreMatrixPtr_(std::move(scoreMatrixPtr)) {
+
+            }
+
+            void setRuleEvaluationFactory(
+                    std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr) override {
+                this->ruleEvaluationFactoryPtr_ = ruleEvaluationFactoryPtr;
+            }
+
+            void resetSampledStatistics() override {
+                // This function is equivalent to the function `resetCoveredStatistics`...
+                this->resetCoveredStatistics();
+            }
+
+            void addSampledStatistic(uint32 statisticIndex, uint32 weight) override {
+                // This function is equivalent to the function `updateCoveredStatistic`...
+                this->updateCoveredStatistic(statisticIndex, weight, false);
+            }
+
+            void resetCoveredStatistics() override {
+                totalSumVectorPtr_->setAllToZero();
+            }
+
+            void updateCoveredStatistic(uint32 statisticIndex, uint32 weight, bool remove) override {
+                float64 signedWeight = remove ? -((float64) weight) : weight;
+                totalSumVectorPtr_->add(this->statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
+                                        this->statisticMatrixPtr_->gradients_row_cend(statisticIndex),
+                                        this->statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
+                                        this->statisticMatrixPtr_->hessians_row_cend(statisticIndex), signedWeight);
+            }
+
+            void applyPrediction(uint32 statisticIndex, const FullPrediction& prediction) override {
+                this->applyPredictionInternally<FullPrediction>(statisticIndex, prediction);
+            }
+
+            void applyPrediction(uint32 statisticIndex, const PartialPrediction& prediction) override {
+                this->applyPredictionInternally<PartialPrediction>(statisticIndex, prediction);
+            }
+
+            std::unique_ptr<IHistogramBuilder> createHistogramBuilder(uint32 numBins) const override {
+                return std::make_unique<HistogramBuilder>(*this, numBins);
+            }
+
+            std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override {
+                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename LabelWiseStatistics::FullSubset>(*this, totalSumVectorPtr_.get(),
+                                                                                  std::move(ruleEvaluationPtr),
+                                                                                  labelIndices);
+            }
+
+            std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override {
+                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
+                    this->ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<typename LabelWiseStatistics::PartialSubset>(*this, totalSumVectorPtr_.get(),
+                                                                                     std::move(ruleEvaluationPtr),
+                                                                                     labelIndices);
+            }
+
+    };
+
+}

--- a/python/boomer/boosting/cpp/statistics/statistics_label_wise_dense.cpp
+++ b/python/boomer/boosting/cpp/statistics/statistics_label_wise_dense.cpp
@@ -4,35 +4,37 @@
 #include "../data/matrix_dense_label_wise.h"
 #include "../data/vector_dense_label_wise.h"
 
-using namespace boosting;
 
+namespace boosting {
 
-DenseLabelWiseStatisticsFactory::DenseLabelWiseStatisticsFactory(
-        std::shared_ptr<ILabelWiseLoss> lossFunctionPtr,
-        std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
-        std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr)
-    : lossFunctionPtr_(lossFunctionPtr), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr),
-      labelMatrixPtr_(labelMatrixPtr) {
+    DenseLabelWiseStatisticsFactory::DenseLabelWiseStatisticsFactory(
+            std::shared_ptr<ILabelWiseLoss> lossFunctionPtr,
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
+            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr)
+        : lossFunctionPtr_(lossFunctionPtr), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr),
+          labelMatrixPtr_(labelMatrixPtr) {
 
-}
-
-std::unique_ptr<ILabelWiseStatistics> DenseLabelWiseStatisticsFactory::create() const {
-    uint32 numExamples = labelMatrixPtr_->getNumRows();
-    uint32 numLabels = labelMatrixPtr_->getNumCols();
-    std::unique_ptr<DenseLabelWiseStatisticMatrix> statisticMatrixPtr =
-        std::make_unique<DenseLabelWiseStatisticMatrix>(numExamples, numLabels);
-    std::unique_ptr<DenseNumericMatrix<float64>> scoreMatrixPtr =
-        std::make_unique<DenseNumericMatrix<float64>>(numExamples, numLabels, true);
-    FullIndexVector labelIndices(numLabels);
-    FullIndexVector::const_iterator labelIndicesBegin = labelIndices.cbegin();
-    FullIndexVector::const_iterator labelIndicesEnd = labelIndices.cend();
-
-    for (uint32 r = 0; r < numExamples; r++) {
-        lossFunctionPtr_->updateLabelWiseStatistics(r, *labelMatrixPtr_, *scoreMatrixPtr, labelIndicesBegin,
-                                                    labelIndicesEnd, *statisticMatrixPtr);
     }
 
-    return std::make_unique<LabelWiseStatistics<DenseLabelWiseStatisticVector, DenseLabelWiseStatisticMatrix, DenseNumericMatrix<float64>>>(
-        lossFunctionPtr_, ruleEvaluationFactoryPtr_, labelMatrixPtr_, std::move(statisticMatrixPtr),
-        std::move(scoreMatrixPtr));
+    std::unique_ptr<ILabelWiseStatistics> DenseLabelWiseStatisticsFactory::create() const {
+        uint32 numExamples = labelMatrixPtr_->getNumRows();
+        uint32 numLabels = labelMatrixPtr_->getNumCols();
+        std::unique_ptr<DenseLabelWiseStatisticMatrix> statisticMatrixPtr =
+            std::make_unique<DenseLabelWiseStatisticMatrix>(numExamples, numLabels);
+        std::unique_ptr<DenseNumericMatrix<float64>> scoreMatrixPtr =
+            std::make_unique<DenseNumericMatrix<float64>>(numExamples, numLabels, true);
+        FullIndexVector labelIndices(numLabels);
+        FullIndexVector::const_iterator labelIndicesBegin = labelIndices.cbegin();
+        FullIndexVector::const_iterator labelIndicesEnd = labelIndices.cend();
+
+        for (uint32 r = 0; r < numExamples; r++) {
+            lossFunctionPtr_->updateLabelWiseStatistics(r, *labelMatrixPtr_, *scoreMatrixPtr, labelIndicesBegin,
+                                                        labelIndicesEnd, *statisticMatrixPtr);
+        }
+
+        return std::make_unique<LabelWiseStatistics<DenseLabelWiseStatisticVector, DenseLabelWiseStatisticMatrix, DenseNumericMatrix<float64>>>(
+            lossFunctionPtr_, ruleEvaluationFactoryPtr_, labelMatrixPtr_, std::move(statisticMatrixPtr),
+            std::move(scoreMatrixPtr));
+    }
+
 }

--- a/python/boomer/seco/cpp/head_refinement/head_refinement_partial.cpp
+++ b/python/boomer/seco/cpp/head_refinement/head_refinement_partial.cpp
@@ -4,164 +4,168 @@
 #include "../../../common/cpp/rule_evaluation/score_processor_label_wise.h"
 #include <algorithm>
 
-using namespace seco;
 
+namespace seco {
 
-template<class Iterator>
-static inline std::unique_ptr<SparseArrayVector<float64>> argsort(Iterator iterator, uint32 numElements) {
-    std::unique_ptr<SparseArrayVector<float64>> sortedVectorPtr = std::make_unique<SparseArrayVector<float64>>(
-        numElements);
-    SparseArrayVector<float64>::iterator sortedIterator = sortedVectorPtr->begin();
+    template<class Iterator>
+    static inline std::unique_ptr<SparseArrayVector<float64>> argsort(Iterator iterator, uint32 numElements) {
+        std::unique_ptr<SparseArrayVector<float64>> sortedVectorPtr = std::make_unique<SparseArrayVector<float64>>(
+            numElements);
+        SparseArrayVector<float64>::iterator sortedIterator = sortedVectorPtr->begin();
 
-    for (uint32 i = 0; i < numElements; i++) {
-        sortedIterator[i].index = i;
-        sortedIterator[i].value = iterator[i];
+        for (uint32 i = 0; i < numElements; i++) {
+            sortedIterator[i].index = i;
+            sortedIterator[i].value = iterator[i];
+        }
+
+        sortedVectorPtr->sortByValues();
+        return sortedVectorPtr;
     }
 
-    sortedVectorPtr->sortByValues();
-    return sortedVectorPtr;
-}
+    /**
+     * Allows to find the best head that predicts for one or several labels depending on a lift function.
+     *
+     * @tparam T The type of the vector that provides access to the indices of the labels that are considered when
+     *           searching for the best head
+     */
+    template<class T>
+    class PartialHeadRefinement final : public IHeadRefinement, public ILabelWiseScoreProcessor {
 
-/**
- * Allows to find the best head that predicts for one or several labels depending on a lift function.
- *
- * @tparam T The type of the vector that provides access to the indices of the labels that are considered when searching
- *           for the best head
- */
-template<class T>
-class PartialHeadRefinement final : public IHeadRefinement, public ILabelWiseScoreProcessor {
+        private:
 
-    private:
+            bool keepLabels_;
 
-        bool keepLabels_;
+            std::shared_ptr<ILiftFunction> liftFunctionPtr_;
 
-        std::shared_ptr<ILiftFunction> liftFunctionPtr_;
+            std::unique_ptr<PartialPrediction> headPtr_;
 
-        std::unique_ptr<PartialPrediction> headPtr_;
-
-        template<class T2>
-        const AbstractEvaluatedPrediction* processScoresInternally(const AbstractEvaluatedPrediction* bestHead,
-                                                                   const T2& scoreVector) {
-            uint32 numPredictions = scoreVector.getNumElements();
-            typename T2::quality_score_const_iterator qualityScoreIterator = scoreVector.quality_scores_cbegin();
-            std::unique_ptr<SparseArrayVector<float64>> sortedVectorPtr;
-            float64 sumOfQualityScores = 0;
-            uint32 bestNumPredictions = 0;
-            float64 bestQualityScore = 0;
-
-            if (keepLabels_) {
-                for (uint32 c = 0; c < numPredictions; c++) {
-                    sumOfQualityScores += 1 - qualityScoreIterator[c];
-                }
-
-                bestQualityScore =
-                    1 - (sumOfQualityScores / numPredictions) * liftFunctionPtr_->calculateLift(numPredictions);
-                bestNumPredictions = numPredictions;
-            } else {
-                sortedVectorPtr = argsort(qualityScoreIterator, numPredictions);
-                SparseArrayVector<float64>::const_iterator sortedIterator = sortedVectorPtr->cbegin();
-                float64 maximumLift = liftFunctionPtr_->getMaxLift();
-
-                for (uint32 c = 0; c < numPredictions; c++) {
-                    sumOfQualityScores += 1 - qualityScoreIterator[sortedIterator[c].index];
-                    float64 qualityScore = 1 - (sumOfQualityScores / (c + 1)) * liftFunctionPtr_->calculateLift(c + 1);
-
-                    if (c == 0 || qualityScore < bestQualityScore) {
-                        bestNumPredictions = c + 1;
-                        bestQualityScore = qualityScore;
-                    }
-
-                    if (qualityScore * maximumLift < bestQualityScore) {
-                        // Prunable by decomposition...
-                        break;
-                    }
-                }
-            }
-
-            if (bestHead == nullptr || bestQualityScore < bestHead->overallQualityScore) {
-                if (headPtr_.get() == nullptr) {
-                    headPtr_ = std::make_unique<PartialPrediction>(bestNumPredictions);
-                } else if (headPtr_->getNumElements() != bestNumPredictions) {
-                    headPtr_->setNumElements(bestNumPredictions, false);
-                }
+            template<class T2>
+            const AbstractEvaluatedPrediction* processScoresInternally(const AbstractEvaluatedPrediction* bestHead,
+                                                                       const T2& scoreVector) {
+                uint32 numPredictions = scoreVector.getNumElements();
+                typename T2::quality_score_const_iterator qualityScoreIterator = scoreVector.quality_scores_cbegin();
+                std::unique_ptr<SparseArrayVector<float64>> sortedVectorPtr;
+                float64 sumOfQualityScores = 0;
+                uint32 bestNumPredictions = 0;
+                float64 bestQualityScore = 0;
 
                 if (keepLabels_) {
-                    std::copy(scoreVector.indices_cbegin(), scoreVector.indices_cend(), headPtr_->indices_begin());
-                    std::copy(scoreVector.scores_cbegin(), scoreVector.scores_cend(), headPtr_->scores_begin());
-                } else {
-                    SparseArrayVector<float64>::const_iterator sortedIterator = sortedVectorPtr->cbegin();
-                    typename T2::score_const_iterator scoreIterator = scoreVector.scores_cbegin();
-                    typename T2::index_const_iterator indexIterator = scoreVector.indices_cbegin();
-                    PartialPrediction::score_iterator headScoreIterator = headPtr_->scores_begin();
-                    PartialPrediction::index_iterator headIndexIterator = headPtr_->indices_begin();
+                    for (uint32 c = 0; c < numPredictions; c++) {
+                        sumOfQualityScores += 1 - qualityScoreIterator[c];
+                    }
 
-                    for (uint32 c = 0; c < bestNumPredictions; c++) {
-                        uint32 i = sortedIterator[c].index;
-                        headIndexIterator[c] = indexIterator[i];
-                        headScoreIterator[c] = scoreIterator[i];
+                    bestQualityScore =
+                        1 - (sumOfQualityScores / numPredictions) * liftFunctionPtr_->calculateLift(numPredictions);
+                    bestNumPredictions = numPredictions;
+                } else {
+                    sortedVectorPtr = argsort(qualityScoreIterator, numPredictions);
+                    SparseArrayVector<float64>::const_iterator sortedIterator = sortedVectorPtr->cbegin();
+                    float64 maximumLift = liftFunctionPtr_->getMaxLift();
+
+                    for (uint32 c = 0; c < numPredictions; c++) {
+                        sumOfQualityScores += 1 - qualityScoreIterator[sortedIterator[c].index];
+                        float64 qualityScore = 1 - (sumOfQualityScores / (c + 1))
+                                               * liftFunctionPtr_->calculateLift(c + 1);
+
+                        if (c == 0 || qualityScore < bestQualityScore) {
+                            bestNumPredictions = c + 1;
+                            bestQualityScore = qualityScore;
+                        }
+
+                        if (qualityScore * maximumLift < bestQualityScore) {
+                            // Prunable by decomposition...
+                            break;
+                        }
                     }
                 }
 
-                headPtr_->overallQualityScore = bestQualityScore;
-                return headPtr_.get();
+                if (bestHead == nullptr || bestQualityScore < bestHead->overallQualityScore) {
+                    if (headPtr_.get() == nullptr) {
+                        headPtr_ = std::make_unique<PartialPrediction>(bestNumPredictions);
+                    } else if (headPtr_->getNumElements() != bestNumPredictions) {
+                        headPtr_->setNumElements(bestNumPredictions, false);
+                    }
+
+                    if (keepLabels_) {
+                        std::copy(scoreVector.indices_cbegin(), scoreVector.indices_cend(), headPtr_->indices_begin());
+                        std::copy(scoreVector.scores_cbegin(), scoreVector.scores_cend(), headPtr_->scores_begin());
+                    } else {
+                        SparseArrayVector<float64>::const_iterator sortedIterator = sortedVectorPtr->cbegin();
+                        typename T2::score_const_iterator scoreIterator = scoreVector.scores_cbegin();
+                        typename T2::index_const_iterator indexIterator = scoreVector.indices_cbegin();
+                        PartialPrediction::score_iterator headScoreIterator = headPtr_->scores_begin();
+                        PartialPrediction::index_iterator headIndexIterator = headPtr_->indices_begin();
+
+                        for (uint32 c = 0; c < bestNumPredictions; c++) {
+                            uint32 i = sortedIterator[c].index;
+                            headIndexIterator[c] = indexIterator[i];
+                            headScoreIterator[c] = scoreIterator[i];
+                        }
+                    }
+
+                    headPtr_->overallQualityScore = bestQualityScore;
+                    return headPtr_.get();
+                }
+
+                return nullptr;
             }
 
-            return nullptr;
-        }
+        public:
 
-    public:
+            /**
+             * @param labelIndices      A reference to an object of template type `T` that provides access to the
+             *                          indices of the labels that should be considered when searching for the best head
+             * @param liftFunctionPtr   A shared pointer to an object of type `ILiftFunction` that should affect the
+             *                          quality scores of rules, depending on how many labels they predict
+             */
+            PartialHeadRefinement(const T& labelIndices, std::shared_ptr<ILiftFunction> liftFunctionPtr)
+                : keepLabels_(labelIndices.isPartial()), liftFunctionPtr_(liftFunctionPtr) {
 
-        /**
-         * @param labelIndices      A reference to an object of template type `T` that provides access to the indices of
-         *                          the labels that should be considered when searching for the best head
-         * @param liftFunctionPtr   A shared pointer to an object of type `ILiftFunction` that should affect the quality
-         *                          scores of rules, depending on how many labels they predict
-         */
-        PartialHeadRefinement(const T& labelIndices, std::shared_ptr<ILiftFunction> liftFunctionPtr)
-            : keepLabels_(labelIndices.isPartial()), liftFunctionPtr_(liftFunctionPtr) {
+            }
 
-        }
+            const AbstractEvaluatedPrediction* processScores(
+                    const AbstractEvaluatedPrediction* bestHead,
+                    const DenseLabelWiseScoreVector<FullIndexVector>& scoreVector) override {
+                return processScoresInternally<DenseLabelWiseScoreVector<FullIndexVector>>(bestHead, scoreVector);
+            }
 
-        const AbstractEvaluatedPrediction* processScores(
-                const AbstractEvaluatedPrediction* bestHead,
-                const DenseLabelWiseScoreVector<FullIndexVector>& scoreVector) override {
-            return processScoresInternally<DenseLabelWiseScoreVector<FullIndexVector>>(bestHead, scoreVector);
-        }
+            const AbstractEvaluatedPrediction* processScores(
+                    const AbstractEvaluatedPrediction* bestHead,
+                    const DenseLabelWiseScoreVector<PartialIndexVector>& scoreVector) override {
+                return processScoresInternally<DenseLabelWiseScoreVector<PartialIndexVector>>(bestHead, scoreVector);
+            }
 
-        const AbstractEvaluatedPrediction* processScores(
-                const AbstractEvaluatedPrediction* bestHead,
-                const DenseLabelWiseScoreVector<PartialIndexVector>& scoreVector) override {
-            return processScoresInternally<DenseLabelWiseScoreVector<PartialIndexVector>>(bestHead, scoreVector);
-        }
+            const AbstractEvaluatedPrediction* findHead(const AbstractEvaluatedPrediction* bestHead,
+                                                        IStatisticsSubset& statisticsSubset, bool uncovered,
+                                                        bool accumulated) override {
+                const ILabelWiseScoreVector& scoreVector = statisticsSubset.calculateLabelWisePrediction(uncovered,
+                                                                                                         accumulated);
+                return scoreVector.processScores(bestHead, *this);
+            }
 
-        const AbstractEvaluatedPrediction* findHead(const AbstractEvaluatedPrediction* bestHead,
-                                                    IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                    bool accumulated) override {
-            const ILabelWiseScoreVector& scoreVector = statisticsSubset.calculateLabelWisePrediction(uncovered,
-                                                                                                     accumulated);
-            return scoreVector.processScores(bestHead, *this);
-        }
+            std::unique_ptr<AbstractEvaluatedPrediction> pollHead() override {
+                return std::move(headPtr_);
+            }
 
-        std::unique_ptr<AbstractEvaluatedPrediction> pollHead() override {
-            return std::move(headPtr_);
-        }
+            const IScoreVector& calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
+                                                    bool accumulated) const override {
+                return statisticsSubset.calculateLabelWisePrediction(uncovered, accumulated);
+            }
 
-        const IScoreVector& calculatePrediction(IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                bool accumulated) const override {
-            return statisticsSubset.calculateLabelWisePrediction(uncovered, accumulated);
-        }
+    };
 
-};
+    PartialHeadRefinementFactory::PartialHeadRefinementFactory(std::shared_ptr<ILiftFunction> liftFunctionPtr)
+        : liftFunctionPtr_(liftFunctionPtr) {
 
-PartialHeadRefinementFactory::PartialHeadRefinementFactory(std::shared_ptr<ILiftFunction> liftFunctionPtr)
-    : liftFunctionPtr_(liftFunctionPtr) {
+    }
 
-}
+    std::unique_ptr<IHeadRefinement> PartialHeadRefinementFactory::create(const FullIndexVector& labelIndices) const {
+        return std::make_unique<PartialHeadRefinement<FullIndexVector>>(labelIndices, liftFunctionPtr_);
+    }
 
-std::unique_ptr<IHeadRefinement> PartialHeadRefinementFactory::create(const FullIndexVector& labelIndices) const {
-    return std::make_unique<PartialHeadRefinement<FullIndexVector>>(labelIndices, liftFunctionPtr_);
-}
+    std::unique_ptr<IHeadRefinement> PartialHeadRefinementFactory::create(
+            const PartialIndexVector& labelIndices) const {
+        return std::make_unique<PartialHeadRefinement<PartialIndexVector>>(labelIndices, liftFunctionPtr_);
+    }
 
-std::unique_ptr<IHeadRefinement> PartialHeadRefinementFactory::create(const PartialIndexVector& labelIndices) const {
-    return std::make_unique<PartialHeadRefinement<PartialIndexVector>>(labelIndices, liftFunctionPtr_);
 }

--- a/python/boomer/seco/cpp/head_refinement/lift_function_peak.cpp
+++ b/python/boomer/seco/cpp/head_refinement/lift_function_peak.cpp
@@ -1,28 +1,31 @@
 #include "lift_function_peak.h"
 #include <cmath>
 
-using namespace seco;
 
+namespace seco {
 
-PeakLiftFunction::PeakLiftFunction(uint32 numLabels, uint32 peakLabel, float64 maxLift, float64 curvature)
-    : numLabels_(numLabels), peakLabel_(peakLabel), maxLift_(maxLift), exponent_(1.0 / curvature) {
+    PeakLiftFunction::PeakLiftFunction(uint32 numLabels, uint32 peakLabel, float64 maxLift, float64 curvature)
+        : numLabels_(numLabels), peakLabel_(peakLabel), maxLift_(maxLift), exponent_(1.0 / curvature) {
 
-}
+    }
 
-float64 PeakLiftFunction::calculateLift(uint32 numLabels) const {
-    float64 normalization;
+    float64 PeakLiftFunction::calculateLift(uint32 numLabels) const {
+        float64 normalization;
 
-    if (numLabels < peakLabel_) {
-        normalization = ((float64) numLabels - 1) / ((float64) peakLabel_ - 1);
-    } else if (numLabels > peakLabel_) {
-        normalization = ((float64) numLabels - (float64) numLabels_) / ((float64) numLabels_ - (float64) peakLabel_);
-    } else {
+        if (numLabels < peakLabel_) {
+            normalization = ((float64) numLabels - 1) / ((float64) peakLabel_ - 1);
+        } else if (numLabels > peakLabel_) {
+            normalization = ((float64) numLabels - (float64) numLabels_)
+                            / ((float64) numLabels_ - (float64) peakLabel_);
+        } else {
+            return maxLift_;
+        }
+
+        return 1 + pow(normalization, exponent_) * (maxLift_ - 1);
+    }
+
+    float64 PeakLiftFunction::getMaxLift() const {
         return maxLift_;
     }
 
-    return 1 + pow(normalization, exponent_) * (maxLift_ - 1);
-}
-
-float64 PeakLiftFunction::getMaxLift() const {
-    return maxLift_;
 }

--- a/python/boomer/seco/cpp/heuristics/heuristic_f_measure.cpp
+++ b/python/boomer/seco/cpp/heuristics/heuristic_f_measure.cpp
@@ -2,33 +2,35 @@
 #include "heuristic_common.h"
 #include <cmath>
 
-using namespace seco;
 
+namespace seco {
 
-FMeasure::FMeasure(float64 beta)
-    : beta_(beta) {
+    FMeasure::FMeasure(float64 beta)
+        : beta_(beta) {
 
-}
-
-float64 FMeasure::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin, float64 uip,
-                                          float64 urn, float64 urp) const {
-    if (std::isinf(beta_)) {
-        // Equivalent to recall
-        return recall(cin, crp, uin, urp);
-    } else if (beta_ > 0) {
-        // Weighted harmonic mean between precision and recall
-        float64 numCoveredEqual = cin + crp;
-        float64 betaPow = beta_ * beta_;
-        float64 numerator = (1 + betaPow) * numCoveredEqual;
-        float64 denominator = numerator + (betaPow * (uin + urp)) + (cip + crn);
-
-        if (denominator == 0) {
-            return 1;
-        }
-
-        return 1 - (numerator / denominator);
-    } else {
-        // Equivalent to precision
-        return precision(cin, cip, crn, crp);
     }
+
+    float64 FMeasure::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
+                                              float64 uip, float64 urn, float64 urp) const {
+        if (std::isinf(beta_)) {
+            // Equivalent to recall
+            return recall(cin, crp, uin, urp);
+        } else if (beta_ > 0) {
+            // Weighted harmonic mean between precision and recall
+            float64 numCoveredEqual = cin + crp;
+            float64 betaPow = beta_ * beta_;
+            float64 numerator = (1 + betaPow) * numCoveredEqual;
+            float64 denominator = numerator + (betaPow * (uin + urp)) + (cip + crn);
+
+            if (denominator == 0) {
+                return 1;
+            }
+
+            return 1 - (numerator / denominator);
+        } else {
+            // Equivalent to precision
+            return precision(cin, cip, crn, crp);
+        }
+    }
+
 }

--- a/python/boomer/seco/cpp/heuristics/heuristic_hamming_loss.cpp
+++ b/python/boomer/seco/cpp/heuristics/heuristic_hamming_loss.cpp
@@ -1,19 +1,21 @@
 #include "heuristic_hamming_loss.h"
 
-using namespace seco;
 
+namespace seco {
 
-float64 HammingLoss::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
-                                             float64 uip, float64 urn, float64 urp) const {
-    float64 numCoveredIncorrect = cip + crn;
-    float64 numCoveredCorrect = cin + crp;
-    float64 numCovered = numCoveredIncorrect + numCoveredCorrect;
+    float64 HammingLoss::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
+                                                 float64 uip, float64 urn, float64 urp) const {
+        float64 numCoveredIncorrect = cip + crn;
+        float64 numCoveredCorrect = cin + crp;
+        float64 numCovered = numCoveredIncorrect + numCoveredCorrect;
 
-    if (numCovered == 0) {
-        return 1;
+        if (numCovered == 0) {
+            return 1;
+        }
+
+        float64 numIncorrect = numCoveredIncorrect + urn + urp;
+        float64 numTotal = numIncorrect + numCoveredCorrect + uin + uip;
+        return numIncorrect / numTotal;
     }
 
-    float64 numIncorrect = numCoveredIncorrect + urn + urp;
-    float64 numTotal = numIncorrect + numCoveredCorrect + uin + uip;
-    return numIncorrect / numTotal;
 }

--- a/python/boomer/seco/cpp/heuristics/heuristic_m_estimate.cpp
+++ b/python/boomer/seco/cpp/heuristics/heuristic_m_estimate.cpp
@@ -2,34 +2,36 @@
 #include "heuristic_common.h"
 #include <cmath>
 
-using namespace seco;
 
+namespace seco {
 
-MEstimate::MEstimate(float64 m)
-    : m_(m) {
+    MEstimate::MEstimate(float64 m)
+        : m_(m) {
 
-}
-
-float64 MEstimate::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin, float64 uip,
-                                           float64 urn, float64 urp) const {
-    if (std::isinf(m_)) {
-        // Equivalent to weighted relative accuracy
-        return wra(cin, cip, crn, crp, uin, uip, urn, urp);
-    } else if (m_ > 0) {
-        // Trade-off between precision and weighted relative accuracy
-        float64 numCoveredEqual = cin + crp;
-        float64 numCovered = numCoveredEqual + cip + crn;
-
-        if (numCovered == 0) {
-            return 1;
-        }
-
-        float64 numUncoveredEqual = uin + urp;
-        float64 numTotal = numCovered + numUncoveredEqual + uip + urn;
-        float64 numEqual = numCoveredEqual + numUncoveredEqual;
-        return 1 - ((numCoveredEqual + (m_ * (numEqual / numTotal))) / (numCovered + m_));
-    } else {
-        // Equivalent to precision
-        return precision(cin, cip, crn, crp);
     }
+
+    float64 MEstimate::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
+                                               float64 uip, float64 urn, float64 urp) const {
+        if (std::isinf(m_)) {
+            // Equivalent to weighted relative accuracy
+            return wra(cin, cip, crn, crp, uin, uip, urn, urp);
+        } else if (m_ > 0) {
+            // Trade-off between precision and weighted relative accuracy
+            float64 numCoveredEqual = cin + crp;
+            float64 numCovered = numCoveredEqual + cip + crn;
+
+            if (numCovered == 0) {
+                return 1;
+            }
+
+            float64 numUncoveredEqual = uin + urp;
+            float64 numTotal = numCovered + numUncoveredEqual + uip + urn;
+            float64 numEqual = numCoveredEqual + numUncoveredEqual;
+            return 1 - ((numCoveredEqual + (m_ * (numEqual / numTotal))) / (numCovered + m_));
+        } else {
+            // Equivalent to precision
+            return precision(cin, cip, crn, crp);
+        }
+    }
+
 }

--- a/python/boomer/seco/cpp/heuristics/heuristic_precision.cpp
+++ b/python/boomer/seco/cpp/heuristics/heuristic_precision.cpp
@@ -1,10 +1,12 @@
 #include "heuristic_precision.h"
 #include "heuristic_common.h"
 
-using namespace seco;
 
+namespace seco {
 
-float64 Precision::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin, float64 uip,
-                                           float64 urn, float64 urp) const {
-    return precision(cin, cip, crn, crp);
+    float64 Precision::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
+                                               float64 uip, float64 urn, float64 urp) const {
+        return precision(cin, cip, crn, crp);
+    }
+
 }

--- a/python/boomer/seco/cpp/heuristics/heuristic_recall.cpp
+++ b/python/boomer/seco/cpp/heuristics/heuristic_recall.cpp
@@ -1,10 +1,12 @@
 #include "heuristic_recall.h"
 #include "heuristic_common.h"
 
-using namespace seco;
 
+namespace seco {
 
-float64 Recall::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin, float64 uip,
-                                        float64 urn, float64 urp) const {
-    return recall(cin, crp, uin, urp);
+    float64 Recall::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin,
+                                            float64 uip, float64 urn, float64 urp) const {
+        return recall(cin, crp, uin, urp);
+    }
+
 }

--- a/python/boomer/seco/cpp/heuristics/heuristic_wra.cpp
+++ b/python/boomer/seco/cpp/heuristics/heuristic_wra.cpp
@@ -1,10 +1,12 @@
 #include "heuristic_wra.h"
 #include "heuristic_common.h"
 
-using namespace seco;
 
+namespace seco {
 
-float64 WRA::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin, float64 uip,
-                                     float64 urn, float64 urp) const {
-    return wra(cin, cip, crn, crp, uin, uip, urn, urp);
+    float64 WRA::evaluateConfusionMatrix(float64 cin, float64 cip, float64 crn, float64 crp, float64 uin, float64 uip,
+                                         float64 urn, float64 urp) const {
+        return wra(cin, cip, crn, crp, uin, uip, urn, urp);
+    }
+
 }

--- a/python/boomer/seco/cpp/model/decision_list.cpp
+++ b/python/boomer/seco/cpp/model/decision_list.cpp
@@ -2,26 +2,29 @@
 #include "../../../common/cpp/model/body_empty.h"
 #include "../../../common/cpp/model/body_conjunctive.h"
 
-using namespace seco;
 
+namespace seco {
 
-DecisionListBuilder::DecisionListBuilder()
-    : modelPtr_(std::make_unique<RuleModel>()){
+    DecisionListBuilder::DecisionListBuilder()
+        : modelPtr_(std::make_unique<RuleModel>()){
 
-}
-
-void DecisionListBuilder::setDefaultRule(const AbstractPrediction& prediction) {
-    defaultHeadPtr_ = prediction.toHead();
-}
-
-void DecisionListBuilder::addRule(const ConditionList& conditions, const AbstractPrediction& prediction) {
-    modelPtr_->addRule(std::make_unique<ConjunctiveBody>(conditions), prediction.toHead());
-}
-
-std::unique_ptr<RuleModel> DecisionListBuilder::build() {
-    if (defaultHeadPtr_.get() != nullptr) {
-        modelPtr_->addRule(std::make_unique<EmptyBody>(), std::move(defaultHeadPtr_));
     }
 
-    return std::move(modelPtr_);
+    void DecisionListBuilder::setDefaultRule(const AbstractPrediction& prediction) {
+        defaultHeadPtr_ = prediction.toHead();
+    }
+
+    void DecisionListBuilder::addRule(const ConditionList& conditions, const AbstractPrediction& prediction) {
+        modelPtr_->addRule(std::make_unique<ConjunctiveBody>(conditions), prediction.toHead());
+    }
+
+    std::unique_ptr<RuleModel> DecisionListBuilder::build() {
+        if (defaultHeadPtr_.get() != nullptr) {
+            modelPtr_->addRule(std::make_unique<EmptyBody>(), std::move(defaultHeadPtr_));
+        }
+
+        return std::move(modelPtr_);
+    }
+
 }
+

--- a/python/boomer/seco/cpp/output/predictor_classification.cpp
+++ b/python/boomer/seco/cpp/output/predictor_classification.cpp
@@ -4,97 +4,99 @@
 #include "../../../common/cpp/model/head_full.h"
 #include "../../../common/cpp/model/head_partial.h"
 
-using namespace seco;
 
+namespace seco {
 
-static inline void applyFullHead(const FullHead& head, CContiguousView<uint8>::iterator begin,
-                                 CContiguousView<uint8>::iterator end, DenseVector<uint8>::iterator mask) {
-    FullHead::score_const_iterator iterator = head.scores_cbegin();
-    uint32 numElements = head.getNumElements();
+    static inline void applyFullHead(const FullHead& head, CContiguousView<uint8>::iterator begin,
+                                     CContiguousView<uint8>::iterator end, DenseVector<uint8>::iterator mask) {
+        FullHead::score_const_iterator iterator = head.scores_cbegin();
+        uint32 numElements = head.getNumElements();
 
-    for (uint32 i = 0; i < numElements; i++) {
-        if (mask[i] == 0) {
-            uint8 prediction = iterator[i] > 0;
-            begin[i] = prediction;
-            mask[i] = 1;
-        }
-    }
-}
-
-static inline void applyPartialHead(const PartialHead& head, CContiguousView<uint8>::iterator begin,
-                                    CContiguousView<uint8>::iterator end, DenseVector<uint8>::iterator mask) {
-    PartialHead::score_const_iterator scoreIterator = head.scores_cbegin();
-    PartialHead::index_const_iterator indexIterator = head.indices_cbegin();
-    uint32 numElements = head.getNumElements();
-
-    for (uint32 i = 0; i < numElements; i++) {
-        uint32 index = indexIterator[i];
-
-        if (mask[index] == 0) {
-            uint8 prediction = scoreIterator[i] > 0;
-            begin[index] = prediction;
-            mask[index] = 1;
-        }
-    }
-}
-
-static inline void applyHead(const IHead& head, CContiguousView<uint8>& predictionMatrix, DenseVector<uint8>& mask,
-                             uint32 row) {
-    auto fullHeadVisitor = [&, row](const FullHead& head) {
-        applyFullHead(head, predictionMatrix.row_begin(row), predictionMatrix.row_end(row), mask.begin());
-    };
-    auto partialHeadVisitor = [&, row](const PartialHead& head) {
-        applyPartialHead(head, predictionMatrix.row_begin(row), predictionMatrix.row_end(row), mask.begin());
-    };
-    head.visit(fullHeadVisitor, partialHeadVisitor);
-}
-
-void ClassificationPredictor::predict(const CContiguousFeatureMatrix& featureMatrix,
-                                      CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
-    uint32 numExamples = featureMatrix.getNumRows();
-    uint32 numLabels = predictionMatrix.getNumCols();
-    DenseVector<uint8> mask(numLabels);
-
-    for (uint32 i = 0; i < numExamples; i++) {
-        setArrayToZeros(mask.begin(), numLabels);
-
-        for (auto it = model.cbegin(); it != model.cend(); it++) {
-            const Rule& rule = *it;
-            const IBody& body = rule.getBody();
-            const IHead& head = rule.getHead();
-
-            if (body.covers(featureMatrix.row_cbegin(i), featureMatrix.row_cend(i))) {
-                applyHead(head, predictionMatrix, mask, i);
+        for (uint32 i = 0; i < numElements; i++) {
+            if (mask[i] == 0) {
+                uint8 prediction = iterator[i] > 0;
+                begin[i] = prediction;
+                mask[i] = 1;
             }
         }
     }
-}
 
-void ClassificationPredictor::predict(const CsrFeatureMatrix& featureMatrix,
-                                      CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
-    uint32 numExamples = featureMatrix.getNumRows();
-    uint32 numFeatures = featureMatrix.getNumCols();
-    uint32 numLabels = predictionMatrix.getNumCols();
-    DenseVector<uint8> mask(numLabels);
-    float32 tmpArray1[numFeatures];
-    uint32 tmpArray2[numFeatures] = {};
-    uint32 n = 1;
+    static inline void applyPartialHead(const PartialHead& head, CContiguousView<uint8>::iterator begin,
+                                        CContiguousView<uint8>::iterator end, DenseVector<uint8>::iterator mask) {
+        PartialHead::score_const_iterator scoreIterator = head.scores_cbegin();
+        PartialHead::index_const_iterator indexIterator = head.indices_cbegin();
+        uint32 numElements = head.getNumElements();
 
-    for (uint32 i = 0; i < numExamples; i++) {
-        setArrayToZeros(mask.begin(), numLabels);
+        for (uint32 i = 0; i < numElements; i++) {
+            uint32 index = indexIterator[i];
 
-        for (auto it = model.cbegin(); it != model.cend(); it++) {
-            const Rule& rule = *it;
-            const IBody& body = rule.getBody();
-            const IHead& head = rule.getHead();
-
-            if (body.covers(featureMatrix.row_indices_cbegin(i), featureMatrix.row_indices_cend(i),
-                            featureMatrix.row_values_cbegin(i), featureMatrix.row_values_cend(i), &tmpArray1[0],
-                            &tmpArray2[0], n)) {
-                applyHead(head, predictionMatrix, mask, i);
+            if (mask[index] == 0) {
+                uint8 prediction = scoreIterator[i] > 0;
+                begin[index] = prediction;
+                mask[index] = 1;
             }
-
-            n++;
         }
     }
+
+    static inline void applyHead(const IHead& head, CContiguousView<uint8>& predictionMatrix, DenseVector<uint8>& mask,
+                                 uint32 row) {
+        auto fullHeadVisitor = [&, row](const FullHead& head) {
+            applyFullHead(head, predictionMatrix.row_begin(row), predictionMatrix.row_end(row), mask.begin());
+        };
+        auto partialHeadVisitor = [&, row](const PartialHead& head) {
+            applyPartialHead(head, predictionMatrix.row_begin(row), predictionMatrix.row_end(row), mask.begin());
+        };
+        head.visit(fullHeadVisitor, partialHeadVisitor);
+    }
+
+    void ClassificationPredictor::predict(const CContiguousFeatureMatrix& featureMatrix,
+                                          CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
+        uint32 numExamples = featureMatrix.getNumRows();
+        uint32 numLabels = predictionMatrix.getNumCols();
+        DenseVector<uint8> mask(numLabels);
+
+        for (uint32 i = 0; i < numExamples; i++) {
+            setArrayToZeros(mask.begin(), numLabels);
+
+            for (auto it = model.cbegin(); it != model.cend(); it++) {
+                const Rule& rule = *it;
+                const IBody& body = rule.getBody();
+                const IHead& head = rule.getHead();
+
+                if (body.covers(featureMatrix.row_cbegin(i), featureMatrix.row_cend(i))) {
+                    applyHead(head, predictionMatrix, mask, i);
+                }
+            }
+        }
+    }
+
+    void ClassificationPredictor::predict(const CsrFeatureMatrix& featureMatrix,
+                                          CContiguousView<uint8>& predictionMatrix, const RuleModel& model) const {
+        uint32 numExamples = featureMatrix.getNumRows();
+        uint32 numFeatures = featureMatrix.getNumCols();
+        uint32 numLabels = predictionMatrix.getNumCols();
+        DenseVector<uint8> mask(numLabels);
+        float32 tmpArray1[numFeatures];
+        uint32 tmpArray2[numFeatures] = {};
+        uint32 n = 1;
+
+        for (uint32 i = 0; i < numExamples; i++) {
+            setArrayToZeros(mask.begin(), numLabels);
+
+            for (auto it = model.cbegin(); it != model.cend(); it++) {
+                const Rule& rule = *it;
+                const IBody& body = rule.getBody();
+                const IHead& head = rule.getHead();
+
+                if (body.covers(featureMatrix.row_indices_cbegin(i), featureMatrix.row_indices_cend(i),
+                                featureMatrix.row_values_cbegin(i), featureMatrix.row_values_cend(i), &tmpArray1[0],
+                                &tmpArray2[0], n)) {
+                    applyHead(head, predictionMatrix, mask, i);
+                }
+
+                n++;
+            }
+        }
+    }
+
 }

--- a/python/boomer/seco/cpp/rule_evaluation/rule_evaluation_label_wise_heuristic.cpp
+++ b/python/boomer/seco/cpp/rule_evaluation/rule_evaluation_label_wise_heuristic.cpp
@@ -2,115 +2,118 @@
 #include "../heuristics/confusion_matrices.h"
 #include "../../../common/cpp/rule_evaluation/score_vector_label_wise_dense.h"
 
-using namespace seco;
 
+namespace seco {
 
-/**
- * Allows to calculate the predictions of rules, as well as corresponding quality scores, such that they optimize a
- * heuristic that is applied using label-wise averaging.
- *
- * @tparam T The type of the vector that provides access to the labels for which predictions should be calculated
- */
-template<class T>
-class HeuristicLabelWiseRuleEvaluation final : public ILabelWiseRuleEvaluation {
+    /**
+     * Allows to calculate the predictions of rules, as well as corresponding quality scores, such that they optimize a
+     * heuristic that is applied using label-wise averaging.
+     *
+     * @tparam T The type of the vector that provides access to the labels for which predictions should be calculated
+     */
+    template<class T>
+    class HeuristicLabelWiseRuleEvaluation final : public ILabelWiseRuleEvaluation {
 
-    private:
+        private:
 
-        std::shared_ptr<IHeuristic> heuristicPtr_;
+            std::shared_ptr<IHeuristic> heuristicPtr_;
 
-        bool predictMajority_;
+            bool predictMajority_;
 
-        DenseLabelWiseScoreVector<T> scoreVector_;
+            DenseLabelWiseScoreVector<T> scoreVector_;
 
-    public:
+        public:
 
-        /**
-         * @param labelIndices      A reference to an object of template type `T` that provides access to the indices of
-         *                          the labels for which the rules may predict
-         * @param heuristicPtr      A shared pointer to an object of type `IHeuristic`, representing the heuristic to be
-         *                          optimized
-         * @param predictMajority   True, if for each label the majority label should be predicted, false, if the
-         *                          minority label should be predicted
-         */
-        HeuristicLabelWiseRuleEvaluation(const T& labelIndices, std::shared_ptr<IHeuristic> heuristicPtr,
-                                         bool predictMajority)
-            : heuristicPtr_(heuristicPtr), predictMajority_(predictMajority),
-              scoreVector_(DenseLabelWiseScoreVector<T>(labelIndices)) {
+            /**
+             * @param labelIndices      A reference to an object of template type `T` that provides access to the
+             *                          indices of the labels for which the rules may predict
+             * @param heuristicPtr      A shared pointer to an object of type `IHeuristic`, representing the heuristic
+             *                          to be optimized
+             * @param predictMajority   True, if for each label the majority label should be predicted, false, if the
+             *                          minority label should be predicted
+             */
+            HeuristicLabelWiseRuleEvaluation(const T& labelIndices, std::shared_ptr<IHeuristic> heuristicPtr,
+                                             bool predictMajority)
+                : heuristicPtr_(heuristicPtr), predictMajority_(predictMajority),
+                  scoreVector_(DenseLabelWiseScoreVector<T>(labelIndices)) {
 
-        }
-
-        const ILabelWiseScoreVector& calculateLabelWisePrediction(const uint8* minorityLabels,
-                                                                  const float64* confusionMatricesTotal,
-                                                                  const float64* confusionMatricesSubset,
-                                                                  const float64* confusionMatricesCovered,
-                                                                  bool uncovered) override {
-            uint32 numPredictions = scoreVector_.getNumElements();
-            typename DenseLabelWiseScoreVector<T>::score_iterator scoreIterator = scoreVector_.scores_begin();
-            typename DenseLabelWiseScoreVector<T>::index_const_iterator indexIterator = scoreVector_.indices_cbegin();
-            typename DenseLabelWiseScoreVector<T>::quality_score_iterator qualityScoreIterator =
-                scoreVector_.quality_scores_begin();
-            float64 overallQualityScore = 0;
-
-            for (uint32 c = 0; c < numPredictions; c++) {
-                uint32 l = indexIterator[c];
-
-                // Set the score to be predicted for the current label...
-                uint8 minorityLabel = minorityLabels[l];
-                float64 score = (float64) (predictMajority_ ? (minorityLabel > 0 ? 0 : 1) : minorityLabel);
-                scoreIterator[c] = score;
-
-                // Calculate the quality score for the current label...
-                uint32 offsetC = c * NUM_CONFUSION_MATRIX_ELEMENTS;
-                uint32 offsetL = l * NUM_CONFUSION_MATRIX_ELEMENTS;
-                uint32 uin, uip, urn, urp;
-
-                uint32 cin = confusionMatricesCovered[offsetC + IN];
-                uint32 cip = confusionMatricesCovered[offsetC + IP];
-                uint32 crn = confusionMatricesCovered[offsetC + RN];
-                uint32 crp = confusionMatricesCovered[offsetC + RP];
-
-                if (uncovered) {
-                    uin = cin + confusionMatricesTotal[offsetL + IN] - confusionMatricesSubset[offsetL + IN];
-                    uip = cip + confusionMatricesTotal[offsetL + IP] - confusionMatricesSubset[offsetL + IP];
-                    urn = crn + confusionMatricesTotal[offsetL + RN] - confusionMatricesSubset[offsetL + RN];
-                    urp = crp + confusionMatricesTotal[offsetL + RP] - confusionMatricesSubset[offsetL + RP];
-                    cin = confusionMatricesSubset[offsetC + IN] - cin;
-                    cip = confusionMatricesSubset[offsetC + IP] - cip;
-                    crn = confusionMatricesSubset[offsetC + RN] - crn;
-                    crp = confusionMatricesSubset[offsetC + RP] - crp;
-                } else {
-                    uin = confusionMatricesTotal[offsetL + IN] - cin;
-                    uip = confusionMatricesTotal[offsetL + IP] - cip;
-                    urn = confusionMatricesTotal[offsetL + RN] - crn;
-                    urp = confusionMatricesTotal[offsetL + RP] - crp;
-                }
-
-                score = heuristicPtr_->evaluateConfusionMatrix(cin, cip, crn, crp, uin, uip, urn, urp);
-                qualityScoreIterator[c] = score;
-                overallQualityScore += score;
             }
 
-            overallQualityScore /= numPredictions;
-            scoreVector_.overallQualityScore = overallQualityScore;
-            return scoreVector_;
-        }
+            const ILabelWiseScoreVector& calculateLabelWisePrediction(const uint8* minorityLabels,
+                                                                      const float64* confusionMatricesTotal,
+                                                                      const float64* confusionMatricesSubset,
+                                                                      const float64* confusionMatricesCovered,
+                                                                      bool uncovered) override {
+                uint32 numPredictions = scoreVector_.getNumElements();
+                typename DenseLabelWiseScoreVector<T>::score_iterator scoreIterator = scoreVector_.scores_begin();
+                typename DenseLabelWiseScoreVector<T>::index_const_iterator indexIterator =
+                    scoreVector_.indices_cbegin();
+                typename DenseLabelWiseScoreVector<T>::quality_score_iterator qualityScoreIterator =
+                    scoreVector_.quality_scores_begin();
+                float64 overallQualityScore = 0;
 
-};
+                for (uint32 c = 0; c < numPredictions; c++) {
+                    uint32 l = indexIterator[c];
 
-HeuristicLabelWiseRuleEvaluationFactory::HeuristicLabelWiseRuleEvaluationFactory(
-        std::shared_ptr<IHeuristic> heuristicPtr, bool predictMajority)
-    : heuristicPtr_(heuristicPtr), predictMajority_(predictMajority) {
+                    // Set the score to be predicted for the current label...
+                    uint8 minorityLabel = minorityLabels[l];
+                    float64 score = (float64) (predictMajority_ ? (minorityLabel > 0 ? 0 : 1) : minorityLabel);
+                    scoreIterator[c] = score;
 
-}
+                    // Calculate the quality score for the current label...
+                    uint32 offsetC = c * NUM_CONFUSION_MATRIX_ELEMENTS;
+                    uint32 offsetL = l * NUM_CONFUSION_MATRIX_ELEMENTS;
+                    uint32 uin, uip, urn, urp;
 
-std::unique_ptr<ILabelWiseRuleEvaluation> HeuristicLabelWiseRuleEvaluationFactory::create(
-        const FullIndexVector& indexVector) const {
-    return std::make_unique<HeuristicLabelWiseRuleEvaluation<FullIndexVector>>(indexVector, heuristicPtr_,
-                                                                               predictMajority_);
-}
+                    uint32 cin = confusionMatricesCovered[offsetC + IN];
+                    uint32 cip = confusionMatricesCovered[offsetC + IP];
+                    uint32 crn = confusionMatricesCovered[offsetC + RN];
+                    uint32 crp = confusionMatricesCovered[offsetC + RP];
 
-std::unique_ptr<ILabelWiseRuleEvaluation> HeuristicLabelWiseRuleEvaluationFactory::create(
-        const PartialIndexVector& indexVector) const {
-    return std::make_unique<HeuristicLabelWiseRuleEvaluation<PartialIndexVector>>(indexVector, heuristicPtr_,
-                                                                                  predictMajority_);
+                    if (uncovered) {
+                        uin = cin + confusionMatricesTotal[offsetL + IN] - confusionMatricesSubset[offsetL + IN];
+                        uip = cip + confusionMatricesTotal[offsetL + IP] - confusionMatricesSubset[offsetL + IP];
+                        urn = crn + confusionMatricesTotal[offsetL + RN] - confusionMatricesSubset[offsetL + RN];
+                        urp = crp + confusionMatricesTotal[offsetL + RP] - confusionMatricesSubset[offsetL + RP];
+                        cin = confusionMatricesSubset[offsetC + IN] - cin;
+                        cip = confusionMatricesSubset[offsetC + IP] - cip;
+                        crn = confusionMatricesSubset[offsetC + RN] - crn;
+                        crp = confusionMatricesSubset[offsetC + RP] - crp;
+                    } else {
+                        uin = confusionMatricesTotal[offsetL + IN] - cin;
+                        uip = confusionMatricesTotal[offsetL + IP] - cip;
+                        urn = confusionMatricesTotal[offsetL + RN] - crn;
+                        urp = confusionMatricesTotal[offsetL + RP] - crp;
+                    }
+
+                    score = heuristicPtr_->evaluateConfusionMatrix(cin, cip, crn, crp, uin, uip, urn, urp);
+                    qualityScoreIterator[c] = score;
+                    overallQualityScore += score;
+                }
+
+                overallQualityScore /= numPredictions;
+                scoreVector_.overallQualityScore = overallQualityScore;
+                return scoreVector_;
+            }
+
+    };
+
+    HeuristicLabelWiseRuleEvaluationFactory::HeuristicLabelWiseRuleEvaluationFactory(
+            std::shared_ptr<IHeuristic> heuristicPtr, bool predictMajority)
+        : heuristicPtr_(heuristicPtr), predictMajority_(predictMajority) {
+
+    }
+
+    std::unique_ptr<ILabelWiseRuleEvaluation> HeuristicLabelWiseRuleEvaluationFactory::create(
+            const FullIndexVector& indexVector) const {
+        return std::make_unique<HeuristicLabelWiseRuleEvaluation<FullIndexVector>>(indexVector, heuristicPtr_,
+                                                                                   predictMajority_);
+    }
+
+    std::unique_ptr<ILabelWiseRuleEvaluation> HeuristicLabelWiseRuleEvaluationFactory::create(
+            const PartialIndexVector& indexVector) const {
+        return std::make_unique<HeuristicLabelWiseRuleEvaluation<PartialIndexVector>>(indexVector, heuristicPtr_,
+                                                                                      predictMajority_);
+    }
+
 }

--- a/python/boomer/seco/cpp/statistics/statistics_label_wise_dense.cpp
+++ b/python/boomer/seco/cpp/statistics/statistics_label_wise_dense.cpp
@@ -4,400 +4,407 @@
 #include "../heuristics/confusion_matrices.h"
 #include <cstdlib>
 
-using namespace seco;
 
+namespace seco {
 
-/**
- * Provides access to the elements of confusion matrices that are computed independently for each label using dense data
- * structures.
- */
-class LabelWiseStatistics final : public ILabelWiseStatistics {
+    /**
+     * Provides access to the elements of confusion matrices that are computed independently for each label using dense
+     * data structures.
+     */
+    class LabelWiseStatistics final : public ILabelWiseStatistics {
 
-    private:
+        private:
 
-        /**
-         * Provides access to a subset of the confusion matrices that are stored by an instance of the class
-         * `LabelWiseStatistics`.
-         *
-         * @tparam T The type of the vector that provides access to the indices of the labels that are included in the
-         *           subset
-         */
-        template<class T>
-        class StatisticsSubset final : public AbstractDecomposableStatisticsSubset {
+            /**
+             * Provides access to a subset of the confusion matrices that are stored by an instance of the class
+             * `LabelWiseStatistics`.
+             *
+             * @tparam T The type of the vector that provides access to the indices of the labels that are included in
+             *           the subset
+             */
+            template<class T>
+            class StatisticsSubset final : public AbstractDecomposableStatisticsSubset {
 
-            private:
+                private:
 
-                const LabelWiseStatistics& statistics_;
+                    const LabelWiseStatistics& statistics_;
 
-                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr_;
+                    std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr_;
 
-                const T& labelIndices_;
+                    const T& labelIndices_;
 
-                float64* confusionMatricesCovered_;
+                    float64* confusionMatricesCovered_;
 
-                float64* accumulatedConfusionMatricesCovered_;
+                    float64* accumulatedConfusionMatricesCovered_;
 
-                float64* confusionMatricesSubset_;
+                    float64* confusionMatricesSubset_;
 
-                float64* confusionMatricesCoverableSubset_;
+                    float64* confusionMatricesCoverableSubset_;
 
-            public:
+                public:
 
-                /**
-                 * @param statistics        A reference to an object of type `LabelWiseStatistics` that stores the
-                 *                          confusion matrices
-                 * @param ruleEvaluationPtr An unique pointer to an object of type `ILabelWiseRuleEvaluation` that
-                 *                          should be used to calculate the predictions, as well as corresponding
-                 *                          quality scores, of rules
-                 * @param labelIndices      A reference to an object of template type `T` that provides access to the
-                 *                          indices of the labels that are included in the subset
-                 */
-                StatisticsSubset(const LabelWiseStatistics& statistics,
-                                 std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr, const T& labelIndices)
-                    : statistics_(statistics), ruleEvaluationPtr_(std::move(ruleEvaluationPtr)),
-                      labelIndices_(labelIndices) {
-                    uint32 numPredictions = labelIndices.getNumElements();
-                    confusionMatricesCovered_ =
-                        (float64*) malloc(numPredictions * NUM_CONFUSION_MATRIX_ELEMENTS * sizeof(float64));
-                    setArrayToZeros(confusionMatricesCovered_, numPredictions * NUM_CONFUSION_MATRIX_ELEMENTS);
-                    accumulatedConfusionMatricesCovered_ = nullptr;
-                    confusionMatricesSubset_ = statistics_.confusionMatricesSubset_;
-                    confusionMatricesCoverableSubset_ = nullptr;
-                }
-
-                ~StatisticsSubset() {
-                    free(confusionMatricesCovered_);
-                    free(accumulatedConfusionMatricesCovered_);
-                    free(confusionMatricesCoverableSubset_);
-                }
-
-                void addToMissing(uint32 statisticIndex, uint32 weight) override {
-                    uint32 numLabels = statistics_.getNumLabels();
-
-                    // Allocate arrays for storing the totals sums of gradients and Hessians, if necessary...
-                    if (confusionMatricesCoverableSubset_ == nullptr) {
-                        confusionMatricesCoverableSubset_ = (float64*) malloc(numLabels * sizeof(float64));
-                        copyArray(confusionMatricesSubset_, confusionMatricesCoverableSubset_, numLabels);
-                        confusionMatricesSubset_ = confusionMatricesCoverableSubset_;
-                    }
-
-                    // For each label, subtract the gradient and Hessian of the example at the given index (weighted by
-                    // the given weight) from the total sum of gradients and Hessians...
-                    uint32 offset = statisticIndex * numLabels;
-
-                    for (uint32 c = 0; c < numLabels; c++) {
-                        float64 labelWeight = statistics_.uncoveredLabels_[offset + c];
-
-                        // Only uncovered labels must be considered...
-                        if (labelWeight > 0) {
-                            // Remove the current example and label from the confusion matrix that corresponds to the
-                            // current label...
-                            uint8 trueLabel = statistics_.labelMatrixPtr_->getValue(statisticIndex, c);
-                            uint8 predictedLabel = statistics_.minorityLabels_[c];
-                            uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
-                            confusionMatricesSubset_[c * NUM_CONFUSION_MATRIX_ELEMENTS + element] -= weight;
-                        }
-                    }
-                }
-
-                void addToSubset(uint32 statisticIndex, uint32 weight) override {
-                    uint32 numLabels = statistics_.getNumLabels();
-                    uint32 offset = statisticIndex * numLabels;
-                    uint32 numPredictions = labelIndices_.getNumElements();
-                    typename T::const_iterator indexIterator = labelIndices_.cbegin();
-
-                    for (uint32 c = 0; c < numPredictions; c++) {
-                        uint32 l = indexIterator[c];
-
-                        // Only uncovered labels must be considered...
-                        if (statistics_.uncoveredLabels_[offset + l] > 0) {
-                            // Add the current example and label to the confusion matrix for the current label...
-                            uint8 trueLabel = statistics_.labelMatrixPtr_->getValue(statisticIndex, l);
-                            uint8 predictedLabel = statistics_.minorityLabels_[l];
-                            uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
-                            confusionMatricesCovered_[c * NUM_CONFUSION_MATRIX_ELEMENTS + element] += weight;
-                        }
-                    }
-                }
-
-                void resetSubset() override {
-                    uint32 numPredictions = labelIndices_.getNumElements();
-
-                    // Allocate an array for storing the accumulated confusion matrices, if necessary...
-                    if (accumulatedConfusionMatricesCovered_ == nullptr) {
-                        accumulatedConfusionMatricesCovered_ =
+                    /**
+                     * @param statistics        A reference to an object of type `LabelWiseStatistics` that stores the
+                     *                          confusion matrices
+                     * @param ruleEvaluationPtr An unique pointer to an object of type `ILabelWiseRuleEvaluation` that
+                     *                          should be used to calculate the predictions, as well as corresponding
+                     *                          quality scores, of rules
+                     * @param labelIndices      A reference to an object of template type `T` that provides access to
+                     *                          the indices of the labels that are included in the subset
+                     */
+                    StatisticsSubset(const LabelWiseStatistics& statistics,
+                                     std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr, const T& labelIndices)
+                        : statistics_(statistics), ruleEvaluationPtr_(std::move(ruleEvaluationPtr)),
+                          labelIndices_(labelIndices) {
+                        uint32 numPredictions = labelIndices.getNumElements();
+                        confusionMatricesCovered_ =
                             (float64*) malloc(numPredictions * NUM_CONFUSION_MATRIX_ELEMENTS * sizeof(float64));
-                        setArrayToZeros(accumulatedConfusionMatricesCovered_,
-                                        numPredictions * NUM_CONFUSION_MATRIX_ELEMENTS);
+                        setArrayToZeros(confusionMatricesCovered_, numPredictions * NUM_CONFUSION_MATRIX_ELEMENTS);
+                        accumulatedConfusionMatricesCovered_ = nullptr;
+                        confusionMatricesSubset_ = statistics_.confusionMatricesSubset_;
+                        confusionMatricesCoverableSubset_ = nullptr;
                     }
 
-                    // Reset the confusion matrix for each label to zero and add its elements to the accumulated
-                    // confusion matrix...
-                    for (uint32 c = 0; c < numPredictions; c++) {
-                        uint32 offset = c * NUM_CONFUSION_MATRIX_ELEMENTS;
-                        copyArray(&confusionMatricesCovered_[offset], &accumulatedConfusionMatricesCovered_[offset],
-                                  NUM_CONFUSION_MATRIX_ELEMENTS);
-                        setArrayToZeros(&confusionMatricesCovered_[offset], NUM_CONFUSION_MATRIX_ELEMENTS);
+                    ~StatisticsSubset() {
+                        free(confusionMatricesCovered_);
+                        free(accumulatedConfusionMatricesCovered_);
+                        free(confusionMatricesCoverableSubset_);
                     }
-                }
 
-                const ILabelWiseScoreVector& calculateLabelWisePrediction(bool uncovered, bool accumulated) override {
-                    float64* confusionMatricesCovered =
-                        accumulated ? accumulatedConfusionMatricesCovered_ : confusionMatricesCovered_;
-                    return ruleEvaluationPtr_->calculateLabelWisePrediction(statistics_.minorityLabels_,
-                                                                            statistics_.confusionMatricesTotal_,
-                                                                            confusionMatricesSubset_,
-                                                                            confusionMatricesCovered, uncovered);
-                }
+                    void addToMissing(uint32 statisticIndex, uint32 weight) override {
+                        uint32 numLabels = statistics_.getNumLabels();
 
-        };
+                        // Allocate arrays for storing the totals sums of gradients and Hessians, if necessary...
+                        if (confusionMatricesCoverableSubset_ == nullptr) {
+                            confusionMatricesCoverableSubset_ = (float64*) malloc(numLabels * sizeof(float64));
+                            copyArray(confusionMatricesSubset_, confusionMatricesCoverableSubset_, numLabels);
+                            confusionMatricesSubset_ = confusionMatricesCoverableSubset_;
+                        }
 
-        uint32 numStatistics_;
+                        // For each label, subtract the gradient and Hessian of the example at the given index (weighted
+                        // by the given weight) from the total sum of gradients and Hessians...
+                        uint32 offset = statisticIndex * numLabels;
 
-        uint32 numLabels_;
+                        for (uint32 c = 0; c < numLabels; c++) {
+                            float64 labelWeight = statistics_.uncoveredLabels_[offset + c];
 
-        float64 sumUncoveredLabels_;
+                            // Only uncovered labels must be considered...
+                            if (labelWeight > 0) {
+                                // Remove the current example and label from the confusion matrix that corresponds to
+                                // the current label...
+                                uint8 trueLabel = statistics_.labelMatrixPtr_->getValue(statisticIndex, c);
+                                uint8 predictedLabel = statistics_.minorityLabels_[c];
+                                uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
+                                confusionMatricesSubset_[c * NUM_CONFUSION_MATRIX_ELEMENTS + element] -= weight;
+                            }
+                        }
+                    }
 
-        std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr_;
+                    void addToSubset(uint32 statisticIndex, uint32 weight) override {
+                        uint32 numLabels = statistics_.getNumLabels();
+                        uint32 offset = statisticIndex * numLabels;
+                        uint32 numPredictions = labelIndices_.getNumElements();
+                        typename T::const_iterator indexIterator = labelIndices_.cbegin();
 
-        std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr_;
+                        for (uint32 c = 0; c < numPredictions; c++) {
+                            uint32 l = indexIterator[c];
 
-        float64* uncoveredLabels_;
+                            // Only uncovered labels must be considered...
+                            if (statistics_.uncoveredLabels_[offset + l] > 0) {
+                                // Add the current example and label to the confusion matrix for the current label...
+                                uint8 trueLabel = statistics_.labelMatrixPtr_->getValue(statisticIndex, l);
+                                uint8 predictedLabel = statistics_.minorityLabels_[l];
+                                uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
+                                confusionMatricesCovered_[c * NUM_CONFUSION_MATRIX_ELEMENTS + element] += weight;
+                            }
+                        }
+                    }
 
-        uint8* minorityLabels_;
+                    void resetSubset() override {
+                        uint32 numPredictions = labelIndices_.getNumElements();
 
-        float64* confusionMatricesTotal_;
+                        // Allocate an array for storing the accumulated confusion matrices, if necessary...
+                        if (accumulatedConfusionMatricesCovered_ == nullptr) {
+                            accumulatedConfusionMatricesCovered_ =
+                                (float64*) malloc(numPredictions * NUM_CONFUSION_MATRIX_ELEMENTS * sizeof(float64));
+                            setArrayToZeros(accumulatedConfusionMatricesCovered_,
+                                            numPredictions * NUM_CONFUSION_MATRIX_ELEMENTS);
+                        }
 
-        float64* confusionMatricesSubset_;
+                        // Reset the confusion matrix for each label to zero and add its elements to the accumulated
+                        // confusion matrix...
+                        for (uint32 c = 0; c < numPredictions; c++) {
+                            uint32 offset = c * NUM_CONFUSION_MATRIX_ELEMENTS;
+                            copyArray(&confusionMatricesCovered_[offset], &accumulatedConfusionMatricesCovered_[offset],
+                                      NUM_CONFUSION_MATRIX_ELEMENTS);
+                            setArrayToZeros(&confusionMatricesCovered_[offset], NUM_CONFUSION_MATRIX_ELEMENTS);
+                        }
+                    }
 
-    public:
+                    const ILabelWiseScoreVector& calculateLabelWisePrediction(bool uncovered,
+                                                                              bool accumulated) override {
+                        float64* confusionMatricesCovered =
+                            accumulated ? accumulatedConfusionMatricesCovered_ : confusionMatricesCovered_;
+                        return ruleEvaluationPtr_->calculateLabelWisePrediction(statistics_.minorityLabels_,
+                                                                                statistics_.confusionMatricesTotal_,
+                                                                                confusionMatricesSubset_,
+                                                                                confusionMatricesCovered, uncovered);
+                    }
 
-        /**
-         * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory` that
-         *                                  allows to create instances of the class that is used for calculating the
-         *                                  predictions, as well as corresponding quality scores, of rules
-         * @param labelMatrixPtr            A shared pointer to an object of type `IRandomAccessLabelMatrix` that
-         *                                  provides random access to the labels of the training examples
-         * @param uncoveredLabels           A pointer to an array of type `float64`, shape `(numExamples, numLabels)`,
-         *                                  indicating which examples and labels remain to be covered
-         * @param sumUncoveredLabels        The sum of weights of all labels that remain to be covered
-         * @param minorityLabels            A pointer to an array of type `uint8`, shape `(numLabels)`, indicating
-         *                                  whether rules should predict individual labels as relevant (1) or irrelevant
-         *                                  (0)
-         */
-        LabelWiseStatistics(std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
-                            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr, float64* uncoveredLabels,
-                            float64 sumUncoveredLabels, uint8* minorityLabels)
-            : numStatistics_(labelMatrixPtr->getNumRows()), numLabels_(labelMatrixPtr->getNumCols()),
-              sumUncoveredLabels_(sumUncoveredLabels), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr),
-              labelMatrixPtr_(labelMatrixPtr), uncoveredLabels_(uncoveredLabels), minorityLabels_(minorityLabels) {
-            // The number of labels
-            uint32 numLabels = this->getNumLabels();
-            // A matrix that stores a confusion matrix, which takes into account all examples, for each label
-            confusionMatricesTotal_ = (float64*) malloc(numLabels * NUM_CONFUSION_MATRIX_ELEMENTS * sizeof(float64));
-            // A matrix that stores a confusion matrix, which takes into account the examples covered by the previous
-            // refinement of a rule, for each label
-            confusionMatricesSubset_ = (float64*) malloc(numLabels * NUM_CONFUSION_MATRIX_ELEMENTS * sizeof(float64));
-        }
+            };
 
-        ~LabelWiseStatistics() {
-            free(uncoveredLabels_);
-            free(minorityLabels_);
-            free(confusionMatricesTotal_);
-            free(confusionMatricesSubset_);
-        }
+            uint32 numStatistics_;
 
-        uint32 getNumStatistics() const override {
-            return numStatistics_;
-        }
+            uint32 numLabels_;
 
-        uint32 getNumLabels() const override {
-            return numLabels_;
-        }
+            float64 sumUncoveredLabels_;
 
-        float64 getSumOfUncoveredLabels() const override {
-            return sumUncoveredLabels_;
-        }
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr_;
 
-        void setRuleEvaluationFactory(
-                std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr) override {
-            ruleEvaluationFactoryPtr_ = ruleEvaluationFactoryPtr;
-        }
+            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr_;
 
-        void resetSampledStatistics() override {
-            uint32 numLabels = this->getNumLabels();
-            uint32 numElements = numLabels * NUM_CONFUSION_MATRIX_ELEMENTS;
-            setArrayToZeros(confusionMatricesTotal_, numElements);
-            setArrayToZeros(confusionMatricesSubset_, numElements);
-        }
+            float64* uncoveredLabels_;
 
-        void addSampledStatistic(uint32 statisticIndex, uint32 weight) override {
-            uint32 numLabels = this->getNumLabels();
-            uint32 offset = statisticIndex * numLabels;
+            uint8* minorityLabels_;
 
-            for (uint32 c = 0; c < numLabels; c++) {
-                float64 labelWeight = uncoveredLabels_[offset + c];
+            float64* confusionMatricesTotal_;
 
-                // Only uncovered labels must be considered...
-                if (labelWeight > 0) {
-                    // Add the current example and label to the confusion matrix that corresponds to the current
-                    // label...
-                    uint8 trueLabel = labelMatrixPtr_->getValue(statisticIndex, c);
-                    uint8 predictedLabel = minorityLabels_[c];
-                    uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
-                    uint32 i = c * NUM_CONFUSION_MATRIX_ELEMENTS + element;
-                    confusionMatricesTotal_[i] += weight;
-                    confusionMatricesSubset_[i] += weight;
-                }
+            float64* confusionMatricesSubset_;
+
+        public:
+
+            /**
+             * @param ruleEvaluationFactoryPtr  A shared pointer to an object of type `ILabelWiseRuleEvaluationFactory`
+             *                                  that allows to create instances of the class that is used for
+             *                                  calculating the predictions, as well as corresponding quality scores, of
+             *                                  rules
+             * @param labelMatrixPtr            A shared pointer to an object of type `IRandomAccessLabelMatrix` that
+             *                                  provides random access to the labels of the training examples
+             * @param uncoveredLabels           A pointer to an array of type `float64`, shape
+             *                                  `(numExamples, numLabels)`, indicating which examples and labels remain
+             *                                  to be covered
+             * @param sumUncoveredLabels        The sum of weights of all labels that remain to be covered
+             * @param minorityLabels            A pointer to an array of type `uint8`, shape `(numLabels)`, indicating
+             *                                  whether rules should predict individual labels as relevant (1) or
+             *                                  irrelevant (0)
+             */
+            LabelWiseStatistics(std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
+                                std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr, float64* uncoveredLabels,
+                                float64 sumUncoveredLabels, uint8* minorityLabels)
+                : numStatistics_(labelMatrixPtr->getNumRows()), numLabels_(labelMatrixPtr->getNumCols()),
+                  sumUncoveredLabels_(sumUncoveredLabels), ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr),
+                  labelMatrixPtr_(labelMatrixPtr), uncoveredLabels_(uncoveredLabels), minorityLabels_(minorityLabels) {
+                // The number of labels
+                uint32 numLabels = this->getNumLabels();
+                // A matrix that stores a confusion matrix, which takes into account all examples, for each label
+                confusionMatricesTotal_ =
+                    (float64*) malloc(numLabels * NUM_CONFUSION_MATRIX_ELEMENTS * sizeof(float64));
+                // A matrix that stores a confusion matrix, which takes into account the examples covered by the
+                // previous refinement of a rule, for each label
+                confusionMatricesSubset_ =
+                    (float64*) malloc(numLabels * NUM_CONFUSION_MATRIX_ELEMENTS * sizeof(float64));
             }
-        }
 
-        void resetCoveredStatistics() override {
-            // Reset confusion matrices to 0...
-            uint32 numLabels = this->getNumLabels();
-            uint32 numElements = numLabels * NUM_CONFUSION_MATRIX_ELEMENTS;
-            setArrayToZeros(confusionMatricesSubset_, numElements);
-        }
-
-        void updateCoveredStatistic(uint32 statisticIndex, uint32 weight, bool remove) override {
-            uint32 numLabels = this->getNumLabels();
-            uint32 offset = statisticIndex * numLabels;
-            float64 signedWeight = remove ? -((float64) weight) : weight;
-
-            for (uint32 c = 0; c < numLabels; c++) {
-                float64 labelWeight = uncoveredLabels_[offset + c];
-
-                // Only uncovered labels must be considered...
-                if (labelWeight > 0) {
-                    // Add the current example and label to the confusion matrix that corresponds to the current
-                    // label...
-                    uint8 trueLabel = labelMatrixPtr_->getValue(statisticIndex, c);
-                    uint8 predictedLabel = minorityLabels_[c];
-                    uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
-                    confusionMatricesSubset_[c * NUM_CONFUSION_MATRIX_ELEMENTS + element] += signedWeight;
-                }
+            ~LabelWiseStatistics() {
+                free(uncoveredLabels_);
+                free(minorityLabels_);
+                free(confusionMatricesTotal_);
+                free(confusionMatricesSubset_);
             }
-        }
 
-        std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override {
-            std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
-                ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<StatisticsSubset<FullIndexVector>>(*this, std::move(ruleEvaluationPtr),
-                                                                       labelIndices);
-        }
+            uint32 getNumStatistics() const override {
+                return numStatistics_;
+            }
 
-        std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override {
-            std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
-                ruleEvaluationFactoryPtr_->create(labelIndices);
-            return std::make_unique<StatisticsSubset<PartialIndexVector>>(*this, std::move(ruleEvaluationPtr),
-                                                                          labelIndices);
-        }
+            uint32 getNumLabels() const override {
+                return numLabels_;
+            }
 
-        void applyPrediction(uint32 statisticIndex, const FullPrediction& prediction) override {
-            uint32 numLabels = this->getNumLabels();
-            uint32 offset = statisticIndex * numLabels;
-            uint32 numPredictions = prediction.getNumElements();
-            FullPrediction::score_const_iterator scoreIterator = prediction.scores_cbegin();
+            float64 getSumOfUncoveredLabels() const override {
+                return sumUncoveredLabels_;
+            }
 
-            // Only the labels that are predicted by the new rule must be considered...
-            for (uint32 c = 0; c < numPredictions; c++) {
-                uint8 predictedLabel = scoreIterator[c];
-                uint8 minorityLabel = minorityLabels_[c];
+            void setRuleEvaluationFactory(
+                    std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr) override {
+                ruleEvaluationFactoryPtr_ = ruleEvaluationFactoryPtr;
+            }
 
-                // Do only consider predictions that are different from the default rule's predictions...
-                if (predictedLabel == minorityLabel) {
-                    uint32 i = offset + c;
-                    float64 labelWeight = uncoveredLabels_[i];
+            void resetSampledStatistics() override {
+                uint32 numLabels = this->getNumLabels();
+                uint32 numElements = numLabels * NUM_CONFUSION_MATRIX_ELEMENTS;
+                setArrayToZeros(confusionMatricesTotal_, numElements);
+                setArrayToZeros(confusionMatricesSubset_, numElements);
+            }
 
+            void addSampledStatistic(uint32 statisticIndex, uint32 weight) override {
+                uint32 numLabels = this->getNumLabels();
+                uint32 offset = statisticIndex * numLabels;
+
+                for (uint32 c = 0; c < numLabels; c++) {
+                    float64 labelWeight = uncoveredLabels_[offset + c];
+
+                    // Only uncovered labels must be considered...
                     if (labelWeight > 0) {
-                        // Decrement the total sum of uncovered labels...
-                        sumUncoveredLabels_ -= labelWeight;
-
-                        // Mark the current example and label as covered...
-                        uncoveredLabels_[i] = 0;
+                        // Add the current example and label to the confusion matrix that corresponds to the current
+                        // label...
+                        uint8 trueLabel = labelMatrixPtr_->getValue(statisticIndex, c);
+                        uint8 predictedLabel = minorityLabels_[c];
+                        uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
+                        uint32 i = c * NUM_CONFUSION_MATRIX_ELEMENTS + element;
+                        confusionMatricesTotal_[i] += weight;
+                        confusionMatricesSubset_[i] += weight;
                     }
                 }
             }
-        }
 
-        void applyPrediction(uint32 statisticIndex, const PartialPrediction& prediction) override {
-            uint32 numLabels = this->getNumLabels();
-            uint32 offset = statisticIndex * numLabels;
-            uint32 numPredictions = prediction.getNumElements();
-            PartialPrediction::score_const_iterator scoreIterator = prediction.scores_cbegin();
-            PartialPrediction::index_const_iterator indexIterator = prediction.indices_cbegin();
+            void resetCoveredStatistics() override {
+                // Reset confusion matrices to 0...
+                uint32 numLabels = this->getNumLabels();
+                uint32 numElements = numLabels * NUM_CONFUSION_MATRIX_ELEMENTS;
+                setArrayToZeros(confusionMatricesSubset_, numElements);
+            }
 
-            // Only the labels that are predicted by the new rule must be considered...
-            for (uint32 c = 0; c < numPredictions; c++) {
-                uint32 l = indexIterator[c];
-                uint8 predictedLabel = scoreIterator[c];
-                uint8 minorityLabel = minorityLabels_[l];
+            void updateCoveredStatistic(uint32 statisticIndex, uint32 weight, bool remove) override {
+                uint32 numLabels = this->getNumLabels();
+                uint32 offset = statisticIndex * numLabels;
+                float64 signedWeight = remove ? -((float64) weight) : weight;
 
-                // Do only consider predictions that are different from the default rule's predictions...
-                if (predictedLabel == minorityLabel) {
-                    uint32 i = offset + l;
-                    float64 labelWeight = uncoveredLabels_[i];
+                for (uint32 c = 0; c < numLabels; c++) {
+                    float64 labelWeight = uncoveredLabels_[offset + c];
 
+                    // Only uncovered labels must be considered...
                     if (labelWeight > 0) {
-                        // Decrement the total sum of uncovered labels...
-                        sumUncoveredLabels_ -= labelWeight;
-
-                        // Mark the current example and label as covered...
-                        uncoveredLabels_[i] = 0;
+                        // Add the current example and label to the confusion matrix that corresponds to the current
+                        // label...
+                        uint8 trueLabel = labelMatrixPtr_->getValue(statisticIndex, c);
+                        uint8 predictedLabel = minorityLabels_[c];
+                        uint32 element = getConfusionMatrixElement(trueLabel, predictedLabel);
+                        confusionMatricesSubset_[c * NUM_CONFUSION_MATRIX_ELEMENTS + element] += signedWeight;
                     }
                 }
             }
-        }
 
-        std::unique_ptr<IHistogramBuilder> createHistogramBuilder(uint32 numBins) const override {
-            //TODO Support creation of histograms
-            std::unique_ptr<IHistogramBuilder> result;
-            return result;
-        }
+            std::unique_ptr<IStatisticsSubset> createSubset(const FullIndexVector& labelIndices) const override {
+                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
+                    ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<StatisticsSubset<FullIndexVector>>(*this, std::move(ruleEvaluationPtr),
+                                                                           labelIndices);
+            }
 
-};
+            std::unique_ptr<IStatisticsSubset> createSubset(const PartialIndexVector& labelIndices) const override {
+                std::unique_ptr<ILabelWiseRuleEvaluation> ruleEvaluationPtr =
+                    ruleEvaluationFactoryPtr_->create(labelIndices);
+                return std::make_unique<StatisticsSubset<PartialIndexVector>>(*this, std::move(ruleEvaluationPtr),
+                                                                              labelIndices);
+            }
 
-DenseLabelWiseStatisticsFactory::DenseLabelWiseStatisticsFactory(
-        std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
-        std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr)
-    : ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr), labelMatrixPtr_(labelMatrixPtr) {
+            void applyPrediction(uint32 statisticIndex, const FullPrediction& prediction) override {
+                uint32 numLabels = this->getNumLabels();
+                uint32 offset = statisticIndex * numLabels;
+                uint32 numPredictions = prediction.getNumElements();
+                FullPrediction::score_const_iterator scoreIterator = prediction.scores_cbegin();
 
-}
+                // Only the labels that are predicted by the new rule must be considered...
+                for (uint32 c = 0; c < numPredictions; c++) {
+                    uint8 predictedLabel = scoreIterator[c];
+                    uint8 minorityLabel = minorityLabels_[c];
 
-std::unique_ptr<ILabelWiseStatistics> DenseLabelWiseStatisticsFactory::create() const {
-    // The number of examples
-    uint32 numExamples = labelMatrixPtr_->getNumRows();
-    // The number of labels
-    uint32 numLabels = labelMatrixPtr_->getNumCols();
-    // A matrix that stores the weights of individual examples and labels that are still uncovered
-    float64* uncoveredLabels = (float64*) malloc(numExamples * numLabels * sizeof(float64));
-    // The sum of weights of all examples and labels that remain to be covered
-    float64 sumUncoveredLabels = 0;
-    // An array that stores whether rules should predict individual labels as relevant (1) or irrelevant (0)
-    uint8* minorityLabels = (uint8*) malloc(numLabels * sizeof(uint8));
-    // The number of positive examples that must be exceeded for the default rule to predict a label as relevant
-    float64 threshold = numExamples / 2.0;
+                    // Do only consider predictions that are different from the default rule's predictions...
+                    if (predictedLabel == minorityLabel) {
+                        uint32 i = offset + c;
+                        float64 labelWeight = uncoveredLabels_[i];
 
-    for (uint32 c = 0; c < numLabels; c++) {
-        uint32 numPositiveLabels = 0;
+                        if (labelWeight > 0) {
+                            // Decrement the total sum of uncovered labels...
+                            sumUncoveredLabels_ -= labelWeight;
 
-        for (uint32 r = 0; r < numExamples; r++) {
-            uint8 trueLabel = labelMatrixPtr_->getValue(r, c);
-            numPositiveLabels += trueLabel;
+                            // Mark the current example and label as covered...
+                            uncoveredLabels_[i] = 0;
+                        }
+                    }
+                }
+            }
 
-            // Mark the current example and label as uncovered...
-            uncoveredLabels[r * numLabels + c] = 1;
-        }
+            void applyPrediction(uint32 statisticIndex, const PartialPrediction& prediction) override {
+                uint32 numLabels = this->getNumLabels();
+                uint32 offset = statisticIndex * numLabels;
+                uint32 numPredictions = prediction.getNumElements();
+                PartialPrediction::score_const_iterator scoreIterator = prediction.scores_cbegin();
+                PartialPrediction::index_const_iterator indexIterator = prediction.indices_cbegin();
 
-        if (numPositiveLabels > threshold) {
-            minorityLabels[c] = 0;
-            sumUncoveredLabels += (numExamples - numPositiveLabels);
-        } else {
-            minorityLabels[c] = 1;
-            sumUncoveredLabels += numPositiveLabels;
-        }
+                // Only the labels that are predicted by the new rule must be considered...
+                for (uint32 c = 0; c < numPredictions; c++) {
+                    uint32 l = indexIterator[c];
+                    uint8 predictedLabel = scoreIterator[c];
+                    uint8 minorityLabel = minorityLabels_[l];
+
+                    // Do only consider predictions that are different from the default rule's predictions...
+                    if (predictedLabel == minorityLabel) {
+                        uint32 i = offset + l;
+                        float64 labelWeight = uncoveredLabels_[i];
+
+                        if (labelWeight > 0) {
+                            // Decrement the total sum of uncovered labels...
+                            sumUncoveredLabels_ -= labelWeight;
+
+                            // Mark the current example and label as covered...
+                            uncoveredLabels_[i] = 0;
+                        }
+                    }
+                }
+            }
+
+            std::unique_ptr<IHistogramBuilder> createHistogramBuilder(uint32 numBins) const override {
+                //TODO Support creation of histograms
+                std::unique_ptr<IHistogramBuilder> result;
+                return result;
+            }
+
+    };
+
+    DenseLabelWiseStatisticsFactory::DenseLabelWiseStatisticsFactory(
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> ruleEvaluationFactoryPtr,
+            std::shared_ptr<IRandomAccessLabelMatrix> labelMatrixPtr)
+        : ruleEvaluationFactoryPtr_(ruleEvaluationFactoryPtr), labelMatrixPtr_(labelMatrixPtr) {
+
     }
 
-    return std::make_unique<LabelWiseStatistics>(ruleEvaluationFactoryPtr_, labelMatrixPtr_, uncoveredLabels,
-                                                 sumUncoveredLabels, minorityLabels);
+    std::unique_ptr<ILabelWiseStatistics> DenseLabelWiseStatisticsFactory::create() const {
+        // The number of examples
+        uint32 numExamples = labelMatrixPtr_->getNumRows();
+        // The number of labels
+        uint32 numLabels = labelMatrixPtr_->getNumCols();
+        // A matrix that stores the weights of individual examples and labels that are still uncovered
+        float64* uncoveredLabels = (float64*) malloc(numExamples * numLabels * sizeof(float64));
+        // The sum of weights of all examples and labels that remain to be covered
+        float64 sumUncoveredLabels = 0;
+        // An array that stores whether rules should predict individual labels as relevant (1) or irrelevant (0)
+        uint8* minorityLabels = (uint8*) malloc(numLabels * sizeof(uint8));
+        // The number of positive examples that must be exceeded for the default rule to predict a label as relevant
+        float64 threshold = numExamples / 2.0;
+
+        for (uint32 c = 0; c < numLabels; c++) {
+            uint32 numPositiveLabels = 0;
+
+            for (uint32 r = 0; r < numExamples; r++) {
+                uint8 trueLabel = labelMatrixPtr_->getValue(r, c);
+                numPositiveLabels += trueLabel;
+
+                // Mark the current example and label as uncovered...
+                uncoveredLabels[r * numLabels + c] = 1;
+            }
+
+            if (numPositiveLabels > threshold) {
+                minorityLabels[c] = 0;
+                sumUncoveredLabels += (numExamples - numPositiveLabels);
+            } else {
+                minorityLabels[c] = 1;
+                sumUncoveredLabels += numPositiveLabels;
+            }
+        }
+
+        return std::make_unique<LabelWiseStatistics>(ruleEvaluationFactoryPtr_, labelMatrixPtr_, uncoveredLabels,
+                                                     sumUncoveredLabels, minorityLabels);
+    }
+
 }

--- a/python/boomer/seco/cpp/stopping/stopping_criterion_coverage.cpp
+++ b/python/boomer/seco/cpp/stopping/stopping_criterion_coverage.cpp
@@ -1,15 +1,17 @@
 #include "stopping_criterion_coverage.h"
 #include "../statistics/statistics_coverage.h"
 
-using namespace seco;
 
+namespace seco {
 
-CoverageStoppingCriterion::CoverageStoppingCriterion(float64 threshold)
-    : threshold_(threshold) {
+    CoverageStoppingCriterion::CoverageStoppingCriterion(float64 threshold)
+        : threshold_(threshold) {
 
-}
+    }
 
-bool CoverageStoppingCriterion::shouldContinue(const IStatistics& statistics, uint32 numRules) {
-    const ICoverageStatistics& coverageStatistics = static_cast<const ICoverageStatistics&>(statistics);
-    return coverageStatistics.getSumOfUncoveredLabels() > threshold_;
+    bool CoverageStoppingCriterion::shouldContinue(const IStatistics& statistics, uint32 numRules) {
+        const ICoverageStatistics& coverageStatistics = static_cast<const ICoverageStatistics&>(statistics);
+        return coverageStatistics.getSumOfUncoveredLabels() > threshold_;
+    }
+
 }


### PR DESCRIPTION
Bisher wurde in `cpp`-Files, die zu den Namespaces "seco" "boosting" gehören, die Klausel `using namespace` verwendet. Wenn nicht öffentliche Klassen innerhalb eines solchen `cpp`-Files definiert werden, ohne dass die Klasse von einem `namespace`-Block  umfasst werden, kann dies im Fall gleichnamiger Klassen zu schwer nachvollziehbaren Linker-Problemen führen. Um dies in Zukunft zu vermeiden, werden ab sofort stets `namespace`-Blöcke der oben genannten Klausel verwendet.