### PR TITLE
Refactoring der Klasse "ScoreProcessor"

### DIFF
--- a/cpp/subprojects/common/include/common/rule_evaluation/score_vector.hpp
+++ b/cpp/subprojects/common/include/common/rule_evaluation/score_vector.hpp
@@ -36,13 +36,10 @@ class IScoreVector {
         /**
          * Passes the scores to an `ScoreProcessor` in order to convert them into the head of a rule.
          *
-         * @param bestHead       A reference to an object of type `AbstractEvaluatedPrediction`, representing the best
-         *                       head that has been created so far
          * @param scoreProcessor A reference to an object of type `ScoreProcessor`, the scores should be passed to
          * @return               A pointer to an object of type `AbstractEvaluatedPrediction` that has been created or a
          *                       null pointer if no object has been created
          */
-        virtual const AbstractEvaluatedPrediction* processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                                 ScoreProcessor& scoreProcessor) const = 0;
+        virtual const AbstractEvaluatedPrediction* processScores(ScoreProcessor& scoreProcessor) const = 0;
 
 };

--- a/cpp/subprojects/common/include/common/rule_evaluation/score_vector_binned_dense.hpp
+++ b/cpp/subprojects/common/include/common/rule_evaluation/score_vector_binned_dense.hpp
@@ -182,7 +182,6 @@ class DenseBinnedScoreVector : virtual public IScoreVector {
 
         void updatePrediction(AbstractPrediction& prediction) const override final;
 
-        const AbstractEvaluatedPrediction* processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                         ScoreProcessor& scoreProcessor) const override final;
+        const AbstractEvaluatedPrediction* processScores(ScoreProcessor& scoreProcessor) const override final;
 
 };

--- a/cpp/subprojects/common/include/common/rule_evaluation/score_vector_dense.hpp
+++ b/cpp/subprojects/common/include/common/rule_evaluation/score_vector_dense.hpp
@@ -103,7 +103,6 @@ class DenseScoreVector : virtual public IScoreVector {
 
         void updatePrediction(AbstractPrediction& prediction) const override final;
 
-        const AbstractEvaluatedPrediction* processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                         ScoreProcessor& scoreProcessor) const override final;
+        const AbstractEvaluatedPrediction* processScores(ScoreProcessor& scoreProcessor) const override final;
 
 };

--- a/cpp/subprojects/common/include/common/rule_refinement/score_processor.hpp
+++ b/cpp/subprojects/common/include/common/rule_refinement/score_processor.hpp
@@ -8,7 +8,6 @@
 #include "common/rule_refinement/prediction_evaluated.hpp"
 #include "common/indices/index_vector_complete.hpp"
 #include "common/indices/index_vector_partial.hpp"
-#include "common/statistics/statistics_subset.hpp"
 
 
 /**
@@ -27,84 +26,50 @@ class ScoreProcessor {
          * Processes the scores that are stored by a `DenseScoreVector<CompleteIndexVector>` in order to convert them
          * into the head of a rule.
          *
-         * @param bestHead      A pointer to an object of type `AbstractEvaluatedPrediction` that represents the best
-         *                      head that has been created so far
          * @param scoreVector   A reference to an object of type `DenseScoreVector<CompleteIndexVector>` that stores the
          *                      scores to be processed
-         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created or a
-         *                      null pointer if no object has been created
+         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created
          */
-        const AbstractEvaluatedPrediction* processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                         const DenseScoreVector<CompleteIndexVector>& scoreVector);
+        const AbstractEvaluatedPrediction* processScores(const DenseScoreVector<CompleteIndexVector>& scoreVector);
 
         /**
          * Processes the scores that are stored by a `DenseScoreVector<PartialIndexVector>` in order to convert them
          * into the head of a rule.
          *
-         * @param bestHead      A pointer to an object of type `AbstractEvaluatedPrediction` that represents the best
-         *                      head that has been created so far
          * @param scoreVector   A reference to an object of type `DenseScoreVector<PartialIndexVector>` that stores the
          *                      scores to be processed
-         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created or a
-         *                      null pointer if no object has been created
+         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created
          */
