### PR TITLE
Zugriff auf IStatistics durch IInstanceSubSamplingFactory

### DIFF
--- a/cpp/subprojects/common/include/common/input/label_matrix.hpp
+++ b/cpp/subprojects/common/include/common/input/label_matrix.hpp
@@ -13,6 +13,7 @@ class IPartitionSampling;
 class IPartitionSamplingFactory;
 class IInstanceSubSampling;
 class IInstanceSubSamplingFactory;
+class IStatistics;
 class SinglePartition;
 class BiPartition;
 
@@ -73,26 +74,32 @@ class ILabelMatrix {
          * Creates and returns a new instance of the class `IInstanceSubSampling`, based on the type of this label
          * matrix.
          *
-         * @param factory   A reference to an object of type `IInstanceSubSamplingFactory` that should be used to create
-         *                  the instance
-         * @param partition A reference to an object of type `SinglePartition` that provides access to the indices of
-         *                  the training examples that are included in the training set
-         * @return          An unique pointer to an object of type `IInstanceSubSampling` that has been created
+         * @param factory       A reference to an object of type `IInstanceSubSamplingFactory` that should be used to
+         *                      create the instance
+         * @param partition     A reference to an object of type `SinglePartition` that provides access to the indices
+         *                      of the training examples that are included in the training set
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to the statistics
+         *                      which serve as a basis for learning rules
+         * @return              An unique pointer to an object of type `IInstanceSubSampling` that has been created
          */
         virtual std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(
-            const IInstanceSubSamplingFactory& factory, const SinglePartition& partition) const = 0;
+            const IInstanceSubSamplingFactory& factory, const SinglePartition& partition,
+            IStatistics& statistics) const = 0;
 
         /**
          * Creates and returns a new instance of the class `IInstanceSubSampling`, based on the type of this label
          * matrix.
          *
-         * @param factory   A reference to an object of type `IInstanceSubSamplingFactory` that should be used to create
-         *                  the instance
-         * @param partition A reference to an object of type `BiPartition` that provides access to the indices of the
-         *                  training examples that are included in the training set and the holdout set, respectively
-         * @return          An unique pointer to an object of type `IInstanceSubSampling` that has been created
+         * @param factory       A reference to an object of type `IInstanceSubSamplingFactory` that should be used to
+         *                      create the instance
+         * @param partition     A reference to an object of type `BiPartition` that provides access to the indices of
+         *                      the training examples that are included in the training set and the holdout set,
+         *                      respectively
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to the statistics
+         *                      which serve as a basis for learning rules
+         * @return              An unique pointer to an object of type `IInstanceSubSampling` that has been created
          */
         virtual std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(
-            const IInstanceSubSamplingFactory& factory, BiPartition& partition) const = 0;
+            const IInstanceSubSamplingFactory& factory, BiPartition& partition, IStatistics& statistics) const = 0;
 
 };

--- a/cpp/subprojects/common/include/common/input/label_matrix_c_contiguous.hpp
+++ b/cpp/subprojects/common/include/common/input/label_matrix_c_contiguous.hpp
@@ -122,9 +122,10 @@ class CContiguousLabelMatrix final : public ILabelMatrix {
             const IPartitionSamplingFactory& factory) const override;
 
         std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(
-            const IInstanceSubSamplingFactory& factory, const SinglePartition& partition) const override;
+            const IInstanceSubSamplingFactory& factory, const SinglePartition& partition,
+            IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(
-            const IInstanceSubSamplingFactory& factory, BiPartition& partition) const override;
+            const IInstanceSubSamplingFactory& factory, BiPartition& partition, IStatistics& statistics) const override;
 
 };

--- a/cpp/subprojects/common/include/common/input/label_matrix_csr.hpp
+++ b/cpp/subprojects/common/include/common/input/label_matrix_csr.hpp
@@ -143,9 +143,10 @@ class CsrLabelMatrix final : public ILabelMatrix {
             const IPartitionSamplingFactory& factory) const override;
 
         std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(
-            const IInstanceSubSamplingFactory& factory, const SinglePartition& partition) const override;
+            const IInstanceSubSamplingFactory& factory, const SinglePartition& partition,
+            IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(
-            const IInstanceSubSamplingFactory& factory, BiPartition& partition) const override;
+            const IInstanceSubSamplingFactory& factory, BiPartition& partition, IStatistics& statistics) const override;
 
 };

