### PR TITLE
Entfernen von "subtract"-Funktionen

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/data/vector_dense_example_wise.hpp
+++ b/cpp/subprojects/boosting/include/boosting/data/vector_dense_example_wise.hpp
@@ -288,19 +288,6 @@ namespace boosting {
                      hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd, float64 weight);
 
             /**
-             * Subtracts all gradients and Hessians in another vector from this vector. The gradients and Hessians to be
-             * subtracted are multiplied by a specific weight.
-             *
-             * @param gradientsBegin    A `gradient_const_iterator` to the beginning of the gradients
-             * @param gradientsEnd      A `gradient_const_iterator` to the end of the gradients
-             * @param hessiansBegin     A `hessian_const_iterator` to the beginning of the Hessians
-             * @param hessiansEnd       A `hessian_const_iterator` to the end of the Hessians
-             * @param weight            The weight, the gradients and Hessians should be multiplied by
-             */
-            void subtract(gradient_const_iterator gradientsBegin, gradient_const_iterator gradientsEnd,
-                          hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd, float64 weight);
-
-            /**
              * Adds certain gradients and Hessians in another vector, whose positions are given as a `FullIndexVector`,
              * to this vector. The gradients and Hessians to be added are multiplied by a specific weight.
              *

--- a/cpp/subprojects/boosting/include/boosting/data/vector_dense_label_wise.hpp
+++ b/cpp/subprojects/boosting/include/boosting/data/vector_dense_label_wise.hpp
@@ -158,19 +158,6 @@ namespace boosting {
                      hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd, float64 weight);
 
             /**
-             * Subtracts all gradients and Hessians in another vector from this vector. The gradients and Hessians to be
-             * subtracted are multiplied by a specific weight.
-             *
-             * @param gradientsBegin    A `gradient_const_iterator` to the beginning of the gradients
-             * @param gradientsEnd      A `gradient_const_iterator` to the end of the gradients
-             * @param hessiansBegin     A `hessian_const_iterator` to the beginning of the Hessians
-             * @param hessiansEnd       A `hessian_const_iterator` to the end of the Hessians
-             * @param weight            The weight, the gradients and Hessians should be multiplied by
-             */
-            void subtract(gradient_const_iterator gradientsBegin, gradient_const_iterator gradientsEnd,
-                          hessian_const_iterator hessiansBegin, hessian_const_iterator hessiansEnd, float64 weight);
-
-            /**
              * Adds certain gradients and Hessians in another vector, whose positions are given as a `FullIndexVector`,
              * to this vector. The gradients and Hessians to be added are multiplied by a specific weight.
              *

--- a/cpp/subprojects/boosting/src/boosting/data/vector_dense_example_wise.cpp
+++ b/cpp/subprojects/boosting/src/boosting/data/vector_dense_example_wise.cpp
@@ -144,15 +144,6 @@ namespace boosting {
         addToArray(hessians_, hessiansBegin, numHessians_, weight);
     }
 
-    void DenseExampleWiseStatisticVector::subtract(gradient_const_iterator gradientsBegin,
-                                                   gradient_const_iterator gradientsEnd,
-                                                   hessian_const_iterator hessiansBegin,
-                                                   hessian_const_iterator hessiansEnd, float64 weight) {
-        float64 invertedWeight = -weight;
-        addToArray(gradients_, gradientsBegin, numGradients_, invertedWeight);
-        addToArray(hessians_, hessiansBegin, numHessians_, invertedWeight);
-    }
-
     void DenseExampleWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
                                                       gradient_const_iterator gradientsEnd,
                                                       hessian_const_iterator hessiansBegin,

--- a/cpp/subprojects/boosting/src/boosting/data/vector_dense_label_wise.cpp
+++ b/cpp/subprojects/boosting/src/boosting/data/vector_dense_label_wise.cpp
@@ -84,15 +84,6 @@ namespace boosting {
         addToArray(hessians_, hessiansBegin, numElements_, weight);
     }
 
-    void DenseLabelWiseStatisticVector::subtract(gradient_const_iterator gradientsBegin,
-                                                 gradient_const_iterator gradientsEnd,
-                                                 hessian_const_iterator hessiansBegin,
-                                                 hessian_const_iterator hessiansEnd, float64 weight) {
-        float64 invertedWeight = -weight;
-        addToArray(gradients_, gradientsBegin, numElements_, invertedWeight);
-        addToArray(hessians_, hessiansBegin, numElements_, invertedWeight);
-    }
-
     void DenseLabelWiseStatisticVector::addToSubset(gradient_const_iterator gradientsBegin,
                                                     gradient_const_iterator gradientsEnd,
                                                     hessian_const_iterator hessiansBegin,

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_common.hpp
@@ -83,11 +83,11 @@ namespace boosting {
 
                         // Subtract the gradients and Hessians of the example at the given index (weighted by the given
                         // weight) from the total sums of gradients and Hessians...
-                        totalCoverableSumVector_->subtract(
+                        totalCoverableSumVector_->add(
                             statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
                             statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
                             statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                            statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), weight);
+                            statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), -weight);
                     }
 
                     void addToSubset(uint32 statisticIndex, float64 weight) override {

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
@@ -83,11 +83,11 @@ namespace boosting {
 
                         // Subtract the gradients and Hessians of the example at the given index (weighted by the given
                         // weight) from the total sums of gradients and Hessians...
-                        totalCoverableSumVector_->subtract(
+                        totalCoverableSumVector_->add(
                             statistics_.statisticMatrixPtr_->gradients_row_cbegin(statisticIndex),
                             statistics_.statisticMatrixPtr_->gradients_row_cend(statisticIndex),
                             statistics_.statisticMatrixPtr_->hessians_row_cbegin(statisticIndex),
-                            statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), weight);
+                            statistics_.statisticMatrixPtr_->hessians_row_cend(statisticIndex), -weight);
                     }
 
                     void addToSubset(uint32 statisticIndex, float64 weight) override {


### PR DESCRIPTION
Entfernt die `subtract`-Funktionen der Klasse `DenseLabelWiseStatisticVector` und `DenseExampleWiseStatisticVector`. Als equivalenter Ersatz dieser Funktionen wird jetzt die `add`-Funktion verwendet, wobei das Vorzeichen des übergebenen Gewichts negiert wird.