### PR TITLE
Stop-Kriterien erlauben eine bestimmte Anzahl Regeln zurückzugeben

### DIFF
--- a/cpp/subprojects/common/include/common/stopping/stopping_criterion.hpp
+++ b/cpp/subprojects/common/include/common/stopping/stopping_criterion.hpp
@@ -15,12 +15,22 @@ class IStoppingCriterion {
     public:
 
         /**
-         * An enum that specifies all values that may be returned by a stopping criterion.
+         * An enum that specifies all possible actions that may be executed, based on the result that is returned by a
+         * stopping criterion.
          */
-        enum Result : uint32 {
+        enum Action : uint32 {
             CONTINUE = 0,
             STORE_STOP = 1,
             FORCE_STOP = 2
+        };
+
+        /**
+         * The result that is returned by a stopping criterion. It consists of the action to be executed, as well as the
+         * number of rules to be used, if the action is not `CONTINUE`.
+         */
+        struct Result {
+            Action action;
+            uint32 numRules;
         };
 
         virtual ~IStoppingCriterion() { };

--- a/cpp/subprojects/common/src/common/rule_induction/rule_model_induction_sequential.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_model_induction_sequential.cpp
@@ -4,17 +4,23 @@
 static inline IStoppingCriterion::Result testStoppingCriteria(
         std::forward_list<std::shared_ptr<IStoppingCriterion>>& stoppingCriteria, const IStatistics& statistics,
         uint32 numRules) {
-    IStoppingCriterion::Result result = IStoppingCriterion::Result::CONTINUE;
+    IStoppingCriterion::Result result;
+    result.action = IStoppingCriterion::Action::CONTINUE;
 
     for (auto it = stoppingCriteria.begin(); it != stoppingCriteria.end(); it++) {
         std::shared_ptr<IStoppingCriterion>& stoppingCriterionPtr = *it;
+        IStoppingCriterion::Result stoppingCriterionResult = stoppingCriterionPtr->test(statistics, numRules);
+        IStoppingCriterion::Action action = stoppingCriterionResult.action;
 
-        switch (stoppingCriterionPtr->test(statistics, numRules)) {
-            case IStoppingCriterion::Result::FORCE_STOP: {
-                return IStoppingCriterion::Result::FORCE_STOP;
+        switch (action) {
+            case IStoppingCriterion::Action::FORCE_STOP: {
+                result.action = action;
+                result.numRules = stoppingCriterionResult.numRules;
+                return result;
             }
-            case IStoppingCriterion::Result::STORE_STOP: {
-                result = IStoppingCriterion::Result::STORE_STOP;
+            case IStoppingCriterion::Action::STORE_STOP: {
+                result.action = action;
+                result.numRules = stoppingCriterionResult.numRules;
                 break;
             }
             default: {
@@ -72,9 +78,9 @@ std::unique_ptr<RuleModel> SequentialRuleModelInduction::induceRules(
 
     while (stoppingCriterionResult = testStoppingCriteria(*stoppingCriteriaPtr_, statisticsProviderPtr->get(),
                                                           numRules),
-           stoppingCriterionResult != IStoppingCriterion::Result::FORCE_STOP) {
-        if (stoppingCriterionResult == IStoppingCriterion::Result::STORE_STOP && numUsedRules == 0) {
-            numUsedRules = numRules;
+           stoppingCriterionResult.action != IStoppingCriterion::Action::FORCE_STOP) {
+        if (stoppingCriterionResult.action == IStoppingCriterion::Action::STORE_STOP && numUsedRules == 0) {
+            numUsedRules = stoppingCriterionResult.numRules;
         }
 
         std::unique_ptr<IWeightVector> weightsPtr = partitionPtr->subSample(*instanceSubSamplingPtr_, rng);

--- a/cpp/subprojects/common/src/common/stopping/stopping_criterion_size.cpp
+++ b/cpp/subprojects/common/src/common/stopping/stopping_criterion_size.cpp
@@ -7,5 +7,14 @@ SizeStoppingCriterion::SizeStoppingCriterion(uint32 maxRules)
 }
 
 IStoppingCriterion::Result SizeStoppingCriterion::test(const IStatistics& statistics, uint32 numRules) {
-    return numRules < maxRules_ ? CONTINUE : FORCE_STOP;
+    Result result;
+
+    if (numRules < maxRules_) {
+        result.action = CONTINUE;
+    } else {
+        result.action = FORCE_STOP;
+        result.numRules = numRules;
+    }
+
+    return result;
 }

--- a/cpp/subprojects/common/src/common/stopping/stopping_criterion_time.cpp
+++ b/cpp/subprojects/common/src/common/stopping/stopping_criterion_time.cpp
@@ -8,13 +8,23 @@ TimeStoppingCriterion::TimeStoppingCriterion(uint32 timeLimit)
 }
 
 IStoppingCriterion::Result TimeStoppingCriterion::test(const IStatistics& statistics, uint32 numRules) {
+    Result result;
+
     if (timerStarted_) {
         auto currentTime = timer::now();
         auto duration = std::chrono::duration_cast<timer_unit>(currentTime - startTime_);
-        return duration < timeLimit_ ? CONTINUE : FORCE_STOP;
+
+        if (duration < timeLimit_) {
+            result.action = CONTINUE;
+        } else {
+            result.action = FORCE_STOP;
+            result.numRules = numRules;
+        }
     } else {
         startTime_ = timer::now();
         timerStarted_ = true;
-        return CONTINUE;
+        result.action = CONTINUE;
     }
+
+    return result;
 }

--- a/cpp/subprojects/seco/src/seco/stopping/stopping_criterion_coverage.cpp
+++ b/cpp/subprojects/seco/src/seco/stopping/stopping_criterion_coverage.cpp
@@ -10,8 +10,17 @@ namespace seco {
     }
 
     IStoppingCriterion::Result CoverageStoppingCriterion::test(const IStatistics& statistics, uint32 numRules) {
+        Result result;
         const ICoverageStatistics& coverageStatistics = static_cast<const ICoverageStatistics&>(statistics);
-        return coverageStatistics.getSumOfUncoveredLabels() > threshold_ ? CONTINUE : FORCE_STOP;
+
+        if (coverageStatistics.getSumOfUncoveredLabels() > threshold_) {
+            result.action = CONTINUE;
+        } else {
+            result.action = FORCE_STOP;
+            result.numRules = numRules;
+        }
+
+        return result;
     }
 
 }


### PR DESCRIPTION
Enthält folgende Änderungen:

* Das Enum `IStoppingCriterion::Result` wurde umbenannt zu `IStoppingCriterion::Action`.
* Das Struct `IStoppingCriterion::Result` wurde hinzugefügt. Es erlaubt eine bestimmt Anzahl Regeln anzugeben.
* Die Funktion `IStoppingCriterion::test` gibt jetzt ein Objekt vom Typ `IStoppingCriterion::Result` zurück.
* Innerhalb der Klasse `SequentialRuleModelInduction` wird die von einem Stop-Kriterium zurückgegebene Anzahl Regeln im Modell gespeichert.