### PR TITLE
Änderungen bezüglich Meson/Ninja in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ venv:
 
 compile: venv
 	@echo "Compiling C++ code..."
-	cd cpp/ && ../venv/bin/meson setup build -Doptimization=3 && cd build/ && ../../venv/bin/ninja
+	@echo ${PATH}
+	cd cpp/ && PATH=$$PATH:../venv/bin/ ../venv/bin/meson setup build -Doptimization=3 && cd build/ && ../../venv/bin/ninja
 	@echo "Compiling Cython code..."
 	cd python/ && ../venv/bin/python setup.py build_ext --inplace
 


### PR DESCRIPTION
Anders als in #394 geplant, funktioniert das Kompilieren des C++-Codes mit Meson zur Zeit nur wenn eine globale Installation von Ninja auf dem System verfügbar ist. Der Grund ist, dass Meson in den gängigen Verzeichnissen (z.B. in `/usr/bin/ unter Linux) nach einer geigneten Ninja-Installation sucht. Falls eine solche nicht vorhanden ist, schlägt Mesons `setup`-Befehl fehl.

Um Meson zukünftig zu ermöglichen die Version von Ninja zu verwenden, die von dem Makefile in das virtuelle Environment installiert wurde, wird durch diesen Pull-Request der Pfad zu dieser Installation (`venv/bin/`) zur "PATH"-Umgebungsvariable hinzugefügt bevor Meson ausgeführt wird.

@AndreasSeidl Die hier enthaltenen Änderungen sollten das Problem lösen, weshalb du auf deinem Rechner Ninja per Paketmanager installieren musstest.