### PR TITLE
Versuch Pruning von Heads zu fixen

### DIFF
--- a/cpp/subprojects/common/include/common/pruning/pruning.hpp
+++ b/cpp/subprojects/common/include/common/pruning/pruning.hpp
@@ -40,6 +40,6 @@ class IPruning {
          */
         virtual std::unique_ptr<ICoverageState> prune(IThresholdsSubset& thresholdsSubset, IPartition& partition,
                                                       ConditionList& conditions,
-                                                      const AbstractEvaluatedPrediction* head) const = 0;
+                                                      AbstractEvaluatedPrediction* head) const = 0;
 
 };

--- a/cpp/subprojects/common/include/common/pruning/pruning_irep.hpp
+++ b/cpp/subprojects/common/include/common/pruning/pruning_irep.hpp
@@ -18,6 +18,6 @@ class IREP final : public IPruning {
     public:
 
         std::unique_ptr<ICoverageState> prune(IThresholdsSubset& thresholdsSubset, IPartition& partition,
-                                          ConditionList& conditions, const AbstractEvaluatedPrediction* head) const override;
+                                          ConditionList& conditions, AbstractEvaluatedPrediction* head) const override;
 
 };

--- a/cpp/subprojects/common/include/common/pruning/pruning_no.hpp
+++ b/cpp/subprojects/common/include/common/pruning/pruning_no.hpp
@@ -14,6 +14,6 @@ class NoPruning final : public IPruning {
     public:
 
         std::unique_ptr<ICoverageState> prune(IThresholdsSubset& thresholdsSubset, IPartition& partition,
-                                              ConditionList& conditions, const AbstractEvaluatedPrediction* head) const override;
+                                              ConditionList& conditions, AbstractEvaluatedPrediction* head) const override;
 
 };

--- a/cpp/subprojects/common/src/common/pruning/pruning_irep.cpp
+++ b/cpp/subprojects/common/src/common/pruning/pruning_irep.cpp
@@ -5,7 +5,7 @@
 
 
 std::unique_ptr<ICoverageState> IREP::prune(IThresholdsSubset& thresholdsSubset, IPartition& partition,
-                                            ConditionList& conditions, const AbstractEvaluatedPrediction* head) const {
+                                            ConditionList& conditions, AbstractEvaluatedPrediction* head) const {
     ConditionList::size_type numConditions = conditions.getNumConditions();
     std::unique_ptr<ICoverageState> bestCoverageStatePtr;
 

--- a/cpp/subprojects/common/src/common/pruning/pruning_no.cpp
+++ b/cpp/subprojects/common/src/common/pruning/pruning_no.cpp
@@ -2,6 +2,6 @@
 
 
 std::unique_ptr<ICoverageState> NoPruning::prune(IThresholdsSubset& thresholdsSubset, IPartition& partition,
-                                                 ConditionList& conditions, const AbstractEvaluatedPrediction* head) const {
+                                                 ConditionList& conditions, AbstractEvaluatedPrediction* head) const {
     return nullptr;
 }

--- a/cpp/subprojects/seco/include/seco/pruning/pruning_seco.hpp
+++ b/cpp/subprojects/seco/include/seco/pruning/pruning_seco.hpp
@@ -36,7 +36,7 @@ namespace seco {
         explicit SecoPruning(std::shared_ptr<seco::ILiftFunction> liftFunctionPtr);
 
         std::unique_ptr<ICoverageState> prune(IThresholdsSubset &thresholdsSubset, IPartition &partition,
-                                              ConditionList &conditions, const AbstractEvaluatedPrediction* bestHead) const override;
+                                              ConditionList &conditions, AbstractEvaluatedPrediction* bestHead) const override;
 
         const AbstractEvaluatedPrediction *processScores(const AbstractEvaluatedPrediction *bestHead,
                                                          const DenseLabelWiseScoreVector<FullIndexVector> &scoreVector) override;


### PR DESCRIPTION
Hallo @AndreasSeidl,

das Problem mit der aktuellen Implementierung zum Prunen von Heads ist meiner Meinung nach, dass die Vorhersagen eines geprunten Heads nicht korrekt in den ursprünglichen Head übernommen werden. Statt die geänderten Werte in das existierende Objekt zu kopieren, werden lediglich Pointer "umgebogen". Das birgt aber die Gefahr, dass das Objekt auf das verwiesen wird später noch geändert oder sogar gelöscht wird.

Hier ein Versuch um das zu beheben, inklusive Kommentare, die die Änderungen erklären sollen. Ich habe den Code nicht getestet (aber sichergestellt dass er kompiliert) und eventuell wird das Problem dadurch noch nicht behoben. Aber mir sind ansonsten keine offensichtlichen Fehler aufgefallen.