### PR TITLE
Fehler "could not detect Ninja" beheben

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ doc: venv
 
 compile: venv
 	@echo "Compiling C++ code..."
-	cd cpp/ && PATH=$$PATH:../venv/bin/ ../venv/bin/meson setup build -Doptimization=3 && cd build/ && ../../venv/bin/ninja
+	cd cpp/ && PATH=$$PATH:../venv/bin/ ../venv/bin/meson setup build/ -Doptimization=3
+	cd cpp/build/ && PATH=$$PATH:../../venv/bin/ ../../venv/bin/meson compile
 	@echo "Compiling Cython code..."
 	cd python/ && ../venv/bin/python setup.py build_ext --inplace
 


### PR DESCRIPTION
Wenn `ninja` nicht global auf dem System installiert ist, sondern lediglich die Installation im virtuellen Environment zur Verfügung steht, konnte es bisher nach mehrmaliger Ausführung des Befehls `make compile` vorkommen, dass Meson den Kompiliervorgang mit dem Fehler `could not detect Ninja` abbricht. Nach Anwendung der Änderungen in diesem Pull-Request konnte dieses Problem bisher nicht mehr beobachtet werden. Durch die Anpassungen im Makefile wird der Befehl `meson compile` zum Kompilieren verwendet, statt `ninja` direkt auszuführen.