-        const AbstractEvaluatedPrediction* processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                         const DenseScoreVector<PartialIndexVector>& scoreVector);
+        const AbstractEvaluatedPrediction* processScores(const DenseScoreVector<PartialIndexVector>& scoreVector);
 
         /**
          * Processes the scores that are stored by a `DenseBinnedScoreVector<CompleteIndexVector>` in order to convert
          * them into the head of a rule.
          *
-         * @param bestHead      A pointer to an object of type `AbstractEvaluatedPrediction` that represents the best
-         *                      head that has been created so far
          * @param scoreVector   A reference to an object of type `DenseBinnedScoreVector<CompleteIndexVector>` that
          *                      stores the scores to be processed
-         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created or a
-         *                      null pointer if no object has been created
+         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created
          */
         const AbstractEvaluatedPrediction* processScores(
-            const AbstractEvaluatedPrediction* bestHead,
             const DenseBinnedScoreVector<CompleteIndexVector>& scoreVector);
 
         /**
          * Processes the scores that are stored by a `DenseBinnedScoreVector<PartialIndexVector>` in order to convert
          * them into the head of a rule.
          *
-         * @param bestHead      A pointer to an object of type `AbstractEvaluatedPrediction` that represents the best
-         *                      head that has been created so far
          * @param scoreVector   A reference to an object of type `DenseBinnedScoreVector<PartialIndexVector>` that
          *                      stores the scores to be processed
-         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created or a
-         *                      null pointer if no object has been created
+         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created
          */
-        const AbstractEvaluatedPrediction* processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                         const DenseBinnedScoreVector<PartialIndexVector>& scoreVector);
+        const AbstractEvaluatedPrediction* processScores(const DenseBinnedScoreVector<PartialIndexVector>& scoreVector);
 
         /**
-         * Finds the best head for a rule, given the predictions that are provided by a `IStatisticsSubset`.
+         * Processes the scores that are stored by a `IScoreVector` in order to convert them into the head of a rule.
          *
-         * The given object of type `IStatisticsSubset` must have been prepared properly via calls to the function
-         * `IStatisticsSubset#addToSubset`.
-         *
-         * @param bestHead          A pointer to an object of type `AbstractEvaluatedPrediction` that corresponds to the
-         *                          best rule known so far (as found in the previous or current refinement iteration) or
-         *                          a null pointer, if no such rule is available yet. The new head must be better than
-         *                          this one, otherwise it is discarded
-         * @param statisticsSubset  A reference to an object of type `IStatisticsSubset` to be used for calculating
-         *                          predictions and corresponding quality scores
-         * @param uncovered         False, if the rule for which the head should be found covers all statistics that
-         *                          have been added to the `IStatisticsSubset` so far, True, if the rule covers all
-         *                          statistics that have not been added yet
-         * @param accumulated       False, if the rule covers all statistics that have been added since the
-         *                          `IStatisticsSubset` has been reset for the last time, True, if the rule covers all
-         *                          statistics that have been added so far
-         * @return                  A pointer to an object of type `AbstractEvaluatedPrediction`, representing the head
-         *                          that has been found or a null pointer if the head that has been found is not better
-         *                          than `bestHead`
+         * @param scoreVector   A reference to an object of type `IScoreVector` that stores the scores to be processed
+         * @return              A pointer to an object of type `AbstractEvaluatedPrediction` that has been created
          */
