### PR TITLE
Optimierung Fisher-Yates Shuffle

### DIFF
--- a/cpp/subprojects/common/src/common/sampling/index_sampling.hpp
+++ b/cpp/subprojects/common/src/common/sampling/index_sampling.hpp
@@ -91,12 +91,13 @@ static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaRe
  * @param secondIterator    The iterator that provides random access to the indices that are contained by the second set
  * @param numFirst          The number of indices that are contained by the first set
  * @param numTotal          The total number of indices to sample from
+ * @param numPermutations   The maximum number of permutations to be performed. Must be in [1, numTotal)
  * @param rng               A reference to an object of type `RNG`, implementing the random number generator to be used
  */
 template<class FirstIterator, class SecondIterator>
 static inline void randomPermutation(FirstIterator firstIterator, SecondIterator secondIterator, uint32 numFirst,
-                                     uint32 numTotal, RNG& rng) {
-    for (uint32 i = 0; i < numTotal - 2; i++) {
+                                     uint32 numTotal, uint32 numPermutations, RNG& rng) {
+    for (uint32 i = 0; i < numPermutations; i++) {
         // Swap elements at index i and at a randomly selected index...
         uint32 randomIndex = rng.random(i, numTotal);
         uint32 tmp1 = i < numFirst ? firstIterator[i] : secondIterator[i - numFirst];
@@ -148,7 +149,7 @@ static inline std::unique_ptr<IIndexVector> sampleIndicesWithoutReplacementViaRa
     }
 
     randomPermutation<PartialIndexVector::iterator, uint32*>(sampleIterator, &unusedIndices[0], numSamples, numTotal,
-                                                             rng);
+                                                             numSamples, rng);
     return indexVectorPtr;
 }
 

--- a/cpp/subprojects/common/src/common/sampling/partition_sampling_bi.cpp
+++ b/cpp/subprojects/common/src/common/sampling/partition_sampling_bi.cpp
@@ -24,6 +24,6 @@ std::unique_ptr<IPartition> BiPartitionSampling::partition(uint32 numExamples, R
     }
 
     randomPermutation<BiPartition::iterator, BiPartition::iterator>(trainingIterator, holdoutIterator, numTraining,
-                                                                    numExamples, rng);
+                                                                    numExamples, numExamples - 1, rng);
     return partitionPtr;
 }


### PR DESCRIPTION
Um eine zufällige Permutation der Werte in zwei Arrays zu erstellen, implementiert die Funktion `randomPermutation` in der Datei `index_sampling.hpp` den Fisher-Yates Shuffle. Wenn die Permutation dazu verwendet wird eine zufällige Untermenge aller Werte zu bestimmen, müssen jedoch nicht alle vorhandenen Werte permutiert werden. Um dies zu vermeiden wurde ein neues Argument `numPermutations` zu der Funktion hinzugefügt, das es erlaubt die Anzahl durchzuführender Permutationen anzugeben.