### PR TITLE
Visitor-Pattern um auf Gradienten/Hessians zuzugreifen

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/statistics/statistics.hpp
+++ b/cpp/subprojects/boosting/include/boosting/statistics/statistics.hpp
@@ -1,0 +1,50 @@
+/*
+ * @author Michael Rapp (mrapp@ke.tu-darmstadt.de)
+ */
+#pragma once
+
+#include "common/statistics/statistics.hpp"
+#include <functional>
+
+
+namespace boosting {
+
+    // Forward declarations
+    class DenseLabelWiseStatisticView;
+    class DenseExampleWiseStatisticView;
+
+    /**
+     * Defines an interface for all classes that provide access to statistics, which serve as the basis for learning a
+     * new gradient boosted rule or refining an existing one.
+     */
+    class IBoostingStatistics : virtual public IStatistics {
+
+        public:
+
+            virtual ~IBoostingStatistics() { };
+
+            /**
+             * A visitor function for handling objects of the type `DenseLabelWiseStatisticView`.
+             */
+            typedef std::function<void(std::unique_ptr<DenseLabelWiseStatisticView>&)> DenseLabelWiseStatisticViewVisitor;
+
+            /**
+             * A visitor function for handling objects of the type `DenseExampleWiseStatisticView`.
+             */
+            typedef std::function<void(std::unique_ptr<DenseExampleWiseStatisticView>&)> DenseExampleWiseStatisticViewVisitor;
+
+            /**
+             * Invokes one of the given visitor functions, depending on which one is able to handle the particular type
+             * of matrix that is used to store the statistics.
+             *
+             * @param denseLabelWiseStatisticViewVisitor    The visitor function for handling objects of the type
+             *                                              `DenseLabelWiseStatisticView`
+             * @param denseExampleWiseStatisticViewVisitor  The visitor function for handling objects of the type
+             *                                              `DenseExampleWiseStatisticView`
+             */
+            virtual void visit(DenseLabelWiseStatisticViewVisitor denseLabelWiseStatisticViewVisitor,
+                               DenseExampleWiseStatisticViewVisitor denseExampleWiseStatisticViewVisitor) = 0;
+
+    };
+
+}

--- a/cpp/subprojects/boosting/include/boosting/statistics/statistics_example_wise.hpp
+++ b/cpp/subprojects/boosting/include/boosting/statistics/statistics_example_wise.hpp
@@ -5,7 +5,7 @@
 
 #include "common/input/label_matrix_c_contiguous.hpp"
 #include "common/input/label_matrix_csr.hpp"
-#include "common/statistics/statistics.hpp"
+#include "boosting/statistics/statistics.hpp"
 #include "boosting/rule_evaluation/rule_evaluation_example_wise.hpp"
 
 
@@ -15,7 +15,7 @@ namespace boosting {
      * Defines an interface for all classes that store gradients and Hessians that have been calculated according to a
      * differentiable loss-function that is applied example-wise.
      */
-    class IExampleWiseStatistics : virtual public IStatistics {
+    class IExampleWiseStatistics : virtual public IBoostingStatistics {
 
         public:
 

--- a/cpp/subprojects/boosting/include/boosting/statistics/statistics_label_wise.hpp
+++ b/cpp/subprojects/boosting/include/boosting/statistics/statistics_label_wise.hpp
@@ -5,7 +5,7 @@
 
 #include "common/input/label_matrix_c_contiguous.hpp"
 #include "common/input/label_matrix_csr.hpp"
-#include "common/statistics/statistics.hpp"
+#include "boosting/statistics/statistics.hpp"
 #include "boosting/rule_evaluation/rule_evaluation_label_wise.hpp"
 
 
@@ -15,7 +15,7 @@ namespace boosting {
      * Defines an interface for all classes that store gradients and Hessians that have been calculated according to a
      * differentiable loss function that is applied label-wise.
      */
-    class ILabelWiseStatistics : virtual public IStatistics {
+    class ILabelWiseStatistics : virtual public IBoostingStatistics {
 
         public:
 

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_dense.cpp
@@ -57,6 +57,11 @@ namespace boosting {
 
             }
 
+            void visit(IBoostingStatistics::DenseLabelWiseStatisticViewVisitor denseLabelWiseStatisticViewVisitor,
+                       IBoostingStatistics::DenseExampleWiseStatisticViewVisitor denseExampleWiseStatisticViewVisitor) override {
+                denseExampleWiseStatisticViewVisitor(this->statisticViewPtr_);
+            }
+
     };
 
     template<class LabelMatrix>

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_dense.cpp
@@ -56,6 +56,11 @@ namespace boosting {
 
             }
 
+            void visit(IBoostingStatistics::DenseLabelWiseStatisticViewVisitor denseLabelWiseStatisticViewVisitor,
+                       IBoostingStatistics::DenseExampleWiseStatisticViewVisitor denseExampleWiseStatisticViewVisitor) override {
+                denseLabelWiseStatisticViewVisitor(this->statisticViewPtr_);
+            }
+
     };
 
     template<class LabelMatrix>


### PR DESCRIPTION
Fügt das Interface `IBoostingStatistics` zu, das eine `visit`-Funktion definiert, die es erlaubt auf die Datenstruktur zuzugreifen, die zur Speicherung der Gradienten/Hessians genutzt wird.