### PR TITLE
Single-Linked List zum Speichern von Regeln verwenden

### DIFF
--- a/cpp/subprojects/common/include/common/model/rule_model.hpp
+++ b/cpp/subprojects/common/include/common/model/rule_model.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "common/model/rule.hpp"
-#include <list>
+#include <forward_list>
 #include <iterator>
 
 
@@ -22,7 +22,7 @@ class RuleModel final {
 
             private:
 
-                std::list<Rule>::const_iterator iterator_;
+                std::forward_list<Rule>::const_iterator iterator_;
 
                 uint32 index_;
 
@@ -32,7 +32,7 @@ class RuleModel final {
                  * @param list  A reference to the list that stores all available rules
                  * @param index The index to start at
                  */
-                UsedIterator(const std::list<Rule>& list, uint32 index);
+                UsedIterator(const std::forward_list<Rule>& list, uint32 index);
 
                 /**
                  * The type that is used to represent the difference between two iterators.
@@ -98,7 +98,11 @@ class RuleModel final {
 
         };
 
-        std::list<Rule> list_;
+        std::forward_list<Rule> list_;
+
+        std::forward_list<Rule>::iterator it_;
+
+        uint32 numRules_;
 
         uint32 numUsedRules_;
 
@@ -109,7 +113,7 @@ class RuleModel final {
         /**
          * An iterator that provides read-only access to all rules.
          */
-        typedef std::list<Rule>::const_iterator const_iterator;
+        typedef std::forward_list<Rule>::const_iterator const_iterator;
 
         /**
          * An iterator that provides read-only access to the used rules.

--- a/cpp/subprojects/common/src/common/model/rule_model.cpp
+++ b/cpp/subprojects/common/src/common/model/rule_model.cpp
@@ -1,6 +1,6 @@
 #include "common/model/rule_model.hpp"
 
-RuleModel::UsedIterator::UsedIterator(const std::list<Rule>& list, uint32 index)
+RuleModel::UsedIterator::UsedIterator(const std::forward_list<Rule>& list, uint32 index)
     : iterator_(list.cbegin()), index_(index) {
 
 }
@@ -30,7 +30,7 @@ RuleModel::UsedIterator::difference_type RuleModel::UsedIterator::operator-(cons
 }
 
 RuleModel::RuleModel()
-    : numUsedRules_(0) {
+    : it_(list_.begin()), numRules_(0), numUsedRules_(0) {
 
 }
 
@@ -51,11 +51,11 @@ RuleModel::used_const_iterator RuleModel::used_cend() const {
 }
 
 uint32 RuleModel::getNumRules() const {
-    return (uint32) list_.size();
+    return numRules_;
 }
 
 uint32 RuleModel::getNumUsedRules() const {
-    return numUsedRules_ > 0 ? numUsedRules_ : this->getNumRules();
+    return numUsedRules_ > 0 ? numUsedRules_ : numRules_;;
 }
 
 void RuleModel::setNumUsedRules(uint32 numUsedRules) {
@@ -63,7 +63,14 @@ void RuleModel::setNumUsedRules(uint32 numUsedRules) {
 }
 
 void RuleModel::addRule(std::unique_ptr<IBody> bodyPtr, std::unique_ptr<IHead> headPtr) {
-    list_.emplace_back(std::move(bodyPtr), std::move(headPtr));
+    if (numRules_ > 0) {
+        it_ = list_.emplace_after(it_, std::move(bodyPtr), std::move(headPtr));
+    } else {
+        list_.emplace_front(std::move(bodyPtr), std::move(headPtr));
+        it_ = list_.begin();
+    }
+
+    numRules_++;
 }
 
 void RuleModel::visit(IBody::EmptyBodyVisitor emptyBodyVisitor, IBody::ConjunctiveBodyVisitor conjunctiveBodyVisitor,


### PR DESCRIPTION
Modifiziert die Klasse `RuleModel` so dass ab sofort eine Datenstruktur vom Typ `std::forward_list`, statt wie bisher `std::list`, verwendet wird um Regeln zu speichern.