### PR TITLE
Refactoring Vorhersagealgorithmus

### DIFF
--- a/python/boomer/boosting/cpp/output/predictor_classification_label_wise.cpp
+++ b/python/boomer/boosting/cpp/output/predictor_classification_label_wise.cpp
@@ -1,95 +1,55 @@
 #include "predictor_classification_label_wise.h"
-#include "../../../common/cpp/model/head_full.h"
-#include "../../../common/cpp/model/head_partial.h"
+#include "predictor_common.h"
 
 
 namespace boosting {
 
-    static inline void applyFullHead(const FullHead& head, CContiguousView<float64>::iterator begin,
-                                     CContiguousView<float64>::iterator end) {
-        FullHead::score_const_iterator iterator = head.scores_cbegin();
-        uint32 numElements = head.getNumElements();
-
+    static inline void applyThreshold(CContiguousView<float64>::const_iterator originalIterator,
+                                      CContiguousView<uint8>::iterator transformedIterator, uint32 numElements,
+                                      float64 threshold) {
         for (uint32 i = 0; i < numElements; i++) {
-            begin[i] += iterator[i];
+            float64 originalValue = originalIterator[i];
+            uint8 transformedValue = originalValue > threshold ? 1 : 0;
+            transformedIterator[i] = transformedValue;
         }
     }
 
-    static inline void applyPartialHead(const PartialHead& head, CContiguousView<float64>::iterator begin,
-                                        CContiguousView<float64>::iterator end) {
-        PartialHead::score_const_iterator scoreIterator = head.scores_cbegin();
-        PartialHead::index_const_iterator indexIterator = head.indices_cbegin();
-        uint32 numElements = head.getNumElements();
-
-        for (uint32 i = 0; i < numElements; i++) {
-            uint32 index = indexIterator[i];
-            begin[index] += scoreIterator[i];
-        }
-    }
-
-    static inline void applyHead(const IHead& head, CContiguousView<float64>& scoreMatrix, uint32 row) {
-        auto fullHeadVisitor = [&, row](const FullHead& head) {
-            applyFullHead(head, scoreMatrix.row_begin(row), scoreMatrix.row_end(row));
-        };
-        auto partialHeadVisitor = [&, row](const PartialHead& head) {
-            applyPartialHead(head, scoreMatrix.row_begin(row), scoreMatrix.row_end(row));
-        };
-        head.visit(fullHeadVisitor, partialHeadVisitor);
-    }
-
-    static inline void aggregatePredictions(const CContiguousFeatureMatrix& featureMatrix,
-                                            CContiguousView<float64>& scoreMatrix, const RuleModel& model) {
+    static inline void predictInternally(const RuleModel& model, const CContiguousFeatureMatrix& featureMatrix,
+                                         CContiguousView<float64>& scoreMatrix,
+                                         CContiguousView<uint8>& predictionMatrix, float64 threshold) {
         uint32 numExamples = featureMatrix.getNumRows();
+        uint32 numLabels = predictionMatrix.getNumCols();
 
-        for (auto it = model.cbegin(); it != model.cend(); it++) {
-            const Rule& rule = *it;
-            const IBody& body = rule.getBody();
-            const IHead& head = rule.getHead();
-
-            for (uint32 i = 0; i < numExamples; i++) {
-                if (body.covers(featureMatrix.row_cbegin(i), featureMatrix.row_cend(i))) {
-                    applyHead(head, scoreMatrix, i);
-                }
+        for (uint32 i = 0; i < numExamples; i++) {
+            for (auto it = model.cbegin(); it != model.cend(); it++) {
+                const Rule& rule = *it;
+                applyRule(rule, featureMatrix.row_cbegin(i), featureMatrix.row_cend(i), scoreMatrix.row_begin(i));
             }
+
+            applyThreshold(scoreMatrix.row_cbegin(i), predictionMatrix.row_begin(i), numLabels, threshold);
         }
     }
 
-    static inline void aggregatePredictions(const CsrFeatureMatrix& featureMatrix,
-                                            CContiguousView<float64>& scoreMatrix, const RuleModel& model) {
+    static inline void predictInternally(const RuleModel& model, const CsrFeatureMatrix& featureMatrix,
+                                         CContiguousView<float64>& scoreMatrix,
+                                         CContiguousView<uint8>& predictionMatrix, float64 threshold) {
         uint32 numExamples = featureMatrix.getNumRows();
         uint32 numFeatures = featureMatrix.getNumCols();
+        uint32 numLabels = predictionMatrix.getNumCols();
         float32 tmpArray1[numFeatures];
         uint32 tmpArray2[numFeatures] = {};
         uint32 n = 1;
 
-        for (auto it = model.cbegin(); it != model.cend(); it++) {
-            const Rule& rule = *it;
-            const IBody& body = rule.getBody();
-            const IHead& head = rule.getHead();
-
-            for (uint32 i = 0; i < numExamples; i++) {
-                if (body.covers(featureMatrix.row_indices_cbegin(i), featureMatrix.row_indices_cend(i),
-                                featureMatrix.row_values_cbegin(i), featureMatrix.row_values_cend(i), &tmpArray1[0],
-                                &tmpArray2[0], n)) {
-                    applyHead(head, scoreMatrix, i);
-                }
-
+        for (uint32 i = 0; i < numExamples; i++) {
+            for (auto it = model.cbegin(); it != model.cend(); it++) {
+                const Rule& rule = *it;
+                applyRuleCsr(rule, featureMatrix.row_indices_cbegin(i), featureMatrix.row_indices_cend(i),
+                             featureMatrix.row_values_cbegin(i), featureMatrix.row_values_cend(i),
+                             scoreMatrix.row_begin(i), &tmpArray1[0], &tmpArray2[0], n);
                 n++;
             }
-        }
-    }
 
-    template<class I, class O>
-    static inline void applyThreshold(const CContiguousView<I>& originalMatrix, CContiguousView<O>& transformedMatrix,
-                                      I threshold) {
-        typename CContiguousView<I>::const_iterator originalIterator = originalMatrix.row_cbegin(0);
-        typename CContiguousView<O>::iterator transformedIterator = transformedMatrix.row_begin(0);
-        uint32 numElements = originalMatrix.getNumRows() * originalMatrix.getNumCols();
-
-        for (uint32 i = 0; i < numElements; i++) {
-            I originalValue = originalIterator[i];
-            O transformedValue = originalValue > threshold ? 1 : 0;
-            transformedIterator[i] = transformedValue;
+            applyThreshold(scoreMatrix.row_cbegin(i), predictionMatrix.row_begin(i), numLabels, threshold);
         }
     }
 
@@ -105,8 +65,7 @@ namespace boosting {
         uint32 numLabels = predictionMatrix.getNumCols();
         float64 scores[numExamples * numLabels] = {};
         CContiguousView<float64> scoreMatrix(numExamples, numLabels, &scores[0]);
-        aggregatePredictions(featureMatrix, scoreMatrix, model);
-        applyThreshold<float64, uint8>(scoreMatrix, predictionMatrix, threshold_);
+        predictInternally(model, featureMatrix, scoreMatrix, predictionMatrix, threshold_);
     }
 
     void LabelWiseClassificationPredictor::predict(const CsrFeatureMatrix& featureMatrix,
@@ -116,8 +75,7 @@ namespace boosting {
         uint32 numLabels = predictionMatrix.getNumCols();
         float64 scores[numExamples * numLabels] = {};
         CContiguousView<float64> scoreMatrix(numExamples, numLabels, &scores[0]);
-        aggregatePredictions(featureMatrix, scoreMatrix, model);
-        applyThreshold<float64, uint8>(scoreMatrix, predictionMatrix, threshold_);
+        predictInternally(model, featureMatrix, scoreMatrix, predictionMatrix, threshold_);
     }
 
 }

--- a/python/boomer/boosting/cpp/output/predictor_common.h
+++ b/python/boomer/boosting/cpp/output/predictor_common.h
@@ -1,0 +1,64 @@
+#pragma once
+#include "../../../common/cpp/model/head_full.h"
+#include "../../../common/cpp/model/head_partial.h"
+
+
+namespace boosting {
+
+    static inline void applyFullHead(const FullHead& head, CContiguousView<float64>::iterator iterator) {
+        FullHead::score_const_iterator scoreIterator = head.scores_cbegin();
+        uint32 numElements = head.getNumElements();
+
+        for (uint32 i = 0; i < numElements; i++) {
+            iterator[i] += scoreIterator[i];
+        }
+    }
+
+    static inline void applyPartialHead(const PartialHead& head, CContiguousView<float64>::iterator iterator) {
+        PartialHead::score_const_iterator scoreIterator = head.scores_cbegin();
+        PartialHead::index_const_iterator indexIterator = head.indices_cbegin();
+        uint32 numElements = head.getNumElements();
+
+        for (uint32 i = 0; i < numElements; i++) {
+            uint32 index = indexIterator[i];
+            iterator[index] += scoreIterator[i];
+        }
+    }
+
+    static inline void applyHead(const IHead& head, CContiguousView<float64>::iterator scoreIterator) {
+        auto fullHeadVisitor = [=](const FullHead& head) {
+            applyFullHead(head, scoreIterator);
+        };
+        auto partialHeadVisitor = [=](const PartialHead& head) {
+            applyPartialHead(head, scoreIterator);
+        };
+        head.visit(fullHeadVisitor, partialHeadVisitor);
+    }
+
+    static inline void applyRule(const Rule& rule, CContiguousFeatureMatrix::const_iterator featureValuesBegin,
+                                 CContiguousFeatureMatrix::const_iterator featureValuesEnd,
+                                 CContiguousView<float64>::iterator scoreIterator) {
+        const IBody& body = rule.getBody();
+
+        if (body.covers(featureValuesBegin, featureValuesEnd)) {
+            const IHead& head = rule.getHead();
+            applyHead(head, scoreIterator);
+        }
+    }
+
+    static inline void applyRuleCsr(const Rule& rule, CsrFeatureMatrix::index_const_iterator featureIndicesBegin,
+                                    CsrFeatureMatrix::index_const_iterator featureIndicesEnd,
+                                    CsrFeatureMatrix::value_const_iterator featureValuesBegin,
+                                    CsrFeatureMatrix::value_const_iterator featureValuesEnd,
+                                    CContiguousView<float64>::iterator scoreIterator, float32* tmpArray1,
+                                    uint32* tmpArray2, uint32 n) {
+        const IBody& body = rule.getBody();
+
+        if (body.covers(featureIndicesBegin, featureIndicesEnd, featureValuesBegin, featureValuesEnd, tmpArray1,
+                        tmpArray2, n)) {
+            const IHead& head = rule.getHead();
+            applyHead(head, scoreIterator);
+        }
+    }
+
+}


### PR DESCRIPTION
Enthält folgende Änderungen in der Implementierung der Klasse `ClassificationPredictor`, die für die Ermittlung der Vorhersagen des Boosting-Algorithmus verwendet wird:

* Funktionen zum Aufaddieren der Vorhersagen einzelner Regeln wurden in eine separate Headerdatei `predictor_common.h` verschoben.
* Die Vorhersage wird jetzt für jeden einzelne Beispiel unabhängig voneinander ermittelt um später die Parallisierung über mehrere CPU-Threads zu erlauben (siehe #377).