### PR TITLE
Funktion "divideOrZero" in "common"-Package verschieben

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/math/math.hpp
+++ b/cpp/subprojects/boosting/include/boosting/math/math.hpp
@@ -10,20 +10,6 @@
 namespace boosting {
 
     /**
-     * Returns the result of the floating point division `numerator / denominator` or 0, if a division by zero occurs.
-     *
-     * @tparam T            The type of the operands
-     * @param numerator     The numerator
-     * @param denominator   The denominator
-     * @return              The result of the division or 0, if a division by zero occurred
-     */
-    template<class T>
-    static inline T divideOrZero(T numerator, T denominator) {
-        T result = numerator / denominator;
-        return std::isfinite(result) ? result : 0;
-    }
-
-    /**
      * Calculates and returns the n-th triangular number, i.e., the number of elements in a n times n triangle.
      *
      * @param n A scalar of type `uint32`, representing the order of the triangular number

--- a/cpp/subprojects/boosting/src/boosting/binning/label_binning_equal_width.cpp
+++ b/cpp/subprojects/boosting/src/boosting/binning/label_binning_equal_width.cpp
@@ -1,7 +1,7 @@
 #include "boosting/binning/label_binning_equal_width.hpp"
 #include "boosting/data/statistic_vector_dense_label_wise.hpp"
 #include "boosting/data/statistic_vector_dense_example_wise.hpp"
-#include "boosting/math/math.hpp"
+#include "common/math/math.hpp"
 #include "common/binning/binning.hpp"
 #include <limits>
 

--- a/cpp/subprojects/boosting/src/boosting/losses/loss_example_wise_logistic.cpp
+++ b/cpp/subprojects/boosting/src/boosting/losses/loss_example_wise_logistic.cpp
@@ -1,5 +1,5 @@
 #include "boosting/losses/loss_example_wise_logistic.hpp"
-#include "boosting/math/math.hpp"
+#include "common/math/math.hpp"
 
 
 namespace boosting {

--- a/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_binning_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_binning_common.hpp
@@ -3,6 +3,7 @@
  */
 #pragma once
 
+#include "common/math/math.hpp"
 #include "boosting/math/math.hpp"
 
 

--- a/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_regularized_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_regularized_common.hpp
@@ -3,6 +3,7 @@
  */
 #pragma once
 
+#include "common/math/math.hpp"
 #include "boosting/math/math.hpp"
 
 

--- a/cpp/subprojects/common/include/common/math/math.hpp
+++ b/cpp/subprojects/common/include/common/math/math.hpp
@@ -4,7 +4,22 @@
 #pragma once
 
 #include "common/data/types.hpp"
+#include <cmath>
 
+
+/**
+ * Returns the result of the floating point division `numerator / denominator` or 0, if a division by zero occurs.
+ *
+ * @tparam T            The type of the operands
+ * @param numerator     The numerator
+ * @param denominator   The denominator
+ * @return              The result of the division or 0, if a division by zero occurred
+ */
+template<class T>
+static inline T divideOrZero(T numerator, T denominator) {
+    T result = numerator / denominator;
+    return std::isfinite(result) ? result : 0;
+}
 
 /**
  * Calculates the arithmetic mean of two values `small` and `large`, where `small < large`.


### PR DESCRIPTION
Verschiebt die Funktion `divideOrZero` aus der Datei `boosting/math/math.hpp` in die Datei `common/math/math.hpp`. Damit steht die Funktion zukünftig auch im "common"- und "seco"-Package zur Verfügung.