### PR TITLE
Klasse "IRuleModelInduction" zu "IRuleModelAssemblage" umbenennen

### DIFF
--- a/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage.hpp
+++ b/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage.hpp
@@ -14,14 +14,14 @@
  * Defines an interface for all classes that implement an algorithm for inducing several rules that will be added to a
  * resulting `RuleModel`.
  */
-class IRuleModelInduction {
+class IRuleModelAssemblage {
 
     public:
 
-        virtual ~IRuleModelInduction() { };
+        virtual ~IRuleModelAssemblage() { };
 
         /**
-         * Trains and returns a `RuleModel` that consists of several rules.
+         * Assembles and returns a `RuleModel` that consists of several rules.
          *
          * @param nominalFeatureMask    A reference to an object of type `INominalFeatureMask` that provides access to
          *                              the information whether individual features are nominal or not

--- a/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage_sequential.hpp
+++ b/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage_sequential.hpp
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include "common/rule_induction/rule_model_induction.hpp"
+#include "common/rule_induction/rule_model_assemblage.hpp"
 #include "common/rule_induction/rule_induction.hpp"
 #include "common/sampling/label_sampling.hpp"
 #include "common/sampling/instance_sampling.hpp"
@@ -19,7 +19,7 @@
  * Allows to sequentially induce several rules, starting with a default rule, that will be added to a resulting
  * `RuleModel`.
  */
-class SequentialRuleModelInduction : public IRuleModelInduction {
+class SequentialRuleModelAssemblage : public IRuleModelAssemblage {
 
     private:
 
@@ -85,7 +85,7 @@ class SequentialRuleModelInduction : public IRuleModelInduction {
          *                                              which should be used to decide whether additional rules should
          *                                              be induced or not
          */
-        SequentialRuleModelInduction(
+        SequentialRuleModelAssemblage(
             std::shared_ptr<IStatisticsProviderFactory> statisticsProviderFactoryPtr,
             std::shared_ptr<IThresholdsFactory> thresholdsFactoryPtr, std::shared_ptr<IRuleInduction> ruleInductionPtr,
             std::shared_ptr<IHeadRefinementFactory> defaultRuleHeadRefinementFactoryPtr,

--- a/cpp/subprojects/common/meson.build
+++ b/cpp/subprojects/common/meson.build
@@ -59,7 +59,7 @@ source_files = [
     'src/common/rule_evaluation/score_vector_label_wise_binned_dense.cpp',
     'src/common/rule_evaluation/score_vector_label_wise_dense.cpp',
     'src/common/rule_induction/rule_induction_top_down.cpp',
-    'src/common/rule_induction/rule_model_induction_sequential.cpp',
+    'src/common/rule_induction/rule_model_assemblage_sequential.cpp',
     'src/common/rule_refinement/refinement.cpp',
     'src/common/rule_refinement/rule_refinement_approximate.cpp',
     'src/common/rule_refinement/rule_refinement_exact.cpp',

--- a/cpp/subprojects/common/src/common/rule_induction/rule_model_assemblage_sequential.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_model_assemblage_sequential.cpp
@@ -1,4 +1,4 @@
-#include "common/rule_induction/rule_model_induction_sequential.hpp"
+#include "common/rule_induction/rule_model_assemblage_sequential.hpp"
 
 
 static inline IStoppingCriterion::Result testStoppingCriteria(
@@ -33,7 +33,7 @@ static inline IStoppingCriterion::Result testStoppingCriteria(
     return result;
 }
 
-SequentialRuleModelInduction::SequentialRuleModelInduction(
+SequentialRuleModelAssemblage::SequentialRuleModelAssemblage(
         std::shared_ptr<IStatisticsProviderFactory> statisticsProviderFactoryPtr,
         std::shared_ptr<IThresholdsFactory> thresholdsFactoryPtr, std::shared_ptr<IRuleInduction> ruleInductionPtr,
         std::shared_ptr<IHeadRefinementFactory> defaultRuleHeadRefinementFactoryPtr,
@@ -53,10 +53,10 @@ SequentialRuleModelInduction::SequentialRuleModelInduction(
 
 }
 
-std::unique_ptr<RuleModel> SequentialRuleModelInduction::induceRules(const INominalFeatureMask& nominalFeatureMask,
-                                                                     const IFeatureMatrix& featureMatrix,
-                                                                     const ILabelMatrix& labelMatrix, RNG& rng,
-                                                                     IModelBuilder& modelBuilder) {
+std::unique_ptr<RuleModel> SequentialRuleModelAssemblage::induceRules(const INominalFeatureMask& nominalFeatureMask,
+                                                                      const IFeatureMatrix& featureMatrix,
+                                                                      const ILabelMatrix& labelMatrix, RNG& rng,
+                                                                      IModelBuilder& modelBuilder) {
     // Induce default rule...
     const IHeadRefinementFactory* defaultRuleHeadRefinementFactory = defaultRuleHeadRefinementFactoryPtr_.get();
     uint32 numRules = defaultRuleHeadRefinementFactory != nullptr ? 1 : 0;

--- a/python/mlrl/boosting/boosting_learners.py
+++ b/python/mlrl/boosting/boosting_learners.py
@@ -28,7 +28,7 @@ from mlrl.common.cython.input import LabelMatrix, LabelVectorSet
 from mlrl.common.cython.model import ModelBuilder
 from mlrl.common.cython.output import Predictor
 from mlrl.common.cython.post_processing import PostProcessor, NoPostProcessor
-from mlrl.common.cython.rule_induction import TopDownRuleInduction, SequentialRuleModelInduction
+from mlrl.common.cython.rule_induction import TopDownRuleInduction, SequentialRuleModelAssemblage
 from mlrl.common.cython.statistics import StatisticsProviderFactory
 from mlrl.common.cython.stopping import MeasureStoppingCriterion, AggregationFunction, MinFunction, MaxFunction, \
     ArithmeticMeanFunction
@@ -290,7 +290,7 @@ class Boomer(MLRuleLearner, ClassifierMixin):
     def _create_model_builder(self) -> ModelBuilder:
         return RuleListBuilder()
 
-    def _create_rule_model_induction(self, num_labels: int) -> SequentialRuleModelInduction:
+    def _create_rule_model_assemblage(self, num_labels: int) -> SequentialRuleModelAssemblage:
         stopping_criteria = create_stopping_criteria(int(self.max_rules), int(self.time_limit))
         early_stopping_criterion = self.__create_early_stopping()
         if early_stopping_criterion is not None:
@@ -318,10 +318,11 @@ class Boomer(MLRuleLearner, ClassifierMixin):
         num_threads_rule_refinement = get_preferred_num_threads(self.num_threads_rule_refinement)
         rule_induction = TopDownRuleInduction(min_coverage, max_conditions, max_head_refinements,
                                               recalculate_predictions, num_threads_rule_refinement)
-        return SequentialRuleModelInduction(statistics_provider_factory, thresholds_factory, rule_induction,
-                                            default_rule_head_refinement_factory, head_refinement_factory,
-                                            label_sampling_factory, instance_sampling_factory, feature_sampling_factory,
-                                            partition_sampling_factory, pruning, shrinkage, stopping_criteria)
+        return SequentialRuleModelAssemblage(statistics_provider_factory, thresholds_factory, rule_induction,
+                                             default_rule_head_refinement_factory, head_refinement_factory,
+                                             label_sampling_factory, instance_sampling_factory,
+                                             feature_sampling_factory, partition_sampling_factory, pruning, shrinkage,
+                                             stopping_criteria)
 
     def __create_early_stopping(self) -> Optional[MeasureStoppingCriterion]:
         early_stopping = self.early_stopping

--- a/python/mlrl/common/cython/rule_induction.pxd
+++ b/python/mlrl/common/cython/rule_induction.pxd
@@ -22,9 +22,9 @@ cdef extern from "common/rule_induction/rule_induction.hpp" nogil:
         pass
 
 
-cdef extern from "common/rule_induction/rule_model_induction.hpp" nogil:
+cdef extern from "common/rule_induction/rule_model_assemblage.hpp" nogil:
 
-    cdef cppclass IRuleModelInduction:
+    cdef cppclass IRuleModelAssemblage:
 
         # Functions:
 
@@ -43,13 +43,13 @@ cdef extern from "common/rule_induction/rule_induction_top_down.hpp" nogil:
                                  bool recalculatePredictions, uint32 numThreads) except +
 
 
-cdef extern from "common/rule_induction/rule_model_induction_sequential.hpp" nogil:
+cdef extern from "common/rule_induction/rule_model_assemblage_sequential.hpp" nogil:
 
-    cdef cppclass SequentialRuleModelInductionImpl"SequentialRuleModelInduction"(IRuleModelInduction):
+    cdef cppclass SequentialRuleModelAssemblageImpl"SequentialRuleModelAssemblage"(IRuleModelAssemblage):
 
         # Constructors:
 
-        SequentialRuleModelInductionImpl(
+        SequentialRuleModelAssemblageImpl(
                 shared_ptr[IStatisticsProviderFactory] statisticsProviderFactoryPtr,
                 shared_ptr[IThresholdsFactory] thresholdsFactoryPtr, shared_ptr[IRuleInduction] ruleInductionPtr,
                 shared_ptr[IHeadRefinementFactory] defaultRuleHeadRefinementFactoryPtr,
@@ -73,11 +73,11 @@ cdef class TopDownRuleInduction(RuleInduction):
     pass
 
 
-cdef class RuleModelInduction:
+cdef class RuleModelAssemblage:
 
     # Attributes:
 
-    cdef shared_ptr[IRuleModelInduction] rule_model_induction_ptr
+    cdef shared_ptr[IRuleModelAssemblage] rule_model_assemblage_ptr
 
     # Functions:
 
@@ -86,5 +86,5 @@ cdef class RuleModelInduction:
 
 
 
-cdef class SequentialRuleModelInduction(RuleModelInduction):
+cdef class SequentialRuleModelAssemblage(RuleModelAssemblage):
     pass

--- a/python/mlrl/common/cython/rule_induction.pyx
+++ b/python/mlrl/common/cython/rule_induction.pyx
@@ -47,16 +47,16 @@ cdef class TopDownRuleInduction(RuleInduction):
             min_coverage, max_conditions, max_head_refinements, recalculate_predictions, num_threads)
 
 
-cdef class RuleModelInduction:
+cdef class RuleModelAssemblage:
     """
-    A wrapper for the pure virtual C++ class `IRuleModelInduction`.
+    A wrapper for the pure virtual C++ class `IRuleModelAssemblage`.
     """
 
     cpdef RuleModel induce_rules(self, NominalFeatureMask nominal_feature_mask, FeatureMatrix feature_matrix,
                                  LabelMatrix label_matrix, uint32 random_state, ModelBuilder model_builder):
-        cdef shared_ptr[IRuleModelInduction] rule_model_induction_ptr = self.rule_model_induction_ptr
+        cdef shared_ptr[IRuleModelAssemblage] rule_model_assemblage_ptr = self.rule_model_assemblage_ptr
         cdef unique_ptr[RNG] rng_ptr = make_unique[RNG](random_state)
-        cdef unique_ptr[RuleModelImpl] rule_model_ptr = rule_model_induction_ptr.get().induceRules(
+        cdef unique_ptr[RuleModelImpl] rule_model_ptr = rule_model_assemblage_ptr.get().induceRules(
             dereference(nominal_feature_mask.nominal_feature_mask_ptr), dereference(feature_matrix.feature_matrix_ptr),
             dereference(label_matrix.label_matrix_ptr), dereference(rng_ptr),
             dereference(model_builder.model_builder_ptr))
@@ -65,9 +65,9 @@ cdef class RuleModelInduction:
         return model
 
 
-cdef class SequentialRuleModelInduction(RuleModelInduction):
+cdef class SequentialRuleModelAssemblage(RuleModelAssemblage):
     """
-    A wrapper for the C++ class `SequentialRuleModelInduction`.
+    A wrapper for the C++ class `SequentialRuleModelAssemblage`.
     """
 
     def __cinit__(self, StatisticsProviderFactory statistics_provider_factory, ThresholdsFactory thresholds_factory,
@@ -116,7 +116,7 @@ cdef class SequentialRuleModelInduction(RuleModelInduction):
             stopping_criterion = stopping_criteria[i]
             stopping_criteria_ptr.get().push_front(stopping_criterion.stopping_criterion_ptr)
 
-        self.rule_model_induction_ptr = <shared_ptr[IRuleModelInduction]>make_shared[SequentialRuleModelInductionImpl](
+        self.rule_model_assemblage_ptr = <shared_ptr[IRuleModelAssemblage]>make_shared[SequentialRuleModelAssemblageImpl](
             statistics_provider_factory.statistics_provider_factory_ptr, thresholds_factory.thresholds_factory_ptr,
             rule_induction.rule_induction_ptr, default_rule_head_refinement_factory.head_refinement_factory_ptr,
             head_refinement_factory.head_refinement_factory_ptr, label_sampling_factory.label_sampling_factory_ptr,

--- a/python/mlrl/common/rule_learners.py
+++ b/python/mlrl/common/rule_learners.py
@@ -21,7 +21,7 @@ from mlrl.common.cython.input import LabelVectorSet
 from mlrl.common.cython.model import ModelBuilder
 from mlrl.common.cython.output import Predictor
 from mlrl.common.cython.pruning import Pruning, NoPruning, IREP
-from mlrl.common.cython.rule_induction import RuleModelInduction
+from mlrl.common.cython.rule_induction import RuleModelAssemblage
 from mlrl.common.cython.sampling import FeatureSamplingFactory, FeatureSamplingWithoutReplacementFactory, \
     NoFeatureSamplingFactory
 from mlrl.common.cython.sampling import InstanceSamplingFactory, InstanceSamplingWithReplacementFactory, \
@@ -382,10 +382,10 @@ class MLRuleLearner(Learner, NominalAttributeLearner):
             nominal_feature_mask = BitNominalFeatureMask(num_features, self.nominal_attribute_indices)
 
         # Induce rules...
-        rule_model_induction = self._create_rule_model_induction(num_labels)
+        rule_model_assemblage = self._create_rule_model_assemblage(num_labels)
         model_builder = self._create_model_builder()
-        return rule_model_induction.induce_rules(nominal_feature_mask, feature_matrix, label_matrix, self.random_state,
-                                                 model_builder)
+        return rule_model_assemblage.induce_rules(nominal_feature_mask, feature_matrix, label_matrix, self.random_state,
+                                                  model_builder)
 
     def _predict(self, x):
         predictor = self.predictor_
@@ -454,7 +454,7 @@ class MLRuleLearner(Learner, NominalAttributeLearner):
         return None
 
     @abstractmethod
-    def _create_rule_model_induction(self, num_labels: int) -> RuleModelInduction:
+    def _create_rule_model_assemblage(self, num_labels: int) -> RuleModelAssemblage:
         """
         Must be implemented by subclasses in order to create the algorithm that should be used for inducing a rule
         model.

--- a/python/mlrl/seco/seco_learners.py
+++ b/python/mlrl/seco/seco_learners.py
@@ -10,7 +10,7 @@ from mlrl.common.cython.head_refinement import HeadRefinementFactory, SingleLabe
 from mlrl.common.cython.model import ModelBuilder
 from mlrl.common.cython.output import Predictor
 from mlrl.common.cython.post_processing import NoPostProcessor
-from mlrl.common.cython.rule_induction import TopDownRuleInduction, SequentialRuleModelInduction
+from mlrl.common.cython.rule_induction import TopDownRuleInduction, SequentialRuleModelAssemblage
 from mlrl.common.cython.statistics import StatisticsProviderFactory
 from mlrl.seco.cython.head_refinement import PartialHeadRefinementFactory, LiftFunction, PeakLiftFunction
 from mlrl.seco.cython.heuristics import Heuristic, Accuracy, Precision, Recall, Laplace, WRA, FMeasure, MEstimate
@@ -187,7 +187,7 @@ class SeparateAndConquerRuleLearner(MLRuleLearner, ClassifierMixin):
     def _create_model_builder(self) -> ModelBuilder:
         return DecisionListBuilder()
 
-    def _create_rule_model_induction(self, num_labels: int) -> SequentialRuleModelInduction:
+    def _create_rule_model_assemblage(self, num_labels: int) -> SequentialRuleModelAssemblage:
         heuristic = self.__create_heuristic(self.heuristic, 'heuristic')
         pruning_heuristic = self.__create_heuristic(self.pruning_heuristic, 'pruning_heuristic')
         statistics_provider_factory = self.__create_statistics_provider_factory(heuristic, pruning_heuristic)
@@ -210,10 +210,11 @@ class SeparateAndConquerRuleLearner(MLRuleLearner, ClassifierMixin):
         post_processor = NoPostProcessor()
         stopping_criteria = create_stopping_criteria(int(self.max_rules), int(self.time_limit))
         stopping_criteria.append(CoverageStoppingCriterion(0))
-        return SequentialRuleModelInduction(statistics_provider_factory, thresholds_factory, rule_induction,
-                                            default_rule_head_refinement_factory, head_refinement_factory,
-                                            label_sampling_factory, instance_sampling_factory, feature_sampling_factory,
-                                            partition_sampling_factory, pruning, post_processor, stopping_criteria)
+        return SequentialRuleModelAssemblage(statistics_provider_factory, thresholds_factory, rule_induction,
+                                             default_rule_head_refinement_factory, head_refinement_factory,
+                                             label_sampling_factory, instance_sampling_factory,
+                                             feature_sampling_factory, partition_sampling_factory,
+                                             pruning, post_processor, stopping_criteria)
 
     def __create_heuristic(self, heuristic: str, parameter_name: str) -> Heuristic:
         prefix, options = parse_prefix_and_options(parameter_name, heuristic, [HEURISTIC_ACCURACY, HEURISTIC_PRECISION,


### PR DESCRIPTION
Benennt die folgenden Klasse um:

* `IRuleModelInduction` -> `IRuleModelAssemblage`
* `SequentialRuleModelInduction` -> `SequentialRuleModelAssemblage`