### PR TITLE
Bugfix in Funktion "filterCurrentVector"

### DIFF
--- a/cpp/subprojects/common/src/common/thresholds/thresholds_exact.cpp
+++ b/cpp/subprojects/common/src/common/thresholds/thresholds_exact.cpp
@@ -148,6 +148,15 @@ static inline void filterCurrentVector(const FeatureVector& vector, FilteredCach
             i++;
         }
     } else {
+        // Discard the indices at positions [start, end) and set the corresponding values in `coverageMask` to
+        // `numConditions`, which marks them as uncovered...
+        for (intp r = start; r < end; r++) {
+            uint32 index = iterator[r].index;
+            coverageMaskIterator[index] = numConditions;
+            float64 weight = weights.getWeight(index);
+            statistics.updateCoveredStatistic(index, weight, true);
+        }
+
         if (conditionComparator == NEQ) {
             // Retain the indices at positions [currentStart, currentEnd), while leaving the corresponding values in
             // `coverageMask` untouched, such that all previously covered examples in said range are still marked
@@ -170,15 +179,6 @@ static inline void filterCurrentVector(const FeatureVector& vector, FilteredCach
                 filteredIterator[i].value = iterator[r].value;
                 i++;
             }
-        }
-
-        // Discard the indices at positions [start, end) and set the corresponding values in `coverageMask` to
-        // `numConditions`, which marks them as uncovered...
-        for (intp r = start; r < end; r++) {
-            uint32 index = iterator[r].index;
-            coverageMaskIterator[index] = numConditions;
-            float64 weight = weights.getWeight(index);
-            statistics.updateCoveredStatistic(index, weight, true);
         }
 
         // Retain the indices at positions [currentStart, currentEnd), while leaving the corresponding values in


### PR DESCRIPTION
Behebt ein Problem in der Funktion `filterCurrentVector` in der Datei `thresholds_exact.cpp`, das dazu führt dass die `CoverageMask` nicht korrekt aktualisiert wird. Wenn eine Bedingung für ein nominales Attribut gelernt wurde, das den Operator `!=` verwendet und dessen Wert größer als 0 ist, wurden Einträge des zu filternden Vektors beschrieben, bevor sie dazu verwendet wurden die `CoverageMask` zu aktualisieren. Das Problem lässt sich beheben indem die Reihenfolge der Lese-, bzw. Schreibzugriffe vertauscht werden.