--- a/cpp/subprojects/common/include/common/sampling/instance_sampling.hpp
+++ b/cpp/subprojects/common/include/common/sampling/instance_sampling.hpp
@@ -7,6 +7,7 @@
 #include "common/sampling/random.hpp"
 #include "common/input/label_matrix_c_contiguous.hpp"
 #include "common/input/label_matrix_csr.hpp"
+#include "common/statistics/statistics.hpp"
 #include <memory>
 
 // Forward declarations
@@ -51,10 +52,13 @@ class IInstanceSubSamplingFactory {
          *                      labels of the training examples
          * @param partition     A reference to an object of type `SinglePartition` that provides access to the indices
          *                      of the training examples that are included in the training set
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to the statistics +
+         *                      which serve as a basis for learning rules
          * @return              An unique pointer to an object of type `IInstanceSubSampling` that has been created
          */
         virtual std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                             const SinglePartition& partition) const = 0;
+                                                             const SinglePartition& partition,
+                                                             IStatistics& statistics) const = 0;
 
         /**
          * Creates and returns a new object of type `IInstanceSubSampling`.
@@ -64,10 +68,12 @@ class IInstanceSubSamplingFactory {
          * @param partition     A reference to an object of type `BiPartition` that provides access to the indices of
          *                      the training examples that are included in the training set and the holdout set,
          *                      respectively
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to the statistics +
+         *                      which serve as a basis for learning rules
          * @return              An unique pointer to an object of type `IInstanceSubSampling` that has been created
          */
         virtual std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                             BiPartition& partition) const = 0;
+                                                             BiPartition& partition, IStatistics& statistics) const = 0;
 
         /**
          * Creates and returns a new object of type `IInstanceSubSampling`.
@@ -76,10 +82,13 @@ class IInstanceSubSamplingFactory {
          *                      the training examples
          * @param partition     A reference to an object of type `SinglePartition` that provides access to the indices
          *                      of the training examples that are included in the training set
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to the statistics +
+         *                      which serve as a basis for learning rules
          * @return              An unique pointer to an object of type `IInstanceSubSampling` that has been created
          */
         virtual std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                             const SinglePartition& partition) const = 0;
+                                                             const SinglePartition& partition,
+                                                             IStatistics& statistics) const = 0;
 
         /**
          * Creates and returns a new object of type `IInstanceSubSampling`.
@@ -89,9 +98,11 @@ class IInstanceSubSamplingFactory {
          * @param partition     A reference to an object of type `BiPartition` that provides access to the indices of
          *                      the training examples that are included in the training set and the holdout set,
          *                      respectively
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to the statistics +
+         *                      which serve as a basis for learning rules
          * @return              An unique pointer to an object of type `IInstanceSubSampling` that has been created
          */
         virtual std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                             BiPartition& partition) const = 0;
+                                                             BiPartition& partition, IStatistics& statistics) const = 0;
 
 };

--- a/cpp/subprojects/common/include/common/sampling/instance_sampling_bagging.hpp
+++ b/cpp/subprojects/common/include/common/sampling/instance_sampling_bagging.hpp
@@ -25,15 +25,17 @@ class BaggingFactory final : public IInstanceSubSamplingFactory {
         BaggingFactory(float32 sampleSize);
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
 };

--- a/cpp/subprojects/common/include/common/sampling/instance_sampling_no.hpp
+++ b/cpp/subprojects/common/include/common/sampling/instance_sampling_no.hpp
@@ -15,15 +15,17 @@ class NoInstanceSubSamplingFactory final : public IInstanceSubSamplingFactory {
     public:
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
 };

--- a/cpp/subprojects/common/include/common/sampling/instance_sampling_random.hpp
+++ b/cpp/subprojects/common/include/common/sampling/instance_sampling_random.hpp
@@ -25,15 +25,17 @@ class RandomInstanceSubsetSelectionFactory final : public IInstanceSubSamplingFa
         RandomInstanceSubsetSelectionFactory(float32 sampleSize);
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
 };

