### PR TITLE
Pruning von Regeln auf Basis von Bins 

### DIFF
--- a/cpp/subprojects/common/src/common/thresholds/thresholds_approximate.cpp
+++ b/cpp/subprojects/common/src/common/thresholds/thresholds_approximate.cpp
@@ -269,7 +269,13 @@ class ApproximateThresholds final : public AbstractThresholds {
                 }
 
                 void filterThresholds(const Condition& condition) override {
-                    // TODO Implement
+                    uint32 featureIndex = condition.featureIndex;
+                    auto cacheIterator = thresholds_.cache_.find(featureIndex);
+                    const ThresholdVector& thresholdVector = *cacheIterator->second.thresholdVectorPtr;
+                    const IBinIndexVector& binIndices = *cacheIterator->second.binIndicesPtr;
+                    updateCoveredExamples(thresholdVector, binIndices, condition.start, condition.end,
+                                          condition.covered, coverageSet_, thresholds_.statisticsProviderPtr_->get(),
+                                          weights_);
                 }
 
                 void resetThresholds() override {


### PR DESCRIPTION
Closes #420 

Implementiert die Funktion `filterThresholds` der Klasse `ApproximateThresholds::ThresholdsSubset`, die ein `Condition`-Objekt als Argument übergeben bekommt, so dass das Prunen von Regeln im Zusammenspiel mit den approximativen Verfahren genutzt werden kann.