-        const AbstractEvaluatedPrediction* findHead(const AbstractEvaluatedPrediction* bestHead,
-                                                    IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                    bool accumulated);
+        const AbstractEvaluatedPrediction* processScores(const IScoreVector& scoreVector);
 
         /**
          * Returns the best head that has been found by the function `findHead.

--- a/cpp/subprojects/common/src/common/rule_evaluation/score_vector_binned_dense.cpp
+++ b/cpp/subprojects/common/src/common/rule_evaluation/score_vector_binned_dense.cpp
@@ -97,9 +97,8 @@ void DenseBinnedScoreVector<T>::updatePrediction(AbstractPrediction& prediction)
 }
 
 template<typename T>
-const AbstractEvaluatedPrediction* DenseBinnedScoreVector<T>::processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                                            ScoreProcessor& scoreProcessor) const {
-    return scoreProcessor.processScores(bestHead, *this);
+const AbstractEvaluatedPrediction* DenseBinnedScoreVector<T>::processScores(ScoreProcessor& scoreProcessor) const {
+    return scoreProcessor.processScores(*this);
 }
 
 template class DenseBinnedScoreVector<PartialIndexVector>;

--- a/cpp/subprojects/common/src/common/rule_evaluation/score_vector_dense.cpp
+++ b/cpp/subprojects/common/src/common/rule_evaluation/score_vector_dense.cpp
@@ -57,9 +57,8 @@ void DenseScoreVector<T>::updatePrediction(AbstractPrediction& prediction) const
 }
 
 template<typename T>
-const AbstractEvaluatedPrediction* DenseScoreVector<T>::processScores(const AbstractEvaluatedPrediction* bestHead,
-                                                                      ScoreProcessor& scoreProcessor) const {
-    return scoreProcessor.processScores(bestHead, *this);
+const AbstractEvaluatedPrediction* DenseScoreVector<T>::processScores(ScoreProcessor& scoreProcessor) const {
+    return scoreProcessor.processScores(*this);
 }
 
 template class DenseScoreVector<PartialIndexVector>;

--- a/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down.cpp
@@ -27,8 +27,9 @@ void TopDownRuleInduction::induceDefaultRule(IStatistics& statistics, IModelBuil
 
     CompleteIndexVector labelIndices(numLabels);
     std::unique_ptr<IStatisticsSubset> statisticsSubsetPtr = labelIndices.createSubset(statistics);
+    const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(true, false);
     ScoreProcessor scoreProcessor;
-    scoreProcessor.findHead(nullptr, *statisticsSubsetPtr, true, false);
+    scoreProcessor.processScores(scoreVector);
     std::unique_ptr<AbstractEvaluatedPrediction> defaultPredictionPtr = scoreProcessor.pollHead();
 
     for (uint32 i = 0; i < numStatistics; i++) {

--- a/cpp/subprojects/common/src/common/rule_refinement/rule_refinement_approximate.cpp
+++ b/cpp/subprojects/common/src/common/rule_refinement/rule_refinement_approximate.cpp
@@ -1,5 +1,6 @@
 #include "common/rule_refinement/rule_refinement_approximate.hpp"
 #include "common/rule_refinement/score_processor.hpp"
+#include "rule_refinement_common.hpp"
 
 
 template<typename T>
@@ -60,12 +61,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
             if (weights[r]) {
                 // Find and evaluate the best head for the current refinement, if a condition that uses the <= operator
                 // (or the == operator in case of a nominal feature) is used...
-                const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false,
-                                                                                  false);
+                const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
                 // If the refinement is better than the current rule...
-                if (head != nullptr) {
-                    bestHead = head;
+                if (isBetterThanBestHead(scoreVector, bestHead)) {
+                    bestHead = scoreProcessor.processScores(scoreVector);
                     refinementPtr->start = firstR;
                     refinementPtr->end = r;
                     refinementPtr->covered = true;
@@ -75,11 +75,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
 
                 // Find and evaluate the best head for the current refinement, if a condition that uses the > operator
                 // (or the != operator in case of a nominal feature) is used...
-                head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+                const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
                 // If the refinement is better than the current rule...
-                if (head != nullptr) {
-                    bestHead = head;
+                if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                    bestHead = scoreProcessor.processScores(scoreVector2);
                     refinementPtr->start = firstR;
                     refinementPtr->end = r;
                     refinementPtr->covered = false;
@@ -104,12 +104,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
         if (subsetModified && sparse) {
             // Find and evaluate the best head for the current refinement, if a condition that uses the <= operator (or
             // the == operator in case of nominal feature) is used...
-            const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false,
-                                                                              false);
+            const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
             // If the refinement is better than the current rule...
-            if (head != nullptr) {
-                bestHead = head;
+            if (isBetterThanBestHead(scoreVector, bestHead)) {
+                bestHead = scoreProcessor.processScores(scoreVector);
                 refinementPtr->start = firstR;
                 refinementPtr->end = sparseBinIndex;
                 refinementPtr->covered = true;
@@ -119,11 +118,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
 
             // Find and evaluate the best head for the current refinement, if a condition that uses the > operator (or
             // the != operator in case of a nominal feature) is used...
-            head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+            const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
             // If the refinement is better than the current rule...
-            if (head != nullptr) {
-                bestHead = head;
+            if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                bestHead = scoreProcessor.processScores(scoreVector2);
                 refinementPtr->start = firstR;
                 refinementPtr->end = sparseBinIndex;
                 refinementPtr->covered = false;
@@ -159,12 +158,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
             if (weights[r]) {
                 // Find and evaluate the best head for the current refinement, if a condition that uses the > operator
                 // (or the == operator in case of a nominal feature) is used..
-                const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false,
-                                                                                  false);
+                const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
                 // If the refinement is better than the current rule...
-                if (head != nullptr) {
-                    bestHead = head;
+                if (isBetterThanBestHead(scoreVector, bestHead)) {
+                    bestHead = scoreProcessor.processScores(scoreVector);
                     refinementPtr->start = firstR;
                     refinementPtr->end = r;
                     refinementPtr->covered = true;
@@ -180,11 +178,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
 
                 // Find and evaluate the best head for the current refinement, if a condition that uses the <= operator
                 // (or the != operator in case of a nominal feature) is used...
-                head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+                const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
                 // If the refinement is better than the current rule...
-                if (head != nullptr) {
-                    bestHead = head;
+                if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                    bestHead = scoreProcessor.processScores(scoreVector2);
                     refinementPtr->start = firstR;
                     refinementPtr->end = r;
                     refinementPtr->covered = false;
@@ -215,12 +213,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
         // (sparseBinIndex, numBins) from the remaining ones...
         if (sparse) {
             // Find and evaluate the best head for the current refinement, if
-            const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false,
-                                                                              false);
+            const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
             // If the refinement is better than the current rule...
-            if (head != nullptr) {
-                bestHead = head;
+            if (isBetterThanBestHead(scoreVector, bestHead)) {
+                bestHead = scoreProcessor.processScores(scoreVector);
                 refinementPtr->start = firstR;
                 refinementPtr->end = sparseBinIndex;
                 refinementPtr->covered = true;
@@ -235,11 +232,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
             }
 
             // Find and evaluate the best head for the current refinement, if
-            head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+            const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
             // If the refinement is better than the current rule...
-            if (head != nullptr) {
-                bestHead = head;
+            if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                bestHead = scoreProcessor.processScores(scoreVector2);
                 refinementPtr->start = firstR;
                 refinementPtr->end = sparseBinIndex;
                 refinementPtr->covered = false;
@@ -262,11 +259,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
 
                 // Find and evaluate the best head for the current refinement, if the condition
                 // `f != thresholdIterator[sparseBinIndex]` is used...
-                head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false, true);
+                const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, true);
 
                 // If the refinement is better than the current rule...
-                if (head != nullptr) {
-                    bestHead = head;
+                if (isBetterThanBestHead(scoreVector, bestHead)) {
+                    bestHead = scoreProcessor.processScores(scoreVector);
                     refinementPtr->start = sparseBinIndex;
                     refinementPtr->end = sparseBinIndex + 1;
                     refinementPtr->covered = false;
@@ -276,10 +273,11 @@ void ApproximateRuleRefinement<T>::findRefinement(const AbstractEvaluatedPredict
 
                 // Find and evaluate the best head for the current refinement, if the condition
                 // `f == thresholdIterator[sparseBinIndex]` is used...
-                head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, true);
+                const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, true);
 
-                if (head != nullptr) {
-                    bestHead = head;
+                // If the refinement is better than the current rule...
+                if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                    bestHead = scoreProcessor.processScores(scoreVector2);
                     refinementPtr->start = sparseBinIndex;
                     refinementPtr->end = sparseBinIndex + 1;
                     refinementPtr->covered = true;

--- a/cpp/subprojects/common/src/common/rule_refinement/rule_refinement_common.hpp
+++ b/cpp/subprojects/common/src/common/rule_refinement/rule_refinement_common.hpp
@@ -1,0 +1,23 @@
+/*
+ * @author Michael Rapp (mrapp@ke.tu-darmstadt.de)
+ */
+#pragma once
+
+#include "common/rule_evaluation/score_vector.hpp"
+#include "common/rule_refinement/prediction_evaluated.hpp"
+
+
+/**
+ * Returns whether the predictions that are stored by a specific `IScoreVector` are better than those of the best head
+ * found so far, according to their respective quality scores.
+ *
+ * @param scoreVector   A reference to an object of type `IScoreVector` that stores the predictions
+ * @param bestHead      A pointer to an object of type `AbstractEvaluatedPrediction` that represents the best head found
+ *                      so far or a null pointer, if no such head is available
+ * @return              True, if the predictions that are stored by the given `IScoreVector` are better than those of
+ *                      the best head, false otherwise
+ */
+static inline constexpr bool isBetterThanBestHead(const IScoreVector& scoreVector,
+                                                  const AbstractEvaluatedPrediction* bestHead) {
+    return bestHead == nullptr || scoreVector.overallQualityScore < bestHead->overallQualityScore;
+}

