### PR TITLE
Bugfix der "difference"-Funktion in Klasse "DenseExampleWiseStatisticVector".

### DIFF
--- a/cpp/subprojects/boosting/src/boosting/data/statistic_vector_dense_example_wise.cpp
+++ b/cpp/subprojects/boosting/src/boosting/data/statistic_vector_dense_example_wise.cpp
@@ -169,8 +169,8 @@ namespace boosting {
 
         for (uint32 i = 0; i < numGradients_; i++) {
             uint32 index = indexIterator[i];
-            uint32 offset = triangularNumber(index);
-            addToArray(&hessians_[triangularNumber(i)], &hessiansBegin[offset], indexIterator, i + 1, weight);
+            addToArray(&hessians_[triangularNumber(i)], &hessiansBegin[triangularNumber(index)], indexIterator, i + 1,
+                       weight);
         }
     }
 
@@ -200,9 +200,9 @@ namespace boosting {
         setArrayToDifference(gradients_, firstGradientsBegin, secondGradientsBegin, indexIterator, numGradients_);
 
         for (uint32 i = 0; i < numGradients_; i++) {
+            uint32 offset = triangularNumber(i);
             uint32 index = indexIterator[i];
-            uint32 offset = triangularNumber(index);
-            setArrayToDifference(&hessians_[triangularNumber(i)], &firstHessiansBegin[offset],
+            setArrayToDifference(&hessians_[offset], &firstHessiansBegin[triangularNumber(index)],
                                  &secondHessiansBegin[offset], indexIterator, i + 1);
         }
     }


### PR DESCRIPTION
Korrigiert die Funktionsweise der Funktion `difference` der Klasse `DenseExampleWiseStatisticVector`, die ein Objekt vom Typ `PartialIndexVector` als Argument entgegen nimmt. Die bisherige Implementierung dieser Funktion hatte eine fehlerhafte Berechnung der Hessians zur Folge.