--- a/cpp/subprojects/common/include/common/sampling/instance_sampling_stratified_example_wise.hpp
+++ b/cpp/subprojects/common/include/common/sampling/instance_sampling_stratified_example_wise.hpp
@@ -26,15 +26,17 @@ class ExampleWiseStratifiedSamplingFactory final : public IInstanceSubSamplingFa
         ExampleWiseStratifiedSamplingFactory(float32 sampleSize);
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
 };

--- a/cpp/subprojects/common/include/common/sampling/instance_sampling_stratified_label_wise.hpp
+++ b/cpp/subprojects/common/include/common/sampling/instance_sampling_stratified_label_wise.hpp
@@ -27,15 +27,17 @@ class LabelWiseStratifiedSamplingFactory final : public IInstanceSubSamplingFact
         LabelWiseStratifiedSamplingFactory(float32 sampleSize);
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CContiguousLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     const SinglePartition& partition) const override;
+                                                     const SinglePartition& partition,
+                                                     IStatistics& statistics) const override;
 
         std::unique_ptr<IInstanceSubSampling> create(const CsrLabelMatrix& labelMatrix,
-                                                     BiPartition& partition) const override;
+                                                     BiPartition& partition, IStatistics& statistics) const override;
 
 };

--- a/cpp/subprojects/common/include/common/sampling/partition.hpp
+++ b/cpp/subprojects/common/include/common/sampling/partition.hpp
@@ -10,6 +10,7 @@
 class IInstanceSubSampling;
 class IInstanceSubSamplingFactory;
 class ILabelMatrix;
+class IStatistics;
 class IThresholdsSubset;
 class ICoverageState;
 class Refinement;