--- a/cpp/subprojects/common/src/common/rule_refinement/rule_refinement_exact.cpp
+++ b/cpp/subprojects/common/src/common/rule_refinement/rule_refinement_exact.cpp
@@ -1,6 +1,7 @@
 #include "common/rule_refinement/rule_refinement_exact.hpp"
 #include "common/rule_refinement/score_processor.hpp"
 #include "common/math/math.hpp"
+#include "rule_refinement_common.hpp"
 
 
 template<typename T>
@@ -89,12 +90,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                 if (previousThreshold != currentThreshold) {
                     // Find and evaluate the best head for the current refinement, if a condition that uses the <=
                     // operator (or the == operator in case of a nominal feature) is used...
-                    const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr,
-                                                                                      false, false);
+                    const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
                     // If the refinement is better than the current rule...
-                    if (head != nullptr) {
-                        bestHead = head;
+                    if (isBetterThanBestHead(scoreVector, bestHead)) {
+                        bestHead = scoreProcessor.processScores(scoreVector);
                         refinementPtr->start = firstR;
                         refinementPtr->end = r;
                         refinementPtr->previous = previousR;
@@ -112,11 +112,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
 
                     // Find and evaluate the best head for the current refinement, if a condition that uses the >
                     // operator (or the != operator in case of a nominal feature) is used...
-                    head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+                    const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
                     // If the refinement is better than the current rule...
-                    if (head != nullptr) {
-                        bestHead = head;
+                    if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                        bestHead = scoreProcessor.processScores(scoreVector2);
                         refinementPtr->start = firstR;
                         refinementPtr->end = r;
                         refinementPtr->previous = previousR;
@@ -158,12 +158,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                                             || accumulatedNumExamples < numExamples_)) {
             // Find and evaluate the best head for the current refinement, if a condition that uses the == operator is
             // used...
-            const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false,
-                                                                              false);
+            const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
             // If the refinement is better than the current rule...
-            if (head != nullptr) {
-                bestHead = head;
+            if (isBetterThanBestHead(scoreVector, bestHead)) {
+                bestHead = scoreProcessor.processScores(scoreVector);
                 refinementPtr->start = firstR;
                 refinementPtr->end = (lastNegativeR + 1);
                 refinementPtr->previous = previousR;
@@ -175,11 +174,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
 
             // Find and evaluate the best head for the current refinement, if a condition that uses the != operator is
             // used...
-            head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+            const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
             // If the refinement is better than the current rule...
-            if (head != nullptr) {
-                bestHead = head;
+            if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                bestHead = scoreProcessor.processScores(scoreVector2);
                 refinementPtr->start = firstR;
                 refinementPtr->end = (lastNegativeR + 1);
                 refinementPtr->previous = previousR;
@@ -234,12 +233,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
                 if (previousThreshold != currentThreshold) {
                     // Find and evaluate the best head for the current refinement, if a condition that uses the
                     // > operator (or the == operator in case of a nominal feature) is used...
-                    const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr,
-                                                                                      false, false);
+                    const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
                     // If the refinement is better than the current rule...
-                    if (head != nullptr) {
-                        bestHead = head;
+                    if (isBetterThanBestHead(scoreVector, bestHead)) {
+                        bestHead = scoreProcessor.processScores(scoreVector);
                         refinementPtr->start = firstR;
                         refinementPtr->end = r;
                         refinementPtr->previous = previousR;
@@ -257,11 +255,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
 
                     // Find and evaluate the best head for the current refinement, if a condition that uses the <=
                     // operator (or the != operator in case of a nominal feature) is used...
-                    head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+                    const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
                     // If the refinement is better than the current rule...
-                    if (head != nullptr) {
-                        bestHead = head;
+                    if (isBetterThanBestHead(scoreVector2, bestHead)) {
+                        bestHead = scoreProcessor.processScores(scoreVector2);
                         refinementPtr->start = firstR;
                         refinementPtr->end = r;
                         refinementPtr->previous = previousR;
@@ -303,11 +301,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
     if (nominal_ && numExamples > 0 && numExamples < accumulatedNumExamples) {
         // Find and evaluate the best head for the current refinement, if a condition that uses the == operator is
         // used...
-        const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false, false);
+        const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, false);
 
         // If the refinement is better than the current rule...
-        if (head != nullptr) {
-            bestHead = head;
+        if (isBetterThanBestHead(scoreVector, bestHead)) {
+            bestHead = scoreProcessor.processScores(scoreVector);
             refinementPtr->start = firstR;
             refinementPtr->end = lastNegativeR;
             refinementPtr->previous = previousR;
@@ -319,11 +317,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
 
         // Find and evaluate the best head for the current refinement, if a condition that uses the != operator is
         // used...
-        head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, false);
+        const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, false);
 
         // If the refinement is better than the current rule...
-        if (head != nullptr) {
-            bestHead = head;
+        if (isBetterThanBestHead(scoreVector2, bestHead)) {
+            bestHead = scoreProcessor.processScores(scoreVector2);
             refinementPtr->start = firstR;
             refinementPtr->end = lastNegativeR;
             refinementPtr->previous = previousR;
@@ -350,12 +348,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
 
         // Find and evaluate the best head for the current refinement, if the condition `f > previous_threshold / 2` (or
         // the condition `f != 0` in case of a nominal feature) is used...
-        const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false,
-                                                                          nominal_);
+        const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, nominal_);
 
         // If the refinement is better than the current rule...
-        if (head != nullptr) {
-            bestHead = head;
+        if (isBetterThanBestHead(scoreVector, bestHead)) {
+            bestHead = scoreProcessor.processScores(scoreVector);
             refinementPtr->start = firstR;
             refinementPtr->covered = true;
 
@@ -376,11 +373,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
 
         // Find and evaluate the best head for the current refinement, if the condition `f <= previous_threshold / 2`
         // (or `f == 0` in case of a nominal feature) is used...
-        head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, nominal_);
+        const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, nominal_);
 
         // If the refinement is better than the current rule...
-        if (head != nullptr) {
-            bestHead = head;
+        if (isBetterThanBestHead(scoreVector2, bestHead)) {
+            bestHead = scoreProcessor.processScores(scoreVector2);
             refinementPtr->start = firstR;
             refinementPtr->covered = false;
 
@@ -408,11 +405,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
     if (!nominal_ && accumulatedNumExamplesNegative > 0 && accumulatedNumExamplesNegative < numExamples_) {
         // Find and evaluate the best head for the current refinement, if the condition that uses the <= operator is
         // used...
-        const AbstractEvaluatedPrediction* head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, false, true);
+        const IScoreVector& scoreVector = statisticsSubsetPtr->calculatePrediction(false, true);
 
         // If the refinement is better than the current rule...
-        if (head != nullptr) {
-            bestHead = head;
+        if (isBetterThanBestHead(scoreVector, bestHead)) {
+            bestHead = scoreProcessor.processScores(scoreVector);
             refinementPtr->start = 0;
             refinementPtr->end = (lastNegativeR + 1);
             refinementPtr->previous = previousRNegative;
@@ -432,11 +429,11 @@ void ExactRuleRefinement<T>::findRefinement(const AbstractEvaluatedPrediction* c
 
         // Find and evaluate the best head for the current refinement, if the condition that uses the > operator is
         // used...
-        head = scoreProcessor.findHead(bestHead, *statisticsSubsetPtr, true, true);
+        const IScoreVector& scoreVector2 = statisticsSubsetPtr->calculatePrediction(true, true);
 
         // If the refinement is better than the current rule...
-        if (head != nullptr) {
-            bestHead = head;
+        if (isBetterThanBestHead(scoreVector2, bestHead)) {
+            bestHead = scoreProcessor.processScores(scoreVector2);
             refinementPtr->start = 0;
             refinementPtr->end = (lastNegativeR + 1);
             refinementPtr->previous = previousRNegative;

--- a/cpp/subprojects/common/src/common/rule_refinement/score_processor.cpp
+++ b/cpp/subprojects/common/src/common/rule_refinement/score_processor.cpp
@@ -6,84 +6,65 @@
 
 template<typename T>
 const AbstractEvaluatedPrediction* processCompleteScores(std::unique_ptr<AbstractEvaluatedPrediction>& existingHeadPtr,
-                                                         const AbstractEvaluatedPrediction* bestHead,
                                                          const T& scoreVector) {
-    float64 overallQualityScore = scoreVector.overallQualityScore;
-
-    // The quality score must be better than that of `bestHead`...
-    if (bestHead == nullptr || overallQualityScore < bestHead->overallQualityScore) {
-        if (existingHeadPtr.get() == nullptr) {
-            // Create a new head, if necessary...
-            uint32 numElements = scoreVector.getNumElements();
-            existingHeadPtr = std::make_unique<CompletePrediction>(numElements);
-        }
-
-        std::copy(scoreVector.scores_cbegin(), scoreVector.scores_cend(), existingHeadPtr->scores_begin());
-        existingHeadPtr->overallQualityScore = overallQualityScore;
-        return existingHeadPtr.get();
+    if (existingHeadPtr.get() == nullptr) {
+        // Create a new head, if necessary...
+        uint32 numElements = scoreVector.getNumElements();
+        existingHeadPtr = std::make_unique<CompletePrediction>(numElements);
     }
 
-    return nullptr;
+    std::copy(scoreVector.scores_cbegin(), scoreVector.scores_cend(), existingHeadPtr->scores_begin());
+    existingHeadPtr->overallQualityScore = scoreVector.overallQualityScore;
+    return existingHeadPtr.get();
 }
 
 template<typename T>
 const AbstractEvaluatedPrediction* processPartialScores(std::unique_ptr<AbstractEvaluatedPrediction>& existingHeadPtr,
-                                                        const AbstractEvaluatedPrediction* bestHead,
                                                         const T& scoreVector) {
-    float64 overallQualityScore = scoreVector.overallQualityScore;
+    PartialPrediction* existingHead = (PartialPrediction*) existingHeadPtr.get();
 
-    // The quality score must be better than that of `bestHead`...
-    if (bestHead == nullptr || overallQualityScore < bestHead->overallQualityScore) {
-        PartialPrediction* existingHead = (PartialPrediction*) existingHeadPtr.get();
+    if (existingHead == nullptr) {
+        // Create a new head, if necessary...
+        uint32 numElements = scoreVector.getNumElements();
+        existingHeadPtr = std::make_unique<PartialPrediction>(numElements);
+        existingHead = (PartialPrediction*) existingHeadPtr.get();
+    } else {
+        // Adjust the size of the existing head, if necessary...
+        uint32 numElements = scoreVector.getNumElements();
 
-        if (existingHead == nullptr) {
-            // Create a new head, if necessary...
-            uint32 numElements = scoreVector.getNumElements();
-            existingHeadPtr = std::make_unique<PartialPrediction>(numElements);
-            existingHead = (PartialPrediction*) existingHeadPtr.get();
-        } else {
-            // Adjust the size of the existing head, if necessary...
-            uint32 numElements = scoreVector.getNumElements();
-
-            if (existingHead->getNumElements() != numElements) {
-                existingHead->setNumElements(numElements, false);
-            }
+        if (existingHead->getNumElements() != numElements) {
+            existingHead->setNumElements(numElements, false);
         }
-
-        std::copy(scoreVector.scores_cbegin(), scoreVector.scores_cend(), existingHead->scores_begin());
-        std::copy(scoreVector.indices_cbegin(), scoreVector.indices_cend(), existingHead->indices_begin());
-        existingHead->overallQualityScore = overallQualityScore;
-        return existingHead;
     }
 
-    return nullptr;
+    std::copy(scoreVector.scores_cbegin(), scoreVector.scores_cend(), existingHead->scores_begin());
+    std::copy(scoreVector.indices_cbegin(), scoreVector.indices_cend(), existingHead->indices_begin());
+    existingHead->overallQualityScore = scoreVector.overallQualityScore;
+    return existingHead;
 }
 
 const AbstractEvaluatedPrediction* ScoreProcessor::processScores(
-        const AbstractEvaluatedPrediction* bestHead, const DenseScoreVector<CompleteIndexVector>& scoreVector) {
-    return processCompleteScores(headPtr_, bestHead, scoreVector);
+        const DenseScoreVector<CompleteIndexVector>& scoreVector) {
+    return processCompleteScores(headPtr_, scoreVector);
 }
 
 const AbstractEvaluatedPrediction* ScoreProcessor::processScores(
-        const AbstractEvaluatedPrediction* bestHead, const DenseScoreVector<PartialIndexVector>& scoreVector) {
-    return processPartialScores(headPtr_, bestHead, scoreVector);
+        const DenseScoreVector<PartialIndexVector>& scoreVector) {
+    return processPartialScores(headPtr_, scoreVector);
 }
 
 const AbstractEvaluatedPrediction* ScoreProcessor::processScores(
-        const AbstractEvaluatedPrediction* bestHead, const DenseBinnedScoreVector<CompleteIndexVector>& scoreVector) {
-    return processCompleteScores(headPtr_, bestHead, scoreVector);
+        const DenseBinnedScoreVector<CompleteIndexVector>& scoreVector) {
+    return processCompleteScores(headPtr_, scoreVector);
 }
 
 const AbstractEvaluatedPrediction* ScoreProcessor::processScores(
-        const AbstractEvaluatedPrediction* bestHead, const DenseBinnedScoreVector<PartialIndexVector>& scoreVector) {
-    return processPartialScores(headPtr_, bestHead, scoreVector);
+        const DenseBinnedScoreVector<PartialIndexVector>& scoreVector) {
+    return processPartialScores(headPtr_, scoreVector);
 }
 
-const AbstractEvaluatedPrediction* ScoreProcessor::findHead(const AbstractEvaluatedPrediction* bestHead,
-                                                            IStatisticsSubset& statisticsSubset, bool uncovered,
-                                                            bool accumulated) {
-    const IScoreVector& scoreVector = statisticsSubset.calculatePrediction(uncovered, accumulated);
-    return scoreVector.processScores(bestHead, *this);
+const AbstractEvaluatedPrediction* ScoreProcessor::processScores(const IScoreVector& scoreVector) {
+    return scoreVector.processScores(*this);
 }
 
 std::unique_ptr<AbstractEvaluatedPrediction> ScoreProcessor::pollHead() {


### PR DESCRIPTION
Vereinfacht die Klasse `ScoreProcessor` indem diese ab sofort nicht mehr für den Vergleich der Qualität verschiedener Vorhersagen zuständig ist. Stattdessen wird für diesen Vergleich die neue Hilfsfunktion `isBetterThanBestHead` (in der Datei `rule_refinement_common.hpp` verwendet).