### PR TITLE
Abweichende Bewertung von Regeln beim Pruning erlauben

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/statistics/statistics_example_wise_dense.hpp
+++ b/cpp/subprojects/boosting/include/boosting/statistics/statistics_example_wise_dense.hpp
@@ -60,6 +60,8 @@ namespace boosting {
 
             std::shared_ptr<IExampleWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr_;
 
+            std::shared_ptr<IExampleWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr_;
+
             uint32 numThreads_;
 
         public:
@@ -75,13 +77,18 @@ namespace boosting {
              *                                          `IExampleWiseRuleEvaluationFactory` that should be used for
              *                                          calculating the predictions, as well as corresponding quality
              *                                          scores, of all remaining rules
+             * @param pruningRuleEvaluationFactoryPtr   A shared pointer to an object of type
+             *                                          `IExampleWiseRuleEvaluationFactory` that should be used for
+             *                                          calculating the predictions, as well as corresponding quality
+             *                                          scores, when pruning rules
              * @param numThreads                        The number of CPU threads to be used to calculate the initial
              *                                          statistics in parallel. Must be at least 1
              */
             DenseExampleWiseStatisticsProviderFactory(
                 std::shared_ptr<IExampleWiseLoss> lossFunctionPtr,
                 std::shared_ptr<IExampleWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
-                std::shared_ptr<IExampleWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr, uint32 numThreads);
+                std::shared_ptr<IExampleWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
+                std::shared_ptr<IExampleWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr, uint32 numThreads);
 
             std::unique_ptr<IStatisticsProvider> create(const CContiguousLabelMatrix& labelMatrix) const override;
 

--- a/cpp/subprojects/boosting/include/boosting/statistics/statistics_label_wise_dense.hpp
+++ b/cpp/subprojects/boosting/include/boosting/statistics/statistics_label_wise_dense.hpp
@@ -60,6 +60,8 @@ namespace boosting {
 
             std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr_;
 
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr_;
+
             uint32 numThreads_;
 
         public:
@@ -75,13 +77,18 @@ namespace boosting {
              *                                          `ILabelWiseRuleEvaluationFactory` that should be used for
              *                                          calculating the predictions, as well as corresponding quality
              *                                          scores, of all remaining rules
+             * @param pruningRuleEvaluationFactoryPtr   A shared pointer to an object of type
+             *                                          `ILabelWiseRuleEvaluationFactory` that should be used for
+             *                                          calculating the predictions, as well as corresponding quality
+             *                                          scores, when pruning rules
              * @param numThreads                        The number of CPU threads to be used to calculate the initial
              *                                          statistics in parallel. Must be at least 1
              */
             DenseLabelWiseStatisticsProviderFactory(
                 std::shared_ptr<ILabelWiseLoss> lossFunctionPtr,
                 std::shared_ptr<ILabelWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
-                std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr, uint32 numThreads);
+                std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
+                std::shared_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr, uint32 numThreads);
 
             std::unique_ptr<IStatisticsProvider> create(const CContiguousLabelMatrix& labelMatrix) const override;
 

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_dense.cpp
@@ -131,9 +131,11 @@ namespace boosting {
     DenseExampleWiseStatisticsProviderFactory::DenseExampleWiseStatisticsProviderFactory(
             std::shared_ptr<IExampleWiseLoss> lossFunctionPtr,
             std::shared_ptr<IExampleWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
-            std::shared_ptr<IExampleWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr, uint32 numThreads)
+            std::shared_ptr<IExampleWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
+            std::shared_ptr<IExampleWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr, uint32 numThreads)
         : lossFunctionPtr_(lossFunctionPtr), defaultRuleEvaluationFactoryPtr_(defaultRuleEvaluationFactoryPtr),
-          regularRuleEvaluationFactoryPtr_(regularRuleEvaluationFactoryPtr), numThreads_(numThreads) {
+          regularRuleEvaluationFactoryPtr_(regularRuleEvaluationFactoryPtr),
+          pruningRuleEvaluationFactoryPtr_(pruningRuleEvaluationFactoryPtr), numThreads_(numThreads) {
 
     }
 
@@ -142,6 +144,7 @@ namespace boosting {
         DenseExampleWiseStatisticsFactory statisticsFactory(*lossFunctionPtr_, *defaultRuleEvaluationFactoryPtr_,
                                                             numThreads_);
         return std::make_unique<ExampleWiseStatisticsProvider>(*regularRuleEvaluationFactoryPtr_,
+                                                               *pruningRuleEvaluationFactoryPtr_,
                                                                statisticsFactory.create(labelMatrix));
     }
 
@@ -150,6 +153,7 @@ namespace boosting {
         DenseExampleWiseStatisticsFactory statisticsFactory(*lossFunctionPtr_, *defaultRuleEvaluationFactoryPtr_,
                                                             numThreads_);
         return std::make_unique<ExampleWiseStatisticsProvider>(*regularRuleEvaluationFactoryPtr_,
+                                                               *pruningRuleEvaluationFactoryPtr_,
                                                                statisticsFactory.create(labelMatrix));
     }
 

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_provider.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_provider.hpp
@@ -13,6 +13,8 @@ namespace boosting {
 
             const IExampleWiseRuleEvaluationFactory& regularRuleEvaluationFactory_;
 
+            const IExampleWiseRuleEvaluationFactory& pruningRuleEvaluationFactory_;
+
             std::unique_ptr<IExampleWiseStatistics> statisticsPtr_;
 
         public:
@@ -21,12 +23,17 @@ namespace boosting {
              * @param regularRuleEvaluationFactory  A reference to an object of type `IExampleWiseRuleEvaluationFactory`
              *                                      to switch to when invoking the function
              *                                      `switchToRegularRuleEvaluation`
+             * @param pruningRuleEvaluationFactory  A reference to an object of type `IExampleWiseRuleEvaluationFactory`
+             *                                      to switch to when invoking the function
+             *                                      `switchToPruningRuleEvaluation`
              * @param statisticsPtr                 An unique pointer to an object of type `IExampleWiseStatistics` to
              *                                      provide access to
              */
             ExampleWiseStatisticsProvider(const IExampleWiseRuleEvaluationFactory& regularRuleEvaluationFactory,
+                                          const IExampleWiseRuleEvaluationFactory& pruningRuleEvaluationFactory,
                                           std::unique_ptr<IExampleWiseStatistics> statisticsPtr)
                 : regularRuleEvaluationFactory_(regularRuleEvaluationFactory),
+                  pruningRuleEvaluationFactory_(pruningRuleEvaluationFactory),
                   statisticsPtr_(std::move(statisticsPtr)) {
 
             }
@@ -37,6 +44,10 @@ namespace boosting {
 
             void switchToRegularRuleEvaluation() override {
                 statisticsPtr_->setRuleEvaluationFactory(regularRuleEvaluationFactory_);
+            }
+
+            void switchToPruningRuleEvaluation() override {
+                statisticsPtr_->setRuleEvaluationFactory(pruningRuleEvaluationFactory_);
             }
 
     };

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_dense.cpp
@@ -133,9 +133,11 @@ namespace boosting {
     DenseLabelWiseStatisticsProviderFactory::DenseLabelWiseStatisticsProviderFactory(
             std::shared_ptr<ILabelWiseLoss> lossFunctionPtr,
             std::shared_ptr<ILabelWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
-            std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr, uint32 numThreads)
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr, uint32 numThreads)
         : lossFunctionPtr_(lossFunctionPtr), defaultRuleEvaluationFactoryPtr_(defaultRuleEvaluationFactoryPtr),
-          regularRuleEvaluationFactoryPtr_(regularRuleEvaluationFactoryPtr), numThreads_(numThreads) {
+          regularRuleEvaluationFactoryPtr_(regularRuleEvaluationFactoryPtr),
+          pruningRuleEvaluationFactoryPtr_(pruningRuleEvaluationFactoryPtr), numThreads_(numThreads) {
 
     }
 
@@ -144,6 +146,7 @@ namespace boosting {
         DenseLabelWiseStatisticsFactory statisticsFactory(*lossFunctionPtr_, *defaultRuleEvaluationFactoryPtr_,
                                                           numThreads_);
         return std::make_unique<LabelWiseStatisticsProvider>(*regularRuleEvaluationFactoryPtr_,
+                                                             *pruningRuleEvaluationFactoryPtr_,
                                                              statisticsFactory.create(labelMatrix));
     }
 
@@ -152,6 +155,7 @@ namespace boosting {
         DenseLabelWiseStatisticsFactory statisticsFactory(*lossFunctionPtr_, *defaultRuleEvaluationFactoryPtr_,
                                                           numThreads_);
         return std::make_unique<LabelWiseStatisticsProvider>(*regularRuleEvaluationFactoryPtr_,
+                                                             *pruningRuleEvaluationFactoryPtr_,
                                                              statisticsFactory.create(labelMatrix));
     }
 

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_provider.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_provider.hpp
@@ -13,6 +13,8 @@ namespace boosting {
 
             const ILabelWiseRuleEvaluationFactory& regularRuleEvaluationFactory_;
 
+            const ILabelWiseRuleEvaluationFactory& pruningRuleEvaluationFactory_;
+
             std::unique_ptr<ILabelWiseStatistics> statisticsPtr_;
 
         public:
@@ -21,12 +23,17 @@ namespace boosting {
              * @param regularRuleEvaluationFactory  A reference to an object of type `ILabelWiseRuleEvaluationFactory`
              *                                      to switch to when invoking the function
              *                                      `switchToRegularRuleEvaluation`
+             * @param pruningRuleEvaluationFactory  A reference to an object of type `ILabelWiseRuleEvaluationFactory`
+             *                                      to switch to when invoking the function
+             *                                      `switchToPruningRuleEvaluation`
              * @param statisticsPtr                 An unique pointer to an object of type `ILabelWiseStatistics` to
              *                                      provide access to
              */
             LabelWiseStatisticsProvider(const ILabelWiseRuleEvaluationFactory& regularRuleEvaluationFactory,
+                                        const ILabelWiseRuleEvaluationFactory& pruningRuleEvaluationFactory,
                                         std::unique_ptr<ILabelWiseStatistics> statisticsPtr)
                 : regularRuleEvaluationFactory_(regularRuleEvaluationFactory),
+                  pruningRuleEvaluationFactory_(pruningRuleEvaluationFactory),
                   statisticsPtr_(std::move(statisticsPtr)) {
 
             }
@@ -37,6 +44,10 @@ namespace boosting {
 
             void switchToRegularRuleEvaluation() override {
                 statisticsPtr_->setRuleEvaluationFactory(regularRuleEvaluationFactory_);
+            }
+
+            void switchToPruningRuleEvaluation() override {
+                statisticsPtr_->setRuleEvaluationFactory(pruningRuleEvaluationFactory_);
             }
 
     };

--- a/cpp/subprojects/common/include/common/statistics/statistics_provider.hpp
+++ b/cpp/subprojects/common/include/common/statistics/statistics_provider.hpp
@@ -23,10 +23,15 @@ class IStatisticsProvider {
         virtual IStatistics& get() const = 0;
 
         /**
-         * Allows to switch the implementation that is used for calculating the predictions of rules, as well as
-         * corresponding quality scores, from the one that was initially used for learning the default rule, to another
-         * one that will be used for learning all remaining rules.
+         * Switches the implementation that is used for calculating the predictions of rules, as well as corresponding
+         * quality scores, to the one that should be used for learning regular rules.
          */
         virtual void switchToRegularRuleEvaluation() = 0;
+
+        /**
+         * Switches the implementation that is used for calculating the predictions of rules, as well as corresponding
+         * quality scores, to the one that should be used for pruning rules.
+         */
+        virtual void switchToPruningRuleEvaluation() = 0;
 
 };

--- a/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down.cpp
@@ -135,8 +135,11 @@ bool TopDownRuleInduction::induceRule(IThresholds& thresholds, const IIndexVecto
     } else {
         if (instanceSamplingUsed) {
             // Prune rule...
+            IStatisticsProvider& statisticsProvider = thresholds.getStatisticsProvider();
+            statisticsProvider.switchToPruningRuleEvaluation();
             std::unique_ptr<ICoverageState> coverageStatePtr = pruning.prune(*thresholdsSubsetPtr, partition,
                                                                              conditions, *bestHead);
+            statisticsProvider.switchToRegularRuleEvaluation();
 
             // Re-calculate the scores in the head based on the entire training data...
             if (recalculatePredictions_) {

--- a/cpp/subprojects/seco/include/seco/statistics/statistics_label_wise_dense.hpp
+++ b/cpp/subprojects/seco/include/seco/statistics/statistics_label_wise_dense.hpp
@@ -47,6 +47,8 @@ namespace seco {
 
             std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr_;
 
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr_;
+
         public:
 
             /**
@@ -58,10 +60,15 @@ namespace seco {
              *                                          `ILabelWiseRuleEvaluationFactory` that should be used for
              *                                          calculating the predictions, as well as corresponding quality
              *                                          scores, of all remaining rules
+             * @param pruningRuleEvaluationFactoryPtr   A shared pointer to an object of type
+             *                                          `ILabelWiseRuleEvaluationFactory` that should be used for
+             *                                          calculating the predictions, as well as corresponding quality
+             *                                          scores, when pruning rules
              */
             DenseLabelWiseStatisticsProviderFactory(
                 std::shared_ptr<ILabelWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
-                std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr);
+                std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
+                std::shared_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr);
 
             std::unique_ptr<IStatisticsProvider> create(const CContiguousLabelMatrix& labelMatrix) const override;
 

--- a/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_dense.cpp
+++ b/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_dense.cpp
@@ -94,9 +94,11 @@ namespace seco {
 
     DenseLabelWiseStatisticsProviderFactory::DenseLabelWiseStatisticsProviderFactory(
             std::shared_ptr<ILabelWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
-            std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr)
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
+            std::shared_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr)
         : defaultRuleEvaluationFactoryPtr_(defaultRuleEvaluationFactoryPtr),
-          regularRuleEvaluationFactoryPtr_(regularRuleEvaluationFactoryPtr) {
+          regularRuleEvaluationFactoryPtr_(regularRuleEvaluationFactoryPtr),
+          pruningRuleEvaluationFactoryPtr_(pruningRuleEvaluationFactoryPtr) {
 
     }
 
@@ -104,6 +106,7 @@ namespace seco {
             const CContiguousLabelMatrix& labelMatrix) const {
         DenseLabelWiseStatisticsFactory statisticsFactory(*defaultRuleEvaluationFactoryPtr_);
         return std::make_unique<LabelWiseStatisticsProvider>(*regularRuleEvaluationFactoryPtr_,
+                                                             *pruningRuleEvaluationFactoryPtr_,
                                                              statisticsFactory.create(labelMatrix));
     }
 
@@ -111,6 +114,7 @@ namespace seco {
             const CsrLabelMatrix& labelMatrix) const {
         DenseLabelWiseStatisticsFactory statisticsFactory(*defaultRuleEvaluationFactoryPtr_);
         return std::make_unique<LabelWiseStatisticsProvider>(*regularRuleEvaluationFactoryPtr_,
+                                                             *pruningRuleEvaluationFactoryPtr_,
                                                              statisticsFactory.create(labelMatrix));
     }
 

--- a/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_provider.hpp
+++ b/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_provider.hpp
@@ -13,6 +13,8 @@ namespace seco {
 
             const ILabelWiseRuleEvaluationFactory& regularRuleEvaluationFactory_;
 
+            const ILabelWiseRuleEvaluationFactory& pruningRuleEvaluationFactory_;
+
             std::unique_ptr<ILabelWiseStatistics> statisticsPtr_;
 
         public:
@@ -21,12 +23,17 @@ namespace seco {
              * @param regularRuleEvaluationFactory  A reference to an object of type `ILabelWiseRuleEvaluationFactory`
              *                                      to switch to when invoking the function
              *                                      `switchToRegularRuleEvaluation`
+             * @param pruningRuleEvaluationFactory  A reference to an object of type `ILabelWiseRuleEvaluationFactory`
+             *                                      to switch to when invoking the function
+             *                                      `switchToPruningRuleEvaluation`
              * @param statisticsPtr                 An unique pointer to an object of type `ILabelWiseStatistics` to
              *                                      provide access to
              */
             LabelWiseStatisticsProvider(const ILabelWiseRuleEvaluationFactory& regularRuleEvaluationFactory,
+                                        const ILabelWiseRuleEvaluationFactory& pruningRuleEvaluationFactory,
                                         std::unique_ptr<ILabelWiseStatistics> statisticsPtr)
                 : regularRuleEvaluationFactory_(regularRuleEvaluationFactory),
+                  pruningRuleEvaluationFactory_(pruningRuleEvaluationFactory),
                   statisticsPtr_(std::move(statisticsPtr)) {
 
             }
@@ -37,6 +44,10 @@ namespace seco {
 
             void switchToRegularRuleEvaluation() override {
                 statisticsPtr_->setRuleEvaluationFactory(regularRuleEvaluationFactory_);
+            }
+
+            void switchToPruningRuleEvaluation() override {
+                statisticsPtr_->setRuleEvaluationFactory(pruningRuleEvaluationFactory_);
             }
 
     };

--- a/python/mlrl/boosting/boosting_learners.py
+++ b/python/mlrl/boosting/boosting_learners.py
@@ -430,10 +430,12 @@ class Boomer(MLRuleLearner, ClassifierMixin):
                                              num_threads: int) -> StatisticsProviderFactory:
         if isinstance(loss_function, LabelWiseLoss):
             return DenseLabelWiseStatisticsProviderFactory(loss_function, rule_evaluation_factory,
-                                                           rule_evaluation_factory, num_threads)
+                                                           rule_evaluation_factory, rule_evaluation_factory,
+                                                           num_threads)
         else:
             return DenseExampleWiseStatisticsProviderFactory(loss_function, rule_evaluation_factory,
-                                                             rule_evaluation_factory, num_threads)
+                                                             rule_evaluation_factory, rule_evaluation_factory,
+                                                             num_threads)
 
     def __create_head_refinement_factory(self) -> HeadRefinementFactory:
         head_type = self.__get_preferred_head_type()

--- a/python/mlrl/boosting/cython/statistics_example_wise.pxd
+++ b/python/mlrl/boosting/cython/statistics_example_wise.pxd
@@ -15,7 +15,8 @@ cdef extern from "boosting/statistics/statistics_example_wise_dense.hpp" namespa
         DenseExampleWiseStatisticsProviderFactoryImpl(
             shared_ptr[IExampleWiseLoss] lossFunctionPtr,
             shared_ptr[IExampleWiseRuleEvaluationFactory] defaultRuleEvaluationFactoryPtr,
-            shared_ptr[IExampleWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr) except +
+            shared_ptr[IExampleWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr,
+            shared_ptr[IExampleWiseRuleEvaluationFactory] pruningRuleEvaluationFactoryPtr) except +
 
 
 cdef class DenseExampleWiseStatisticsProviderFactory(StatisticsProviderFactory):

--- a/python/mlrl/boosting/cython/statistics_example_wise.pyx
+++ b/python/mlrl/boosting/cython/statistics_example_wise.pyx
@@ -14,7 +14,8 @@ cdef class DenseExampleWiseStatisticsProviderFactory(StatisticsProviderFactory):
     """
 
     def __cinit__(self, ExampleWiseLoss loss_function, ExampleWiseRuleEvaluationFactory default_rule_evaluation_factory,
-                  ExampleWiseRuleEvaluationFactory regular_rule_evaluation_factory, uint32 num_threads):
+                  ExampleWiseRuleEvaluationFactory regular_rule_evaluation_factory,
+                  ExampleWiseRuleEvaluationFactory pruning_rule_evaluation_factory, uint32 num_threads):
         """
         :param loss_function:                   The loss function to be used for calculating gradients and Hessians
         :param default_rule_evaluation_factory: The `ExampleWiseRuleEvaluation` to be used for calculating the
@@ -23,6 +24,8 @@ cdef class DenseExampleWiseStatisticsProviderFactory(StatisticsProviderFactory):
         :param regular_rule_evaluation_factory: The `ExampleWiseRuleEvaluationFactory` to be used for calculating the
                                                 predictions, as well as corresponding quality scores, of all remaining
                                                 rules
+        :param pruning_rule_evaluation_factory: The `ExampleWiseRuleEvaluationFactory` to be used for calculating the
+                                                predictions, as well as corresponding quality scores, when pruning rules
         :param label_matrix:                    A label matrix that provides random access to the labels of the training
                                                 examples
         :param num_threads:                     The number of CPU threads to be used to calculate the initial statistics
@@ -30,4 +33,5 @@ cdef class DenseExampleWiseStatisticsProviderFactory(StatisticsProviderFactory):
         """
         self.statistics_provider_factory_ptr = <shared_ptr[IStatisticsProviderFactory]>make_shared[DenseExampleWiseStatisticsProviderFactoryImpl](
             loss_function.loss_function_ptr, default_rule_evaluation_factory.rule_evaluation_factory_ptr,
-            regular_rule_evaluation_factory.rule_evaluation_factory_ptr, num_threads)
+            regular_rule_evaluation_factory.rule_evaluation_factory_ptr,
+            pruning_rule_evaluation_factory.rule_evaluation_factory_ptr, num_threads)

--- a/python/mlrl/boosting/cython/statistics_label_wise.pxd
+++ b/python/mlrl/boosting/cython/statistics_label_wise.pxd
@@ -15,7 +15,8 @@ cdef extern from "boosting/statistics/statistics_label_wise_dense.hpp" namespace
         DenseLabelWiseStatisticsProviderFactoryImpl(
             shared_ptr[ILabelWiseLoss] lossFunctionPtr,
             shared_ptr[ILabelWiseRuleEvaluationFactory] defaultRuleEvaluationFactoryPtr,
-            shared_ptr[ILabelWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr) except +
+            shared_ptr[ILabelWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr,
+            shared_ptr[ILabelWiseRuleEvaluationFactory] pruningRuleEvaluationFactoryPtr) except +
 
 
 cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):

--- a/python/mlrl/boosting/cython/statistics_label_wise.pyx
+++ b/python/mlrl/boosting/cython/statistics_label_wise.pyx
@@ -14,7 +14,8 @@ cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):
     """
 
     def __cinit__(self, LabelWiseLoss loss_function, LabelWiseRuleEvaluationFactory default_rule_evaluation_factory,
-                  LabelWiseRuleEvaluationFactory regular_rule_evaluation_factory, uint32 num_threads):
+                  LabelWiseRuleEvaluationFactory regular_rule_evaluation_factory,
+                  LabelWiseRuleEvaluationFactory pruning_rule_evaluation_factory, uint32 num_threads):
         """
         :param loss_function:                   The loss function to be used for calculating gradients and Hessians
         :param default_rule_evaluation_factory: The `LabelWiseRuleEvaluationFactory` that allows to create instances of
@@ -23,9 +24,13 @@ cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):
         :param regular_rule_evaluation:         The `LabelWiseRuleEvaluationFactory` that allows to create instances of
                                                 the class that should be used for calculating the predictions, as well
                                                 as corresponding quality scores, of all remaining rules
+        :param pruning_rule_evaluation:         The `LabelWiseRuleEvaluationFactory` that allows to create instances of
+                                                the class that should be used for calculating the predictions, as well
+                                                as corresponding quality scores, when pruning rules
         :param num_threads:                     The number of CPU threads to be used to calculate the initial statistics
                                                 in parallel. Must be at least 1
         """
         self.statistics_provider_factory_ptr = <shared_ptr[IStatisticsProviderFactory]>make_shared[DenseLabelWiseStatisticsProviderFactoryImpl](
             loss_function.loss_function_ptr, default_rule_evaluation_factory.rule_evaluation_factory_ptr,
-            regular_rule_evaluation_factory.rule_evaluation_factory_ptr, num_threads)
+            regular_rule_evaluation_factory.rule_evaluation_factory_ptr,
+            pruning_rule_evaluation_factory.rule_evaluation_factory_ptr, num_threads)

--- a/python/mlrl/seco/cython/statistics_label_wise.pxd
+++ b/python/mlrl/seco/cython/statistics_label_wise.pxd
@@ -13,7 +13,8 @@ cdef extern from "seco/statistics/statistics_label_wise_dense.hpp" namespace "se
 
         DenseLabelWiseStatisticsProviderFactoryImpl(
             shared_ptr[ILabelWiseRuleEvaluationFactory] defaultRuleEvaluationFactoryPtr,
-            shared_ptr[ILabelWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr) except +
+            shared_ptr[ILabelWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr,
+            shared_ptr[ILabelWiseRuleEvaluationFactory] pruningRuleEvaluationFactoryPtr) except +
 
 
 cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):

--- a/python/mlrl/seco/cython/statistics_label_wise.pyx
+++ b/python/mlrl/seco/cython/statistics_label_wise.pyx
@@ -13,7 +13,8 @@ cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):
     """
 
     def __cinit__(self, LabelWiseRuleEvaluationFactory default_rule_evaluation_factory,
-                  LabelWiseRuleEvaluationFactory regular_rule_evaluation_factory):
+                  LabelWiseRuleEvaluationFactory regular_rule_evaluation_factory,
+                  LabelWiseRuleEvaluationFactory pruning_rule_evaluation_factory):
         """
         :param default_rule_evaluation_factory: The `LabelWiseRuleEvaluationFactory` that allows to create instances of
                                                 the class that should be used for calculating the predictions, as well
@@ -21,7 +22,11 @@ cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):
         :param regular_rule_evaluation_factory: The `LabelWiseRuleEvaluation` that allows to create instances of the
                                                 class that should be used for calculating the predictions, as well as
                                                 corresponding quality scores, of all remaining rules
+        :param pruning_rule_evaluation_factory: The `LabelWiseRuleEvaluation` that allows to create instances of the
+                                                class that should be used for calculating the predictions, as well as
+                                                corresponding quality scores, when pruning rules
         """
         self.statistics_provider_factory_ptr = <shared_ptr[IStatisticsProviderFactory]>make_shared[DenseLabelWiseStatisticsProviderFactoryImpl](
             default_rule_evaluation_factory.rule_evaluation_factory_ptr,
-            regular_rule_evaluation_factory.rule_evaluation_factory_ptr)
+            regular_rule_evaluation_factory.rule_evaluation_factory_ptr,
+            pruning_rule_evaluation_factory.rule_evaluation_factory_ptr)

--- a/python/mlrl/seco/seco_learners.py
+++ b/python/mlrl/seco/seco_learners.py
@@ -239,6 +239,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner, ClassifierMixin):
             default_rule_evaluation_factory = HeuristicLabelWiseRuleEvaluationFactory(heuristic, predictMajority=True)
             regular_rule_evaluation_factory = HeuristicLabelWiseRuleEvaluationFactory(heuristic)
             return DenseLabelWiseStatisticsProviderFactory(default_rule_evaluation_factory,
+                                                           regular_rule_evaluation_factory,
                                                            regular_rule_evaluation_factory)
         raise ValueError('Invalid value given for parameter \'loss\': ' + str(loss))
 


### PR DESCRIPTION
Erlaubt es, unterschiedliche Implementierungen zur Berechnung und Bewertung der Vorhersagen von Regeln zu verwenden, je nachdem ob eine Regel gelernt oder geprunt werden soll. Hierzu wurde eine neue Funktion `switchToPruningRuleEvaluation` zu der Klasse `IStatisticsProvider` hinzugefügt, die es erlaubt die für das Pruning zu verwendende Implementierung auszutauschen.