@@ -34,10 +35,12 @@ class IPartition {
          *                      create the instance
          * @param labelMatrix   A reference to an object of type `ILabelMatrix` that provides access to the labels of
          *                      the training examples
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to the statistics
+         *                      which serve as a basis for learning rules
          * @return              An unique pointer to an object of type `IInstanceSubSampling` that has been created
          */
         virtual std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(
-            const IInstanceSubSamplingFactory& factory, const ILabelMatrix& labelMatrix) = 0;
+            const IInstanceSubSamplingFactory& factory, const ILabelMatrix& labelMatrix, IStatistics& statistics) = 0;
 
         /**
          * Calculates and returns a quality score that assesses the quality of a rule's prediction for all examples that

--- a/cpp/subprojects/common/include/common/sampling/partition_bi.hpp
+++ b/cpp/subprojects/common/include/common/sampling/partition_bi.hpp
@@ -140,7 +140,8 @@ class BiPartition : public IPartition {
         uint32 getNumElements() const;
 
         std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(const IInstanceSubSamplingFactory& factory,
-                                                                        const ILabelMatrix& labelMatrix) override;
+                                                                        const ILabelMatrix& labelMatrix,
+                                                                        IStatistics& statistics) override;
 
         float64 evaluateOutOfSample(const IThresholdsSubset& thresholdsSubset, const ICoverageState& coverageState,
                                     const AbstractPrediction& head) override;

--- a/cpp/subprojects/common/include/common/sampling/partition_single.hpp
+++ b/cpp/subprojects/common/include/common/sampling/partition_single.hpp
@@ -51,7 +51,8 @@ class SinglePartition : public IPartition {
         uint32 getNumElements() const;
 
         std::unique_ptr<IInstanceSubSampling> createInstanceSubSampling(const IInstanceSubSamplingFactory& factory,
-                                                                        const ILabelMatrix& labelMatrix) override;
+                                                                        const ILabelMatrix& labelMatrix,
+                                                                        IStatistics& statistics) override;
 
         float64 evaluateOutOfSample(const IThresholdsSubset& thresholdsSubset, const ICoverageState& coverageState,
                                     const AbstractPrediction& head) override;

--- a/cpp/subprojects/common/src/common/input/label_matrix_c_contiguous.cpp
+++ b/cpp/subprojects/common/src/common/input/label_matrix_c_contiguous.cpp
@@ -63,11 +63,11 @@ std::unique_ptr<IPartitionSampling> CContiguousLabelMatrix::createPartitionSampl
 }
 
 std::unique_ptr<IInstanceSubSampling> CContiguousLabelMatrix::createInstanceSubSampling(
-        const IInstanceSubSamplingFactory& factory, const SinglePartition& partition) const {
-    return factory.create(*this, partition);
+        const IInstanceSubSamplingFactory& factory, const SinglePartition& partition, IStatistics& statistics) const {
+    return factory.create(*this, partition, statistics);
 }
 
 std::unique_ptr<IInstanceSubSampling> CContiguousLabelMatrix::createInstanceSubSampling(
-        const IInstanceSubSamplingFactory& factory, BiPartition& partition) const {
-    return factory.create(*this, partition);
+        const IInstanceSubSamplingFactory& factory, BiPartition& partition, IStatistics& statistics) const {
+    return factory.create(*this, partition, statistics);
 }

--- a/cpp/subprojects/common/src/common/input/label_matrix_csr.cpp
+++ b/cpp/subprojects/common/src/common/input/label_matrix_csr.cpp
@@ -69,11 +69,11 @@ std::unique_ptr<IPartitionSampling> CsrLabelMatrix::createPartitionSampling(
 }
 
 std::unique_ptr<IInstanceSubSampling> CsrLabelMatrix::createInstanceSubSampling(
-        const IInstanceSubSamplingFactory& factory, const SinglePartition& partition) const {
-    return factory.create(*this, partition);
+        const IInstanceSubSamplingFactory& factory, const SinglePartition& partition, IStatistics& statistics) const {
+    return factory.create(*this, partition, statistics);
 }
 
 std::unique_ptr<IInstanceSubSampling> CsrLabelMatrix::createInstanceSubSampling(
-        const IInstanceSubSamplingFactory& factory, BiPartition& partition) const {
-    return factory.create(*this, partition);
+        const IInstanceSubSamplingFactory& factory, BiPartition& partition, IStatistics& statistics) const {
+    return factory.create(*this, partition, statistics);
 }

--- a/cpp/subprojects/common/src/common/rule_induction/rule_model_induction_sequential.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_model_induction_sequential.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<RuleModel> SequentialRuleModelInduction::induceRules(
         *partitionSamplingFactoryPtr_);
     IPartition& partition = partitionSamplingPtr->partition(rng);
     std::unique_ptr<IInstanceSubSampling> instanceSubSamplingPtr = partition.createInstanceSubSampling(
-        *instanceSubSamplingFactoryPtr_, *labelMatrixPtr);
+        *instanceSubSamplingFactoryPtr_, *labelMatrixPtr, statisticsProviderPtr->get());
     std::unique_ptr<IFeatureSubSampling> featureSubSamplingPtr = featureSubSamplingFactoryPtr_->create(numFeatures);
     std::unique_ptr<ILabelSubSampling> labelSubSamplingPtr = labelSubSamplingFactoryPtr_->create(numLabels);
     IStoppingCriterion::Result stoppingCriterionResult;

--- a/cpp/subprojects/common/src/common/sampling/instance_sampling_bagging.cpp
+++ b/cpp/subprojects/common/src/common/sampling/instance_sampling_bagging.cpp
@@ -101,21 +101,23 @@ BaggingFactory::BaggingFactory(float32 sampleSize)
 }
 
 std::unique_ptr<IInstanceSubSampling> BaggingFactory::create(const CContiguousLabelMatrix& labelMatrix,
-                                                             const SinglePartition& partition) const {
+                                                             const SinglePartition& partition,
+                                                             IStatistics& statistics) const {
     return std::make_unique<Bagging<const SinglePartition>>(partition, sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> BaggingFactory::create(const CContiguousLabelMatrix& labelMatrix,
-                                                             BiPartition& partition) const {
+                                                             BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<Bagging<BiPartition>>(partition, sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> BaggingFactory::create(const CsrLabelMatrix& labelMatrix,
-                                                             const SinglePartition& partition) const {
+                                                             const SinglePartition& partition,
+                                                             IStatistics& statistics) const {
     return std::make_unique<Bagging<const SinglePartition>>(partition, sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> BaggingFactory::create(const CsrLabelMatrix& labelMatrix,
-                                                             BiPartition& partition) const {
+                                                             BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<Bagging<BiPartition>>(partition, sampleSize_);
 }

--- a/cpp/subprojects/common/src/common/sampling/instance_sampling_no.cpp
+++ b/cpp/subprojects/common/src/common/sampling/instance_sampling_no.cpp
@@ -61,21 +61,23 @@ class NoInstanceSubSampling final : public IInstanceSubSampling {
 };
 
 std::unique_ptr<IInstanceSubSampling> NoInstanceSubSamplingFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition, IStatistics& statistics) const {
     return std::make_unique<NoInstanceSubSampling<const SinglePartition, EqualWeightVector>>(partition);
 }
 
 std::unique_ptr<IInstanceSubSampling> NoInstanceSubSamplingFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<NoInstanceSubSampling<BiPartition, DenseWeightVector<uint8>>>(partition);
 }
 
 std::unique_ptr<IInstanceSubSampling> NoInstanceSubSamplingFactory::create(const CsrLabelMatrix& labelMatrix,
-                                                                           const SinglePartition& partition) const {
+                                                                           const SinglePartition& partition,
+                                                                           IStatistics& statistics) const {
     return std::make_unique<NoInstanceSubSampling<const SinglePartition, EqualWeightVector>>(partition);
 }
 
 std::unique_ptr<IInstanceSubSampling> NoInstanceSubSamplingFactory::create(const CsrLabelMatrix& labelMatrix,
-                                                                           BiPartition& partition) const {
+                                                                           BiPartition& partition,
+                                                                           IStatistics& statistics) const {
     return std::make_unique<NoInstanceSubSampling<BiPartition, DenseWeightVector<uint8>>>(partition);
 }

--- a/cpp/subprojects/common/src/common/sampling/instance_sampling_random.cpp
+++ b/cpp/subprojects/common/src/common/sampling/instance_sampling_random.cpp
@@ -65,21 +65,21 @@ RandomInstanceSubsetSelectionFactory::RandomInstanceSubsetSelectionFactory(float
 }
 
 std::unique_ptr<IInstanceSubSampling> RandomInstanceSubsetSelectionFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition, IStatistics& statistics) const {
     return std::make_unique<RandomInstanceSubsetSelection<const SinglePartition>>(partition, sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> RandomInstanceSubsetSelectionFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<RandomInstanceSubsetSelection<BiPartition>>(partition, sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> RandomInstanceSubsetSelectionFactory::create(
-        const CsrLabelMatrix& labelMatrix, const SinglePartition& partition) const {
+        const CsrLabelMatrix& labelMatrix, const SinglePartition& partition, IStatistics& statistics) const {
     return std::make_unique<RandomInstanceSubsetSelection<const SinglePartition>>(partition, sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> RandomInstanceSubsetSelectionFactory::create(
-        const CsrLabelMatrix& labelMatrix, BiPartition& partition) const {
+        const CsrLabelMatrix& labelMatrix, BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<RandomInstanceSubsetSelection<BiPartition>>(partition, sampleSize_);
 }

--- a/cpp/subprojects/common/src/common/sampling/instance_sampling_stratified_example_wise.cpp
+++ b/cpp/subprojects/common/src/common/sampling/instance_sampling_stratified_example_wise.cpp
@@ -58,25 +58,25 @@ ExampleWiseStratifiedSamplingFactory::ExampleWiseStratifiedSamplingFactory(float
 }
 
 std::unique_ptr<IInstanceSubSampling> ExampleWiseStratifiedSamplingFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition, IStatistics& statistics) const {
     return std::make_unique<ExampleWiseStratifiedSampling<CContiguousLabelMatrix, SinglePartition::const_iterator>>(
         labelMatrix, partition.cbegin(), partition.cend(), sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> ExampleWiseStratifiedSamplingFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<ExampleWiseStratifiedSampling<CContiguousLabelMatrix, BiPartition::const_iterator>>(
         labelMatrix, partition.first_cbegin(), partition.first_cend(), sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> ExampleWiseStratifiedSamplingFactory::create(
-        const CsrLabelMatrix& labelMatrix, const SinglePartition& partition) const {
+        const CsrLabelMatrix& labelMatrix, const SinglePartition& partition, IStatistics& statistics) const {
     return std::make_unique<ExampleWiseStratifiedSampling<CsrLabelMatrix, SinglePartition::const_iterator>>(
         labelMatrix, partition.cbegin(), partition.cend(), sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> ExampleWiseStratifiedSamplingFactory::create(
-        const CsrLabelMatrix& labelMatrix, BiPartition& partition) const {
+        const CsrLabelMatrix& labelMatrix, BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<ExampleWiseStratifiedSampling<CsrLabelMatrix, BiPartition::const_iterator>>(
         labelMatrix, partition.first_cbegin(), partition.first_cend(), sampleSize_);
 }

--- a/cpp/subprojects/common/src/common/sampling/instance_sampling_stratified_label_wise.cpp
+++ b/cpp/subprojects/common/src/common/sampling/instance_sampling_stratified_label_wise.cpp
@@ -59,25 +59,25 @@ LabelWiseStratifiedSamplingFactory::LabelWiseStratifiedSamplingFactory(float32 s
 }
 
 std::unique_ptr<IInstanceSubSampling> LabelWiseStratifiedSamplingFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, const SinglePartition& partition, IStatistics& statistics) const {
     return std::make_unique<LabelWiseStratifiedSampling<CContiguousLabelMatrix, SinglePartition::const_iterator>>(
         labelMatrix, partition.cbegin(), partition.cend(), sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> LabelWiseStratifiedSamplingFactory::create(
-        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition) const {
+        const CContiguousLabelMatrix& labelMatrix, BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<LabelWiseStratifiedSampling<CContiguousLabelMatrix, BiPartition::const_iterator>>(
         labelMatrix, partition.first_cbegin(), partition.first_cend(), sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> LabelWiseStratifiedSamplingFactory::create(
-        const CsrLabelMatrix& labelMatrix, const SinglePartition& partition) const {
+        const CsrLabelMatrix& labelMatrix, const SinglePartition& partition, IStatistics& statistics) const {
     return std::make_unique<LabelWiseStratifiedSampling<CsrLabelMatrix, SinglePartition::const_iterator>>(
         labelMatrix, partition.cbegin(), partition.cend(), sampleSize_);
 }
 
 std::unique_ptr<IInstanceSubSampling> LabelWiseStratifiedSamplingFactory::create(
-        const CsrLabelMatrix& labelMatrix, BiPartition& partition) const {
+        const CsrLabelMatrix& labelMatrix, BiPartition& partition, IStatistics& statistics) const {
     return std::make_unique<LabelWiseStratifiedSampling<CsrLabelMatrix, BiPartition::const_iterator>>(
         labelMatrix, partition.first_cbegin(), partition.first_cend(), sampleSize_);
 }

--- a/cpp/subprojects/common/src/common/sampling/partition_bi.cpp
+++ b/cpp/subprojects/common/src/common/sampling/partition_bi.cpp
@@ -87,8 +87,9 @@ const BinaryDokVector& BiPartition::getSecondSet() {
 }
 
 std::unique_ptr<IInstanceSubSampling> BiPartition::createInstanceSubSampling(const IInstanceSubSamplingFactory& factory,
-                                                                             const ILabelMatrix& labelMatrix) {
-    return labelMatrix.createInstanceSubSampling(factory, *this);
+                                                                             const ILabelMatrix& labelMatrix,
+                                                                             IStatistics& statistics) {
+    return labelMatrix.createInstanceSubSampling(factory, *this, statistics);
 }
 
 float64 BiPartition::evaluateOutOfSample(const IThresholdsSubset& thresholdsSubset, const ICoverageState& coverageState,

--- a/cpp/subprojects/common/src/common/sampling/partition_single.cpp
+++ b/cpp/subprojects/common/src/common/sampling/partition_single.cpp
@@ -23,8 +23,8 @@ uint32 SinglePartition::getNumElements() const {
 }
 
 std::unique_ptr<IInstanceSubSampling> SinglePartition::createInstanceSubSampling(
-        const IInstanceSubSamplingFactory& factory, const ILabelMatrix& labelMatrix) {
-    return labelMatrix.createInstanceSubSampling(factory, *this);
+        const IInstanceSubSamplingFactory& factory, const ILabelMatrix& labelMatrix, IStatistics& statistics) {
+    return labelMatrix.createInstanceSubSampling(factory, *this, statistics);
 }
 
 float64 SinglePartition::evaluateOutOfSample(const IThresholdsSubset& thresholdsSubset,


### PR DESCRIPTION
Ergänzt die `create`-Funktion der Klasse `IInstanceSubSamplingFactory` durch ein zusätzliches Argument mit dessen Hilfe eine Referenz auf ein Objekt vom Typ `IStatistics` übergeben werden kann. Dies erlaubt es in Zukunft, dass Sampling-Methoden auf die Statistiken zugreifen können.