### PR TITLE
Argumente der Funktion "induceRule" entfernen

### DIFF
--- a/cpp/subprojects/common/include/common/rule_induction/rule_induction.hpp
+++ b/cpp/subprojects/common/include/common/rule_induction/rule_induction.hpp
@@ -57,15 +57,6 @@ class IRuleInduction {
          *                                  rule
          * @param postProcessor             A reference to an object of type `IPostProcessor` that should be used to
          *                                  post-process the predictions of the rule
-         * @param minCoverage               The minimum number of training examples that must be covered by the rule.
-         *                                  Must be at least 1
-         * @param maxConditions             The maximum number of conditions to be included in the rule's body. Must be
-         *                                  at least 1 or -1, if the number of conditions should not be restricted
-         * @param maxHeadRefinements        The maximum number of times, the head of the rule may be refinement after a
-         *                                  new condition has been added to its body. Must be at least 1 or -1, if the
-         *                                  number of refinements should not be restricted
-         * @param recalculatePredictions    True, if the predictions of the rule should be recalculated on all training
-         *                                  examples, if some of the examples have zero weights, false otherwise
          * @param rng                       A reference to an object of type `RNG` that implements the random number
          *                                  generator to be used
          * @param modelBuilder              A reference to an object of type `IModelBuilder`, the rule should be added
@@ -75,8 +66,6 @@ class IRuleInduction {
         virtual bool induceRule(IThresholds& thresholds, const IIndexVector& labelIndices,
                                 const IWeightVector& weights, IPartition& partition,
                                 IFeatureSubSampling& featureSubSampling, const IPruning& pruning,
-                                const IPostProcessor& postProcessor, uint32 minCoverage, intp maxConditions,
-                                intp maxHeadRefinements, bool recalculatePredictions, RNG& rng,
-                                IModelBuilder& modelBuilder) const = 0;
+                                const IPostProcessor& postProcessor, RNG& rng, IModelBuilder& modelBuilder) const = 0;
 
 };

