### PR TITLE
Refactoring bezüglich der Klasse "IEvaluationMeasure"

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/statistics/statistics_provider_factory_example_wise_dense.hpp
+++ b/cpp/subprojects/boosting/include/boosting/statistics/statistics_provider_factory_example_wise_dense.hpp
@@ -4,8 +4,9 @@
  */
 #pragma once
 
-#include "boosting/statistics/statistics_example_wise.hpp"
 #include "common/statistics/statistics_provider_factory.hpp"
+#include "common/measures/measure_evaluation.hpp"
+#include "boosting/statistics/statistics_example_wise.hpp"
 #include "boosting/losses/loss_example_wise.hpp"
 
 
@@ -21,6 +22,8 @@ namespace boosting {
 
             std::unique_ptr<IExampleWiseLoss> lossFunctionPtr_;
 
+            std::unique_ptr<IEvaluationMeasure> evaluationMeasurePtr_;
+
             std::unique_ptr<IExampleWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr_;
 
             std::unique_ptr<IExampleWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr_;
@@ -34,6 +37,9 @@ namespace boosting {
             /**
              * @param lossFunctionPtr                   An unique pointer to an object of type `IExampleWiseLoss` that
              *                                          should be used for calculating gradients and Hessians
+             * @param evaluationMeasurePtr              An unique pointer to an object of type `IEvaluationMeasure` that
+             *                                          implements the evaluation measure that should be used to assess
+             *                                          the quality of predictions
              * @param defaultRuleEvaluationFactoryPtr   An unique pointer to an object of type
              *                                          `IExampleWiseRuleEvaluationFactory` that should be used for
              *                                          calculating the predictions, as well as corresponding quality
@@ -51,6 +57,7 @@ namespace boosting {
              */
             DenseExampleWiseStatisticsProviderFactory(
                 std::unique_ptr<IExampleWiseLoss> lossFunctionPtr,
+                std::unique_ptr<IEvaluationMeasure> evaluationMeasurePtr,
                 std::unique_ptr<IExampleWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
                 std::unique_ptr<IExampleWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
                 std::unique_ptr<IExampleWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr, uint32 numThreads);
@@ -72,6 +79,8 @@ namespace boosting {
 
             std::unique_ptr<IExampleWiseLoss> lossFunctionPtr_;
 
+            std::unique_ptr<IEvaluationMeasure> evaluationMeasurePtr_;
+
             std::unique_ptr<IExampleWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr_;
 
             std::unique_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr_;
@@ -85,6 +94,9 @@ namespace boosting {
             /**
              * @param lossFunctionPtr                   An unique pointer to an object of type `IExampleWiseLoss` that
              *                                          should be used for calculating gradients and Hessians
+             * @param evaluationMeasurePtr              An unique pointer to an object of type `IEvaluationMeasure` that
+             *                                          implements the evaluation measure that should be used to assess
+             *                                          the quality of predictions
              * @param defaultRuleEvaluationFactoryPtr   An unique pointer to an object of type
              *                                          `IExampleWiseRuleEvaluationFactory` that should be used for
              *                                          calculating the predictions, as well as corresponding quality
@@ -102,6 +114,7 @@ namespace boosting {
              */
             DenseConvertibleExampleWiseStatisticsProviderFactory(
                 std::unique_ptr<IExampleWiseLoss> lossFunctionPtr,
+                std::unique_ptr<IEvaluationMeasure> evaluationMeasurePtr,
                 std::unique_ptr<IExampleWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
                 std::unique_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
                 std::unique_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr, uint32 numThreads);

--- a/cpp/subprojects/boosting/include/boosting/statistics/statistics_provider_factory_label_wise_dense.hpp
+++ b/cpp/subprojects/boosting/include/boosting/statistics/statistics_provider_factory_label_wise_dense.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common/statistics/statistics_provider_factory.hpp"
+#include "common/measures/measure_evaluation.hpp"
 #include "boosting/statistics/statistics_label_wise.hpp"
 #include "boosting/losses/loss_label_wise.hpp"
 
@@ -21,6 +22,8 @@ namespace boosting {
 
             std::unique_ptr<ILabelWiseLoss> lossFunctionPtr_;
 
+            std::unique_ptr<IEvaluationMeasure> evaluationMeasurePtr_;
+
             std::unique_ptr<ILabelWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr_;
 
             std::unique_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr_;
@@ -34,6 +37,9 @@ namespace boosting {
             /**
              * @param lossFunctionPtr                   An unique pointer to an object of type `ILabelWiseLoss` that
              *                                          should be used for calculating gradients and Hessians
+             * @param evaluationMeasurePtr              An unique pointer to an object of type `IEvaluationMeasure` that
+             *                                          implements the evaluation measure that should be used to assess
+             *                                          the quality of predictions
              * @param defaultRuleEvaluationFactoryPtr   An unique pointer to an object of type
              *                                          `ILabelWiseRuleEvaluationFactory` that should be used for
              *                                          calculating the predictions, as well as corresponding quality
@@ -51,6 +57,7 @@ namespace boosting {
              */
             DenseLabelWiseStatisticsProviderFactory(
                 std::unique_ptr<ILabelWiseLoss> lossFunctionPtr,
+                std::unique_ptr<IEvaluationMeasure> evaluationMeasurePtr,
                 std::unique_ptr<ILabelWiseRuleEvaluationFactory> defaultRuleEvaluationFactoryPtr,
                 std::unique_ptr<ILabelWiseRuleEvaluationFactory> regularRuleEvaluationFactoryPtr,
                 std::unique_ptr<ILabelWiseRuleEvaluationFactory> pruningRuleEvaluationFactoryPtr, uint32 numThreads);

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_common.hpp
@@ -297,6 +297,8 @@ namespace boosting {
      * @tparam StatisticMatrix                  The type of the matrix that stores the gradients and Hessians
      * @tparam ScoreMatrix                      The type of the matrices that are used to store predicted scores
      * @tparam LossFunction                     The type of the loss function that is used to calculate gradients and Hessians
+     * @tparam EvaluationMeasure                The type of the evaluation measure that is used to assess the quality of
+     *                                          predictions for a specific statistic
      * @tparam LabelWiseRuleEvaluationFactory   The type of the classes that may be used for calculating the label-wise
      *                                          predictions, as well as corresponding quality scores, of rules
      * @tparam ExampleWiseRuleEvaluationFactory The type of the classes that may be used for calculating the
@@ -304,8 +306,8 @@ namespace boosting {
      *                                          rules
      */
     template<typename LabelMatrix, typename StatisticVector, typename StatisticView, typename StatisticMatrix,
-             typename ScoreMatrix, typename LossFunction, typename ExampleWiseRuleEvaluationFactory,
-             typename LabelWiseRuleEvaluationFactory>
+             typename ScoreMatrix, typename LossFunction, typename EvaluationMeasure,
+             typename ExampleWiseRuleEvaluationFactory, typename LabelWiseRuleEvaluationFactory>
     class AbstractExampleWiseStatistics : public AbstractExampleWiseImmutableStatistics<StatisticVector, StatisticView,
                                                                                         StatisticMatrix, ScoreMatrix,
                                                                                         ExampleWiseRuleEvaluationFactory>,
@@ -320,6 +322,8 @@ namespace boosting {
 
             const LossFunction& lossFunction_;
 
+            const EvaluationMeasure& evaluationMeasure_;
+
             const LabelMatrix& labelMatrix_;
 
             std::unique_ptr<ScoreMatrix> scoreMatrixPtr_;
@@ -329,6 +333,9 @@ namespace boosting {
             /**
              * @param lossFunction          A reference to an object of template type `LossFunction`, representing the
              *                              loss function to be used for calculating gradients and Hessians
+             * @param evaluationMeasure     A reference to an object of template type `EvaluationMeasure` that
+             *                              implements the evaluation measure that should be used to assess the quality
+             *                              of predictions for a specific statistic
              * @param ruleEvaluationFactory A reference to an object of template type
              *                              `ExampleWiseRuleEvaluationFactory`, to be used for calculating the
              *                              predictions, as well as corresponding quality scores, of rules
@@ -339,7 +346,7 @@ namespace boosting {
              * @param scoreMatrixPtr        An unique pointer to an object of template type `ScoreMatrix` that stores
              *                              the currently predicted scores
              */
-            AbstractExampleWiseStatistics(const LossFunction& lossFunction,
+            AbstractExampleWiseStatistics(const LossFunction& lossFunction, const EvaluationMeasure& evaluationMeasure,
                                           const ExampleWiseRuleEvaluationFactory& ruleEvaluationFactory,
                                           const LabelMatrix& labelMatrix,
                                           std::unique_ptr<StatisticView> statisticViewPtr,
@@ -348,7 +355,8 @@ namespace boosting {
                                                          ExampleWiseRuleEvaluationFactory>(
                       std::move(statisticViewPtr), ruleEvaluationFactory),
                   totalSumVectorPtr_(std::make_unique<StatisticVector>(this->statisticViewPtr_->getNumCols())),
-                  lossFunction_(lossFunction), labelMatrix_(labelMatrix), scoreMatrixPtr_(std::move(scoreMatrixPtr)) {
+                  lossFunction_(lossFunction), evaluationMeasure_(evaluationMeasure), labelMatrix_(labelMatrix),
+                  scoreMatrixPtr_(std::move(scoreMatrixPtr)) {
 
             }
 
@@ -416,8 +424,8 @@ namespace boosting {
             /**
              * @see `IStatistics::evaluatePrediction`
              */
-            float64 evaluatePrediction(uint32 statisticIndex, const IEvaluationMeasure& measure) const override final {
-                return measure.evaluate(statisticIndex, labelMatrix_, *scoreMatrixPtr_);
+            float64 evaluatePrediction(uint32 statisticIndex) const override final {
+                return evaluationMeasure_.evaluate(statisticIndex, labelMatrix_, *scoreMatrixPtr_);
             }
 
             /**

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_dense.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_dense.hpp
@@ -6,6 +6,7 @@
 #include "boosting/data/statistic_vector_label_wise_dense.hpp"
 #include "boosting/data/statistic_view_label_wise_dense.hpp"
 #include "boosting/losses/loss_label_wise.hpp"
+#include "common/measures/measure_evaluation.hpp"
 #include "statistics_label_wise_common.hpp"
 #include <cstdlib>
 
@@ -49,7 +50,7 @@ namespace boosting {
                                                                               DenseLabelWiseStatisticView,
                                                                               DenseLabelWiseStatisticMatrix,
                                                                               NumericDenseMatrix<float64>,
-                                                                              ILabelWiseLoss,
+                                                                              ILabelWiseLoss, IEvaluationMeasure,
                                                                               ILabelWiseRuleEvaluationFactory> {
 
         public:
@@ -57,6 +58,9 @@ namespace boosting {
             /**
              * @param lossFunction          A reference to an object of type `ILabelWiseLoss`, representing the loss
              *                              function to be used for calculating gradients and Hessians
+             * @param evaluationMeasure     A reference to an object of type `IEvaluationMeasure` that implements the
+             *                              evaluation measure that should be used to assess the quality of predictions
+             *                              for a specific statistic
              * @param ruleEvaluationFactory A reference to an object of type `ILabelWiseRuleEvaluationFactory`, that
              *                              allows to create instances of the class that is used for calculating the
              *                              predictions, as well as corresponding quality scores, of rules
@@ -67,15 +71,15 @@ namespace boosting {
              * @param scoreMatrixPtr        An unique pointer to an object of type `NumericDenseMatrix` that stores the
              *                              currently predicted scores
              */
-            DenseLabelWiseStatistics(const ILabelWiseLoss& lossFunction,
+            DenseLabelWiseStatistics(const ILabelWiseLoss& lossFunction, const IEvaluationMeasure& evaluationMeasure,
                                      const ILabelWiseRuleEvaluationFactory& ruleEvaluationFactory,
                                      const LabelMatrix& labelMatrix,
                                      std::unique_ptr<DenseLabelWiseStatisticView> statisticViewPtr,
                                      std::unique_ptr<NumericDenseMatrix<float64>> scoreMatrixPtr)
                 : AbstractLabelWiseStatistics<LabelMatrix, DenseLabelWiseStatisticVector, DenseLabelWiseStatisticView,
                                               DenseLabelWiseStatisticMatrix, NumericDenseMatrix<float64>,
-                                              ILabelWiseLoss, ILabelWiseRuleEvaluationFactory>(
-                      lossFunction, ruleEvaluationFactory, labelMatrix, std::move(statisticViewPtr),
+                                              ILabelWiseLoss, IEvaluationMeasure, ILabelWiseRuleEvaluationFactory>(
+                      lossFunction, evaluationMeasure, ruleEvaluationFactory, labelMatrix, std::move(statisticViewPtr),
                       std::move(scoreMatrixPtr)) {
 
             }

--- a/cpp/subprojects/common/include/common/statistics/statistics.hpp
+++ b/cpp/subprojects/common/include/common/statistics/statistics.hpp
@@ -7,7 +7,6 @@
 #include "common/statistics/histogram.hpp"
 #include "common/rule_refinement/prediction_complete.hpp"
 #include "common/rule_refinement/prediction_partial.hpp"
-#include "common/measures/measure_evaluation.hpp"
 
 
 /**
@@ -111,14 +110,12 @@ class IStatistics : virtual public IImmutableStatistics {
 
         /**
          * Calculates and returns a numeric score that assesses the quality of the current predictions for a specific
-         * statistic in terms of a given measure.
+         * statistic.
          *
          * @param statisticIndex    The index of the statistic for which the predictions should be evaluated
-         * @param measure           A reference to an object of type `IEvaluationMeasure` that should be used to assess
-         *                          the quality of the predictions
          * @return                  The numeric score that has been calculated
          */
-        virtual float64 evaluatePrediction(uint32 statisticIndex, const IEvaluationMeasure& measure) const = 0;
+        virtual float64 evaluatePrediction(uint32 statisticIndex) const = 0;
 
         /**
          * Creates and returns a new histogram based on the statistics.

--- a/cpp/subprojects/common/include/common/stopping/stopping_criterion_measure.hpp
+++ b/cpp/subprojects/common/include/common/stopping/stopping_criterion_measure.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "common/stopping/stopping_criterion.hpp"
-#include "common/measures/measure_evaluation.hpp"
 #include "common/data/ring_buffer.hpp"
 #include <memory>
 
@@ -83,8 +82,6 @@ class MeasureStoppingCriterion final : public IStoppingCriterion {
 
     private:
 
-        std::unique_ptr<IEvaluationMeasure> measurePtr_;
-
         std::unique_ptr<IAggregationFunction> aggregationFunctionPtr_;
 
         uint32 updateInterval_;
@@ -110,8 +107,6 @@ class MeasureStoppingCriterion final : public IStoppingCriterion {
     public:
 
         /**
-         * @param measurePtr                An unique pointer to an object of type `IEvaluationMeasure` that should be
-         *                                  used to assess the quality of a model
          * @param aggregationFunctionPtr    An unique pointer to an object of type `IAggregationFunction` that should be
          *                                  used to aggregate the scores in the buffer
          * @param minRules                  The minimum number of rules that must have been learned until the induction
@@ -132,8 +127,7 @@ class MeasureStoppingCriterion final : public IStoppingCriterion {
          *                                  stopping criterion is met, false, if the time of stopping should only be
          *                                  stored
          */
-        MeasureStoppingCriterion(std::unique_ptr<IEvaluationMeasure> measurePtr,
-                                 std::unique_ptr<IAggregationFunction> aggregationFunctionPtr, uint32 minRules,
+        MeasureStoppingCriterion(std::unique_ptr<IAggregationFunction> aggregationFunctionPtr, uint32 minRules,
                                  uint32 updateInterval, uint32 stopInterval, uint32 numPast, uint32 numCurrent,
                                  float64 minImprovement, bool forceStop);
 

--- a/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_common.hpp
@@ -284,7 +284,7 @@ namespace seco {
             /**
              * @see `IStatistics::evaluatePrediction`
              */
-            float64 evaluatePrediction(uint32 statisticIndex, const IEvaluationMeasure& measure) const override final {
+            float64 evaluatePrediction(uint32 statisticIndex) const override final {
                 // TODO Support evaluation of predictions
                 return 0;
             }

--- a/python/mlrl/boosting/boosting_learners.py
+++ b/python/mlrl/boosting/boosting_learners.py
@@ -281,6 +281,7 @@ class Boomer(MLRuleLearner, ClassifierMixin):
             self.__get_preferred_parallel_statistic_update(head_type=default_rule_head_type),
             'parallel_statistic_update')
         loss_function = self.__create_loss_function()
+        evaluation_measure = self.__create_loss_function()
         label_binning_factory = self.__create_label_binning_factory()
 
         if label_binning_factory is not None and head_type == HEAD_TYPE_SINGLE:
@@ -295,18 +296,20 @@ class Boomer(MLRuleLearner, ClassifierMixin):
                                                                                 self.__create_label_binning_factory())
 
         if isinstance(loss_function, LabelWiseLoss):
-            return DenseLabelWiseStatisticsProviderFactory(loss_function, default_rule_evaluation_factory,
+            return DenseLabelWiseStatisticsProviderFactory(loss_function, evaluation_measure,
+                                                           default_rule_evaluation_factory,
                                                            regular_rule_evaluation_factory,
                                                            pruning_rule_evaluation_factory, num_threads)
         else:
             if head_type == HEAD_TYPE_SINGLE:
-                return DenseConvertibleExampleWiseStatisticsProviderFactory(loss_function,
+                return DenseConvertibleExampleWiseStatisticsProviderFactory(loss_function, evaluation_measure,
                                                                             default_rule_evaluation_factory,
                                                                             regular_rule_evaluation_factory,
                                                                             pruning_rule_evaluation_factory,
                                                                             num_threads)
             else:
-                return DenseExampleWiseStatisticsProviderFactory(loss_function, default_rule_evaluation_factory,
+                return DenseExampleWiseStatisticsProviderFactory(loss_function, evaluation_measure,
+                                                                 default_rule_evaluation_factory,
                                                                  regular_rule_evaluation_factory,
                                                                  pruning_rule_evaluation_factory, num_threads)
 
@@ -370,7 +373,6 @@ class Boomer(MLRuleLearner, ClassifierMixin):
                                 + 'set to "None"!')
                     return None
                 else:
-                    loss = self.__create_loss_function()
                     aggregation_function = self.__create_aggregation_function(
                         options.get_string(ARGUMENT_AGGREGATION_FUNCTION, 'avg'))
                     min_rules = options.get_int(ARGUMENT_MIN_RULES, 100)
@@ -380,7 +382,7 @@ class Boomer(MLRuleLearner, ClassifierMixin):
                     num_recent = options.get_int(ARGUMENT_NUM_RECENT, 50)
                     min_improvement = options.get_float(ARGUMENT_MIN_IMPROVEMENT, 0.005)
                     force_stop = options.get_bool(ARGUMENT_FORCE_STOP, True)
-                    return MeasureStoppingCriterion(loss, aggregation_function, min_rules=min_rules,
+                    return MeasureStoppingCriterion(aggregation_function, min_rules=min_rules,
                                                     update_interval=update_interval, stop_interval=stop_interval,
                                                     num_past=num_past, num_recent=num_recent,
                                                     min_improvement=min_improvement, force_stop=force_stop)

--- a/python/mlrl/boosting/cython/statistics_example_wise.pxd
+++ b/python/mlrl/boosting/cython/statistics_example_wise.pxd
@@ -1,3 +1,4 @@
+from mlrl.common.cython._measures cimport IEvaluationMeasure
 from mlrl.common.cython.statistics cimport StatisticsProviderFactory, IStatisticsProviderFactory
 from mlrl.boosting.cython.losses_example_wise cimport IExampleWiseLoss
 from mlrl.boosting.cython.rule_evaluation_example_wise cimport IExampleWiseRuleEvaluationFactory
@@ -14,7 +15,7 @@ cdef extern from "boosting/statistics/statistics_provider_factory_example_wise_d
         # Constructors:
 
         DenseExampleWiseStatisticsProviderFactoryImpl(
-            unique_ptr[IExampleWiseLoss] lossFunctionPtr,
+            unique_ptr[IExampleWiseLoss] lossFunctionPtr, unique_ptr[IEvaluationMeasure] evaluationMeasurePtr,
             unique_ptr[IExampleWiseRuleEvaluationFactory] defaultRuleEvaluationFactoryPtr,
             unique_ptr[IExampleWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr,
             unique_ptr[IExampleWiseRuleEvaluationFactory] pruningRuleEvaluationFactoryPtr) except +
@@ -26,7 +27,7 @@ cdef extern from "boosting/statistics/statistics_provider_factory_example_wise_d
         # Constructors:
 
         DenseConvertibleExampleWiseStatisticsProviderFactoryImpl(
-            unique_ptr[IExampleWiseLoss] lossFunctionPtr,
+            unique_ptr[IExampleWiseLoss] lossFunctionPtr, unique_ptr[IEvaluationMeasure] evaluationMeasurePtr,
             unique_ptr[IExampleWiseRuleEvaluationFactory] defaultRuleEvaluationFactoryPtr,
             unique_ptr[ILabelWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr,
             unique_ptr[ILabelWiseRuleEvaluationFactory] pruningRuleEvaluationFactoryPtr) except +

--- a/python/mlrl/boosting/cython/statistics_example_wise.pyx
+++ b/python/mlrl/boosting/cython/statistics_example_wise.pyx
@@ -2,6 +2,7 @@
 @author Michael Rapp (mrapp@ke.tu-darmstadt.de)
 """
 from mlrl.common.cython._types cimport uint32
+from mlrl.common.cython.measures cimport EvaluationMeasure
 from mlrl.boosting.cython.losses_example_wise cimport ExampleWiseLoss
 from mlrl.boosting.cython.rule_evaluation_example_wise cimport ExampleWiseRuleEvaluationFactory
 from mlrl.boosting.cython.rule_evaluation_label_wise cimport LabelWiseRuleEvaluationFactory
@@ -15,12 +16,14 @@ cdef class DenseExampleWiseStatisticsProviderFactory(StatisticsProviderFactory):
     A wrapper for the C++ class `DenseExampleWiseStatisticsProviderFactory`.
     """
 
-    def __cinit__(self, ExampleWiseLoss loss_function not None,
+    def __cinit__(self, ExampleWiseLoss loss_function not None, EvaluationMeasure evaluation_measure not None,
                   ExampleWiseRuleEvaluationFactory default_rule_evaluation_factory not None,
                   ExampleWiseRuleEvaluationFactory regular_rule_evaluation_factory not None,
                   ExampleWiseRuleEvaluationFactory pruning_rule_evaluation_factory not None, uint32 num_threads):
         """
         :param loss_function:                   The loss function to be used for calculating gradients and Hessians
+        :param evaluation_measure:              The evaluation measure to be used for assessing the quality of
+                                                predictions
         :param default_rule_evaluation_factory: The `ExampleWiseRuleEvaluation` to be used for calculating the
                                                 predictions, as well as corresponding quality scores, of the default
                                                 rule
@@ -35,7 +38,8 @@ cdef class DenseExampleWiseStatisticsProviderFactory(StatisticsProviderFactory):
                                                 in parallel. Must be at least 1
         """
         self.statistics_provider_factory_ptr = <unique_ptr[IStatisticsProviderFactory]>make_unique[DenseExampleWiseStatisticsProviderFactoryImpl](
-            move(loss_function.loss_function_ptr), move(default_rule_evaluation_factory.rule_evaluation_factory_ptr),
+            move(loss_function.loss_function_ptr), move(evaluation_measure.get_evaluation_measure_ptr()),
+            move(default_rule_evaluation_factory.rule_evaluation_factory_ptr),
             move(regular_rule_evaluation_factory.rule_evaluation_factory_ptr),
             move(pruning_rule_evaluation_factory.rule_evaluation_factory_ptr), num_threads)
 
@@ -45,12 +49,14 @@ cdef class DenseConvertibleExampleWiseStatisticsProviderFactory(StatisticsProvid
     A wrapper for the C++ class `DenseConvertibleExampleWiseStatisticsProviderFactory`.
     """
 
-    def __cinit__(self, ExampleWiseLoss loss_function not None,
+    def __cinit__(self, ExampleWiseLoss loss_function not None, EvaluationMeasure evaluation_measure not None,
                   ExampleWiseRuleEvaluationFactory default_rule_evaluation_factory not None,
                   LabelWiseRuleEvaluationFactory regular_rule_evaluation_factory not None,
                   LabelWiseRuleEvaluationFactory pruning_rule_evaluation_factory not None, uint32 num_threads):
         """
         :param loss_function:                   The loss function to be used for calculating gradients and Hessians
+        :param evaluation_measure:              The evaluation measure to be used for assessing the quality of
+                                                predictions
         :param default_rule_evaluation_factory: The `ExampleWiseRuleEvaluation` to be used for calculating the
                                                 predictions, as well as corresponding quality scores, of the default
                                                 rule
@@ -65,6 +71,7 @@ cdef class DenseConvertibleExampleWiseStatisticsProviderFactory(StatisticsProvid
                                                 in parallel. Must be at least 1
         """
         self.statistics_provider_factory_ptr = <unique_ptr[IStatisticsProviderFactory]>make_unique[DenseConvertibleExampleWiseStatisticsProviderFactoryImpl](
-            move(loss_function.loss_function_ptr), move(default_rule_evaluation_factory.rule_evaluation_factory_ptr),
+            move(loss_function.loss_function_ptr), move(evaluation_measure.get_evaluation_measure_ptr()),
+            move(default_rule_evaluation_factory.rule_evaluation_factory_ptr),
             move(regular_rule_evaluation_factory.rule_evaluation_factory_ptr),
             move(pruning_rule_evaluation_factory.rule_evaluation_factory_ptr), num_threads)

--- a/python/mlrl/boosting/cython/statistics_label_wise.pxd
+++ b/python/mlrl/boosting/cython/statistics_label_wise.pxd
@@ -1,3 +1,4 @@
+from mlrl.common.cython._measures cimport IEvaluationMeasure
 from mlrl.common.cython.statistics cimport StatisticsProviderFactory, IStatisticsProviderFactory
 from mlrl.boosting.cython.losses_label_wise cimport ILabelWiseLoss
 from mlrl.boosting.cython.rule_evaluation_label_wise cimport ILabelWiseRuleEvaluationFactory
@@ -13,7 +14,7 @@ cdef extern from "boosting/statistics/statistics_provider_factory_label_wise_den
         # Constructors:
 
         DenseLabelWiseStatisticsProviderFactoryImpl(
-            unique_ptr[ILabelWiseLoss] lossFunctionPtr,
+            unique_ptr[ILabelWiseLoss] lossFunctionPtr, unique_ptr[IEvaluationMeasure] evaluationMeasurePtr,
             unique_ptr[ILabelWiseRuleEvaluationFactory] defaultRuleEvaluationFactoryPtr,
             unique_ptr[ILabelWiseRuleEvaluationFactory] regularRuleEvaluationFactoryPtr,
             unique_ptr[ILabelWiseRuleEvaluationFactory] pruningRuleEvaluationFactoryPtr) except +

--- a/python/mlrl/boosting/cython/statistics_label_wise.pyx
+++ b/python/mlrl/boosting/cython/statistics_label_wise.pyx
@@ -2,6 +2,7 @@
 @author Michael Rapp (mrapp@ke.tu-darmstadt.de)
 """
 from mlrl.common.cython._types cimport uint32
+from mlrl.common.cython.measures cimport EvaluationMeasure
 from mlrl.boosting.cython.losses_label_wise cimport LabelWiseLoss
 from mlrl.boosting.cython.rule_evaluation_label_wise cimport LabelWiseRuleEvaluationFactory
 
@@ -14,12 +15,14 @@ cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):
     A wrapper for the C++ class `DenseLabelWiseStatisticsProviderFactory`.
     """
 
-    def __cinit__(self, LabelWiseLoss loss_function not None,
+    def __cinit__(self, LabelWiseLoss loss_function not None, EvaluationMeasure evaluation_measure not None,
                   LabelWiseRuleEvaluationFactory default_rule_evaluation_factory not None,
                   LabelWiseRuleEvaluationFactory regular_rule_evaluation_factory not None,
                   LabelWiseRuleEvaluationFactory pruning_rule_evaluation_factory not None, uint32 num_threads):
         """
         :param loss_function:                   The loss function to be used for calculating gradients and Hessians
+        :param evaluation_measure:              The evaluation measure to be used for assessing the quality of
+                                                predictions
         :param default_rule_evaluation_factory: The `LabelWiseRuleEvaluationFactory` that allows to create instances of
                                                 the class that should be used for calculating the predictions, as well
                                                 as corresponding quality scores, of the default rule
@@ -33,6 +36,7 @@ cdef class DenseLabelWiseStatisticsProviderFactory(StatisticsProviderFactory):
                                                 in parallel. Must be at least 1
         """
         self.statistics_provider_factory_ptr = <unique_ptr[IStatisticsProviderFactory]>make_unique[DenseLabelWiseStatisticsProviderFactoryImpl](
-            move(loss_function.loss_function_ptr), move(default_rule_evaluation_factory.rule_evaluation_factory_ptr),
+            move(loss_function.loss_function_ptr), move(evaluation_measure.get_evaluation_measure_ptr()),
+            move(default_rule_evaluation_factory.rule_evaluation_factory_ptr),
             move(regular_rule_evaluation_factory.rule_evaluation_factory_ptr),
             move(pruning_rule_evaluation_factory.rule_evaluation_factory_ptr), num_threads)

--- a/python/mlrl/common/cython/stopping.pxd
+++ b/python/mlrl/common/cython/stopping.pxd
@@ -1,5 +1,4 @@
 from mlrl.common.cython._types cimport uint32, float64
-from mlrl.common.cython._measures cimport IEvaluationMeasure
 
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -51,8 +50,7 @@ cdef extern from "common/stopping/stopping_criterion_measure.hpp" nogil:
 
         # Constructors:
 
-        MeasureStoppingCriterionImpl(unique_ptr[IEvaluationMeasure] measurePtr,
-                                     unique_ptr[IAggregationFunction] aggregationFunctionPtr, uint32 minRules,
+        MeasureStoppingCriterionImpl(unique_ptr[IAggregationFunction] aggregationFunctionPtr, uint32 minRules,
                                      uint32 updateInterval, uint32 stopInterval, uint32 numPast, uint32 numRecent,
                                      float64 minImprovement, bool forceStop) except +
 

--- a/python/mlrl/common/cython/stopping.pyx
+++ b/python/mlrl/common/cython/stopping.pyx
@@ -1,8 +1,6 @@
 """
 @author: Michael Rapp (mrapp@ke.tu-darmstadt.de)
 """
-from mlrl.common.cython.measures cimport EvaluationMeasure
-
 from libcpp.utility cimport move
 from libcpp.memory cimport make_unique
 
@@ -77,11 +75,9 @@ cdef class MeasureStoppingCriterion(StoppingCriterion):
     A wrapper for the C++ class `MeasureStoppingCriterion`.
     """
 
-    def __cinit__(self, EvaluationMeasure measure not None, AggregationFunction aggregation_function not None,
-                  uint32 min_rules, uint32 update_interval, uint32 stop_interval, uint32 num_past, uint32 num_recent,
-                  float64 min_improvement, bint force_stop):
+    def __cinit__(self, AggregationFunction aggregation_function not None, uint32 min_rules, uint32 update_interval,
+                  uint32 stop_interval, uint32 num_past, uint32 num_recent, float64 min_improvement, bint force_stop):
         """
-        :param measure:                 The measure that should be used to assess the quality of a model
         :param aggregation_function:    The aggregation function that should be used to aggregate the scores in the
                                         buffer
         :param min_rules:               The minimum number of rules that must have been learned until the induction of
@@ -101,7 +97,6 @@ cdef class MeasureStoppingCriterion(StoppingCriterion):
         :param force_stop:              True, if the induction of rules should be forced to be stopped, if the stopping
                                         criterion is met, False, if the time of stopping should only be stored
         """
-        cdef unique_ptr[IEvaluationMeasure] measure_ptr = measure.get_evaluation_measure_ptr()
         self.stopping_criterion_ptr = <unique_ptr[IStoppingCriterion]>make_unique[MeasureStoppingCriterionImpl](
-            move(measure_ptr), move(aggregation_function.aggregation_function_ptr), min_rules, update_interval,
-            stop_interval, num_past, num_recent, min_improvement, force_stop)
+            move(aggregation_function.aggregation_function_ptr), min_rules, update_interval, stop_interval, num_past,
+            num_recent, min_improvement, force_stop)


### PR DESCRIPTION
Die Klassen, die das Interface `IStatistics` implementieren, speichern nun ein Objekt vom Typ `IEvaluationMeasure`. Dieses Objekt wird von der Funktion `evaluatePredictions` verwendet, statt ein solches Objekt per Funktionsargument zu übergeben. Der Typ des Evaluationmaßes kann außerdem per Template-Parameter spezifiziert werden, was es zukünftig erlaubt andere Typen zu verwenden.