### PR TITLE
Korrekte Bewertung von Single-Label Heads

### DIFF
--- a/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_common.hpp
@@ -22,21 +22,4 @@ namespace boosting {
         return divideOrZero(-gradient, hessian + l2RegularizationWeight);
     }
 
-    /**
-     * Calculates and returns a quality score that assesses the quality of the score that is predicted for a single
-     * label.
-     *
-     * @param score                     The predicted score
-     * @param gradient                  The gradient
-     * @param hessian                   The Hessian
-     * @param l2RegularizationWeight    The weight of the L2 regularization
-     * @return                          The quality score that has been calculated
-     */
-    static inline constexpr float64 calculateLabelWiseQualityScore(float64 score, float64 gradient, float64 hessian,
-                                                                   float64 l2RegularizationWeight) {
-        float64 scorePow = score * score;
-        return (gradient * score) + (0.5 * hessian * scorePow) + (0.5 * l2RegularizationWeight * scorePow);
-    }
-
-
 }

--- a/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_complete_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/rule_evaluation/rule_evaluation_label_wise_complete_common.hpp
@@ -30,4 +30,20 @@ namespace boosting {
         }
     }
 
+    /**
+     * Calculates and returns a quality score that assesses the quality of the score that is predicted for a single
+     * label.
+     *
+     * @param score                     The predicted score
+     * @param gradient                  The gradient
+     * @param hessian                   The Hessian
+     * @param l2RegularizationWeight    The weight of the L2 regularization
+     * @return                          The quality score that has been calculated
+     */
+    static inline constexpr float64 calculateLabelWiseQualityScore(float64 score, float64 gradient, float64 hessian,
+                                                                   float64 l2RegularizationWeight) {
+        float64 scorePow = score * score;
+        return (gradient * score) + (0.5 * hessian * scorePow) + (0.5 * l2RegularizationWeight * scorePow);
+    }
+
 }


### PR DESCRIPTION
Behebt ein mathematisches Problem bei der Bewertung von möglichen Single-Label Heads in der Klasse `LabelWiseSingleLabelRuleEvaluation` das durch Pull-Request #506 entstanden ist. Die Qualität der Vorhersage für ein Label wurde dort durch `-gradient / (hessian + l2RegularizationWeight)` berechnet. Der daraus resultierende Wert entspricht jedoch lediglich der optimalen Vorhersage für das jeweilige Label und ist nicht equivalent zu deren Qualität, die nun korrekt berechnet wird als `-0.5 * gradient^2 / (hessian + l2RegularizationWeight)`.