--- a/cpp/subprojects/common/include/common/rule_induction/rule_induction_top_down.hpp
+++ b/cpp/subprojects/common/include/common/rule_induction/rule_induction_top_down.hpp
@@ -15,15 +15,33 @@ class TopDownRuleInduction : public IRuleInduction {
 
     private:
 
+        uint32 minCoverage_;
+
+        intp maxConditions_;
+
+        intp maxHeadRefinements_;
+
+        bool recalculatePredictions_;
+
         uint32 numThreads_;
 
     public:
 
         /**
-         * @param numThreads The number of CPU threads to be used to search for potential refinements of a rule in
-         *                   parallel. Must be at least 1
+         * @param minCoverage               The minimum number of training examples that must be covered by a rule. Must
+         *                                  be at least 1
+         * @param maxConditions             The maximum number of conditions to be included in a rule's body. Must be at
+         *                                  least 1 or -1, if the number of conditions should not be restricted
+         * @param maxHeadRefinements        The maximum number of times, the head of a rule may be refinement after a
+         *                                  new condition has been added to its body. Must be at least 1 or -1, if the
+         *                                  number of refinements should not be restricted
+         * @param recalculatePredictions    True, if the predictions of rules should be recalculated on all training
+         *                                  examples, if some of the examples have zero weights, false otherwise
+         * @param numThreads                The number of CPU threads to be used to search for potential refinements of
+         *                                  a rule in parallel. Must be at least 1
          */
-        TopDownRuleInduction(uint32 numThreads);
+        TopDownRuleInduction(uint32 minCoverage, intp maxConditions, intp maxHeadRefinements,
+                             bool recalculatePredictions, uint32 numThreads);
 
         void induceDefaultRule(IStatisticsProvider& statisticsProvider,
                                const IHeadRefinementFactory* headRefinementFactory,
@@ -31,8 +49,6 @@ class TopDownRuleInduction : public IRuleInduction {
 
         bool induceRule(IThresholds& thresholds, const IIndexVector& labelIndices, const IWeightVector& weights,
                         IPartition& partition, IFeatureSubSampling& featureSubSampling, const IPruning& pruning,
-                        const IPostProcessor& postProcessor, uint32 minCoverage, intp maxConditions,
-                        intp maxHeadRefinements, bool recalculatePredictions, RNG& rng,
-                        IModelBuilder& modelBuilder) const override;
+                        const IPostProcessor& postProcessor, RNG& rng, IModelBuilder& modelBuilder) const override;
 
 };

--- a/cpp/subprojects/common/include/common/rule_induction/rule_model_induction_sequential.hpp
+++ b/cpp/subprojects/common/include/common/rule_induction/rule_model_induction_sequential.hpp
@@ -45,14 +45,6 @@ class SequentialRuleModelInduction : public IRuleModelInduction {
 
         std::shared_ptr<IPostProcessor> postProcessorPtr_;
 
-        uint32 minCoverage_;
-
-        intp maxConditions_;
-
-        intp maxHeadRefinements_;
-
-        bool recalculatePredictions_;
-
         std::unique_ptr<std::forward_list<std::shared_ptr<IStoppingCriterion>>> stoppingCriteriaPtr_;
 
     public:
@@ -91,18 +83,6 @@ class SequentialRuleModelInduction : public IRuleModelInduction {
          *                                              used to prune the rules
          * @param postProcessorPtr                      A shared pointer to an object of type `IPostProcessor` that
          *                                              should be used to post-process the predictions of rules
-         * @param minCoverage                           The minimum number of training examples that must be covered by
-         *                                              the rule. Must be at least 1
-         * @param maxConditions                         The maximum number of conditions to be included in the rule's
-         *                                              body. Must be at least 1 or -1, if the number of conditions
-         *                                              should not be restricted
-         * @param maxHeadRefinements                    The maximum number of times, the head of the rule may be
-         *                                              refinement after a new condition has been added to its body.
-         *                                              Must be at least 1 or -1, if the number of refinements should
-         *                                              not be restricted
-         * @param recalculatePredictions                True, if the predictions of rules should be recalculated on the
-         *                                              entire training data, if instance sub-sampling is used, false
-         *                                              otherwise
          * @param stoppingCriteriaPtr                   An unique pointer to a list that contains the stopping criteria,
          *                                              which should be used to decide whether additional rules should
          *                                              be induced or not
@@ -116,8 +96,7 @@ class SequentialRuleModelInduction : public IRuleModelInduction {
             std::shared_ptr<IInstanceSubSamplingFactory> instanceSubSamplingFactoryPtr,
             std::shared_ptr<IFeatureSubSamplingFactory> featureSubSamplingFactoryPtr,
             std::shared_ptr<IPartitionSamplingFactory> partitionSamplingFactoryPtr,
-            std::shared_ptr<IPruning> pruningPtr, std::shared_ptr<IPostProcessor> postProcessorPtr, uint32 minCoverage,
-            intp maxConditions, intp maxHeadRefinements, bool recalculatePredictions,
+            std::shared_ptr<IPruning> pruningPtr, std::shared_ptr<IPostProcessor> postProcessorPtr,
             std::unique_ptr<std::forward_list<std::shared_ptr<IStoppingCriterion>>> stoppingCriteriaPtr);
 
         std::unique_ptr<RuleModel> induceRules(std::shared_ptr<INominalFeatureMask> nominalFeatureMaskPtr,

--- a/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down.cpp
@@ -4,8 +4,10 @@
 #include <unordered_map>
 
 
-TopDownRuleInduction::TopDownRuleInduction(uint32 numThreads)
-    : numThreads_(numThreads) {
+TopDownRuleInduction::TopDownRuleInduction(uint32 minCoverage, intp maxConditions, intp maxHeadRefinements,
+                                           bool recalculatePredictions, uint32 numThreads)
+    : minCoverage_(minCoverage), maxConditions_(maxConditions), maxHeadRefinements_(maxHeadRefinements),
+      recalculatePredictions_(recalculatePredictions), numThreads_(numThreads) {
 
 }
 
@@ -42,8 +44,7 @@ void TopDownRuleInduction::induceDefaultRule(IStatisticsProvider& statisticsProv
 bool TopDownRuleInduction::induceRule(IThresholds& thresholds, const IIndexVector& labelIndices,
                                       const IWeightVector& weights, IPartition& partition,
                                       IFeatureSubSampling& featureSubSampling, const IPruning& pruning,
-                                      const IPostProcessor& postProcessor, uint32 minCoverage, intp maxConditions,
-                                      intp maxHeadRefinements, bool recalculatePredictions, RNG& rng,
+                                      const IPostProcessor& postProcessor, RNG& rng,
                                       IModelBuilder& modelBuilder) const {
     // True, if the rule is learned on a sub-sample of the available training examples, False otherwise
     bool instanceSubSamplingUsed = weights.hasZeroWeights();
@@ -68,7 +69,7 @@ bool TopDownRuleInduction::induceRule(IThresholds& thresholds, const IIndexVecto
 
     // Search for the best refinement until no improvement in terms of the rule's quality score is possible anymore or
     // the maximum number of conditions has been reached...
-    while (foundRefinement && (maxConditions == -1 || numConditions < maxConditions)) {
+    while (foundRefinement && (maxConditions_ == -1 || numConditions < maxConditions_)) {
         foundRefinement = false;
 
         // Sample features...
@@ -116,12 +117,12 @@ bool TopDownRuleInduction::induceRule(IThresholds& thresholds, const IIndexVecto
             numConditions++;
 
             // Keep the labels for which the rule predicts, if the head should not be further refined...
-            if (maxHeadRefinements > 0 && numConditions >= maxHeadRefinements) {
+            if (maxHeadRefinements_ > 0 && numConditions >= maxHeadRefinements_) {
                 currentLabelIndices = bestHead;
             }
 
             // Abort refinement process if the rule is not allowed to cover less examples...
-            if (numCoveredExamples <= minCoverage) {
+            if (numCoveredExamples <= minCoverage_) {
                 break;
             }
         }
@@ -138,7 +139,7 @@ bool TopDownRuleInduction::induceRule(IThresholds& thresholds, const IIndexVecto
                                                                              conditions, *bestHead);
 
             // Re-calculate the scores in the head based on the entire training data...
-            if (recalculatePredictions) {
+            if (recalculatePredictions_) {
                 const ICoverageState& coverageState =
                     coverageStatePtr.get() != nullptr ? *coverageStatePtr : thresholdsSubsetPtr->getCoverageState();
                 partition.recalculatePrediction(*thresholdsSubsetPtr, coverageState, *bestRefinementPtr);

--- a/cpp/subprojects/common/src/common/rule_induction/rule_model_induction_sequential.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_model_induction_sequential.cpp
@@ -42,8 +42,7 @@ SequentialRuleModelInduction::SequentialRuleModelInduction(
         std::shared_ptr<IInstanceSubSamplingFactory> instanceSubSamplingFactoryPtr,
         std::shared_ptr<IFeatureSubSamplingFactory> featureSubSamplingFactoryPtr,
         std::shared_ptr<IPartitionSamplingFactory> partitionSamplingFactoryPtr, std::shared_ptr<IPruning> pruningPtr,
-        std::shared_ptr<IPostProcessor> postProcessorPtr, uint32 minCoverage, intp maxConditions,
-        intp maxHeadRefinements, bool recalculatePredictions,
+        std::shared_ptr<IPostProcessor> postProcessorPtr,
         std::unique_ptr<std::forward_list<std::shared_ptr<IStoppingCriterion>>> stoppingCriteriaPtr)
     : statisticsProviderFactoryPtr_(statisticsProviderFactoryPtr), thresholdsFactoryPtr_(thresholdsFactoryPtr),
       ruleInductionPtr_(ruleInductionPtr), defaultRuleHeadRefinementFactoryPtr_(defaultRuleHeadRefinementFactoryPtr),
@@ -51,9 +50,7 @@ SequentialRuleModelInduction::SequentialRuleModelInduction(
       instanceSubSamplingFactoryPtr_(instanceSubSamplingFactoryPtr),
       featureSubSamplingFactoryPtr_(featureSubSamplingFactoryPtr),
       partitionSamplingFactoryPtr_(partitionSamplingFactoryPtr), pruningPtr_(pruningPtr),
-      postProcessorPtr_(postProcessorPtr), minCoverage_(minCoverage), maxConditions_(maxConditions),
-      maxHeadRefinements_(maxHeadRefinements), recalculatePredictions_(recalculatePredictions),
-      stoppingCriteriaPtr_(std::move(stoppingCriteriaPtr)) {
+      postProcessorPtr_(postProcessorPtr), stoppingCriteriaPtr_(std::move(stoppingCriteriaPtr)) {
 
 }
 
@@ -93,9 +90,8 @@ std::unique_ptr<RuleModel> SequentialRuleModelInduction::induceRules(
         const IWeightVector& weights = instanceSubSamplingPtr->subSample(rng);
         const IIndexVector& labelIndices = labelSubSamplingPtr->subSample(rng);
         bool success = ruleInductionPtr_->induceRule(*thresholdsPtr, labelIndices, weights, partition,
-                                                     *featureSubSamplingPtr, *pruningPtr_, *postProcessorPtr_,
-                                                     minCoverage_, maxConditions_, maxHeadRefinements_,
-                                                     recalculatePredictions_, rng, modelBuilder);
+                                                     *featureSubSamplingPtr, *pruningPtr_, *postProcessorPtr_, rng,
+                                                     modelBuilder);
 
         if (success) {
             numRules++;

--- a/python/mlrl/boosting/boosting_learners.py
+++ b/python/mlrl/boosting/boosting_learners.py
@@ -291,10 +291,6 @@ class Boomer(MLRuleLearner, ClassifierMixin):
         partition_sampling_factory = create_partition_sampling_factory(self.holdout_set_size)
         pruning = create_pruning(self.pruning, self.instance_sub_sampling)
         shrinkage = self.__create_post_processor()
-        min_coverage = create_min_coverage(self.min_coverage)
-        max_conditions = create_max_conditions(self.max_conditions)
-        max_head_refinements = create_max_head_refinements(self.max_head_refinements)
-        recalculate_predictions = self.recalculate_predictions
         loss_function = self.__create_loss_function()
         default_rule_head_refinement_factory = FullHeadRefinementFactory() if self.default_rule \
             else NoHeadRefinementFactory()
@@ -305,14 +301,18 @@ class Boomer(MLRuleLearner, ClassifierMixin):
         statistics_provider_factory = self.__create_statistics_provider_factory(loss_function, rule_evaluation_factory,
                                                                                 num_threads_update)
         thresholds_factory = create_thresholds_factory(self.feature_binning, num_threads_update)
+        min_coverage = create_min_coverage(self.min_coverage)
+        max_conditions = create_max_conditions(self.max_conditions)
+        max_head_refinements = create_max_head_refinements(self.max_head_refinements)
+        recalculate_predictions = self.recalculate_predictions
         num_threads_refinement = get_preferred_num_threads(self.num_threads_refinement)
-        rule_induction = TopDownRuleInduction(num_threads_refinement)
+        rule_induction = TopDownRuleInduction(min_coverage, max_conditions, max_head_refinements,
+                                              recalculate_predictions, num_threads_refinement)
         return SequentialRuleModelInduction(statistics_provider_factory, thresholds_factory, rule_induction,
                                             default_rule_head_refinement_factory, head_refinement_factory,
                                             label_sub_sampling_factory, instance_sub_sampling_factory,
                                             feature_sub_sampling_factory, partition_sampling_factory, pruning,
-                                            shrinkage, min_coverage, max_conditions, max_head_refinements,
-                                            recalculate_predictions, stopping_criteria)
+                                            shrinkage, stopping_criteria)
 
     def __create_early_stopping(self) -> Optional[MeasureStoppingCriterion]:
         early_stopping = self.early_stopping

--- a/python/mlrl/common/cython/rule_induction.pxd
+++ b/python/mlrl/common/cython/rule_induction.pxd
@@ -11,7 +11,6 @@ from mlrl.common.cython.thresholds cimport IThresholdsFactory
 from mlrl.common.cython.pruning cimport IPruning
 from mlrl.common.cython.post_processing cimport IPostProcessor
 from mlrl.common.cython.head_refinement cimport IHeadRefinementFactory
-
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr, shared_ptr
 from libcpp.forward_list cimport forward_list
@@ -41,7 +40,8 @@ cdef extern from "common/rule_induction/rule_induction_top_down.hpp" nogil:
 
         # Constructors:
 
-        TopDownRuleInductionImpl(uint32 numThreads) except +
+        TopDownRuleInductionImpl(uint32 minCoverage, intp maxConditions, intp maxHeadRefinements,
+                                 bool recalculatePredictions, uint32 numThreads) except +
 
 
 cdef extern from "common/rule_induction/rule_model_induction_sequential.hpp" nogil:
@@ -59,8 +59,7 @@ cdef extern from "common/rule_induction/rule_model_induction_sequential.hpp" nog
                 shared_ptr[IInstanceSubSamplingFactory] instanceSubSamplingFactoryPtr,
                 shared_ptr[IFeatureSubSamplingFactory] featureSubSamplingFactoryPtr,
                 shared_ptr[IPartitionSamplingFactory] partitionSamplingFactoryPtr, shared_ptr[IPruning] pruningPtr,
-                shared_ptr[IPostProcessor] postProcessorPtr, uint32 minCoverage, intp maxConditions,
-                intp maxHeadRefinements, bool recalculatePredictions,
+                shared_ptr[IPostProcessor] postProcessorPtr,
                 unique_ptr[forward_list[shared_ptr[IStoppingCriterion]]] stoppingCriteriaPtr) except +
 
 

--- a/python/mlrl/common/cython/rule_induction.pyx
+++ b/python/mlrl/common/cython/rule_induction.pyx
@@ -28,12 +28,23 @@ cdef class TopDownRuleInduction(RuleInduction):
     A wrapper for the C++ class `TopDownRuleInduction`.
     """
 
-    def __cinit__(self, uint32 num_threads):
+    def __cinit__(self, uint32 min_coverage, intp max_conditions, intp max_head_refinements,
+                  bint recalculate_predictions, uint32 num_threads):
         """
-        :param num_threads: The number of CPU threads to be used to search for potential refinements of a rule in
-                            parallel. Must be at least 1
+        :param min_coverage:            The minimum number of training examples that must be covered by a rule. Must be
+                                        at least 1
+        :param max_conditions:          The maximum number of conditions to be included in a rule's body. Must be at
+                                        least 1 or -1, if the number of conditions should not be restricted
+        :param max_head_refinements:    The maximum number of times the head of a rule may be refined after a new
+                                        condition has been added to its body. Must be at least 1 or -1, if the number of
+                                        refinements should not be restricted
+        :param recalculate_predictions: True, if the predictions of rules should be recalculated on the entire training
+                                        data, if instance sub-sampling is used, False otherwise
+        :param num_threads:             The number of CPU threads to be used to search for potential refinements of a
+                                        rule in parallel. Must be at least 1
         """
-        self.rule_induction_ptr = <shared_ptr[IRuleInduction]>make_shared[TopDownRuleInductionImpl](num_threads)
+        self.rule_induction_ptr = <shared_ptr[IRuleInduction]>make_shared[TopDownRuleInductionImpl](
+            min_coverage, max_conditions, max_head_refinements, recalculate_predictions, num_threads)
 
 
 cdef class RuleModelInduction:
@@ -65,7 +76,6 @@ cdef class SequentialRuleModelInduction(RuleModelInduction):
                   InstanceSubSamplingFactory instance_sub_sampling_factory,
                   FeatureSubSamplingFactory feature_sub_sampling_factory,
                   PartitionSamplingFactory partition_sampling_factory, Pruning pruning, PostProcessor post_processor,
-                  uint32 min_coverage, intp max_conditions, intp max_head_refinements, bint recalculate_predictions,
                   list stopping_criteria):
         """
         :param statistics_provider_factory:             A factory that allows to create a provider that provides access
@@ -94,18 +104,6 @@ cdef class SequentialRuleModelInduction(RuleModelInduction):
         :param pruning:                                 The strategy that should be used for pruning rules
         :param post_processor:                          The post-processor that should be used to post-process the rule
                                                         once it has been learned
-        :param min_coverage:                            The minimum number of training examples that must be covered by
-                                                        a rule. Must be at least 1
-        :param max_conditions:                          The maximum number of conditions to be included in a rule's
-                                                        body. Must be at least 1 or -1, if the number of conditions
-                                                        should not be restricted
-        :param max_head_refinements:                    The maximum number of times the head of a rule may be refined
-                                                        after a new condition has been added to its body. Must be at
-                                                        least 1 or -1, if the number of refinements should not be
-                                                        restricted
-        :param recalculate_predictions:                 True, if the predictions of rules should be recalculated on the
-                                                        entire training data, if instance sub-sampling is used, False
-                                                        otherwise
         :param stopping_criteria                        A list that contains the stopping criteria that should be used
                                                         to decide whether additional rules should be induced or not
         """
@@ -127,5 +125,4 @@ cdef class SequentialRuleModelInduction(RuleModelInduction):
             instance_sub_sampling_factory.instance_sub_sampling_factory_ptr,
             feature_sub_sampling_factory.feature_sub_sampling_factory_ptr,
             partition_sampling_factory.partition_sampling_factory_ptr, pruning.pruning_ptr,
-            post_processor.post_processor_ptr, min_coverage, max_conditions, max_head_refinements,
-            recalculate_predictions, move(stopping_criteria_ptr))
+            post_processor.post_processor_ptr, move(stopping_criteria_ptr))

--- a/python/mlrl/seco/seco_learners.py
+++ b/python/mlrl/seco/seco_learners.py
@@ -180,8 +180,12 @@ class SeparateAndConquerRuleLearner(MLRuleLearner, ClassifierMixin):
         statistics_provider_factory = self.__create_statistics_provider_factory(heuristic)
         num_threads_update = get_preferred_num_threads(self.num_threads_update)
         thresholds_factory = create_thresholds_factory(self.feature_binning, num_threads_update)
+        min_coverage = create_min_coverage(self.min_coverage)
+        max_conditions = create_max_conditions(self.max_conditions)
+        max_head_refinements = create_max_head_refinements(self.max_head_refinements)
         num_threads_refinement = get_preferred_num_threads(self.num_threads_refinement)
-        rule_induction = TopDownRuleInduction(num_threads_refinement)
+        rule_induction = TopDownRuleInduction(min_coverage, max_conditions, max_head_refinements, False,
+                                              num_threads_refinement)
         lift_function = self.__create_lift_function(num_labels)
         default_rule_head_refinement_factory = FullHeadRefinementFactory()
         head_refinement_factory = self.__create_head_refinement_factory(lift_function)
@@ -191,17 +195,13 @@ class SeparateAndConquerRuleLearner(MLRuleLearner, ClassifierMixin):
         partition_sampling_factory = create_partition_sampling_factory(self.holdout_set_size)
         pruning = create_pruning(self.pruning, self.instance_sub_sampling)
         post_processor = NoPostProcessor()
-        min_coverage = create_min_coverage(self.min_coverage)
-        max_conditions = create_max_conditions(self.max_conditions)
-        max_head_refinements = create_max_head_refinements(self.max_head_refinements)
         stopping_criteria = create_stopping_criteria(int(self.max_rules), int(self.time_limit))
         stopping_criteria.append(CoverageStoppingCriterion(0))
         return SequentialRuleModelInduction(statistics_provider_factory, thresholds_factory, rule_induction,
                                             default_rule_head_refinement_factory, head_refinement_factory,
                                             label_sub_sampling_factory, instance_sub_sampling_factory,
                                             feature_sub_sampling_factory, partition_sampling_factory, pruning,
-                                            post_processor, min_coverage, max_conditions, max_head_refinements, False,
-                                            stopping_criteria)
+                                            post_processor, stopping_criteria)
 
     def __create_heuristic(self) -> Heuristic:
         heuristic = self.heuristic


### PR DESCRIPTION
Entfernt die folgenden Argumente der Funktion `induceRule` der Klasse `IRuleInduction`:

*  `minCoverage`
* `maxConditions`
* `maxHeadRefinements`
* `recalculatePredictions`

Die Argumente ab sofort stattdessen an den Konstruktor der Klasse `TopDownRuleInduction` übergeben.