### PR TITLE
Neue Parameter um Ausgabe der Evaluationsergebnisse zu kontrollieren

### DIFF
--- a/doc/quickstart/parameters.rst
+++ b/doc/quickstart/parameters.rst
@@ -90,6 +90,16 @@ The following parameters allow to customize the console output and output files 
 
   * The path of the directory where experimental results should be saved.
 
+* ``--print-evaluation`` (Default value = true)
+
+  * ``true`` The evaluation results in terms of common metrics are printed on the console.
+  * ``false`` The evaluation results are not printed on the console.
+
+* ``--store-evaluation`` (Default value = true)
+
+  * ``true`` The evaluation results in terms of common metrics are written into output files. Does only have an effect if the parameter --output-dir is specified.
+  * ``false`` The evaluation results are not written into output files.
+
 * ``--store-predictions`` (Default value = false)
 
   * ``true`` The predictions for individual examples and labels are written into output files. Does only have an effect if the parameter --output-dir is specified.

--- a/python/args.py
+++ b/python/args.py
@@ -33,6 +33,10 @@ PARAM_DATASET = '--dataset'
 
 PARAM_FOLDS = '--folds'
 
+PARAM_PRINT_EVALUATION = '--print-evaluation'
+
+PARAM_STORE_EVALUATION = '--store-evaluation'
+
 PARAM_EVALUATE_TRAINING_DATA = '--evaluate-training-data'
 
 PARAM_ONE_HOT_ENCODING = '--one-hot-encoding'
@@ -206,6 +210,15 @@ class ArgumentParserBuilder:
                             help='The cross validation fold to be performed. Must be in [1, ' + PARAM_FOLDS + '] or 0, '
                                  + 'if all folds should be performed. This parameter is ignored if ' + PARAM_FOLDS
                                  + ' is set to 1.')
+        parser.add_argument(PARAM_PRINT_EVALUATION, type=boolean_string,
+                            default=ArgumentParserBuilder.__get_or_default('print_evaluation', True, **kwargs),
+                            help='Whether the evaluation results should be printed on the console or not. Must be one '
+                                 + 'of ' + format_enum_values(BooleanOption) + '.')
+        parser.add_argument(PARAM_STORE_EVALUATION, type=boolean_string,
+                            default=ArgumentParserBuilder.__get_or_default('store_evaluation', True, **kwargs),
+                            help='Whether the evaluation results should be written into output files or not. Must be '
+                                 + 'one of ' + format_enum_values(BooleanOption) + '. Does only have an effect if the '
+                                 + 'parameter ' + PARAM_OUTPUT_DIR + ' is specified')
         parser.add_argument(PARAM_EVALUATE_TRAINING_DATA, type=boolean_string,
                             default=ArgumentParserBuilder.__get_or_default('evaluate_training_data', False, **kwargs),
                             help='Whether the models should not only be evaluated on the test data, but also on the '
@@ -220,7 +233,7 @@ class ArgumentParserBuilder:
                                                                            **kwargs),
                             help='Whether the characteristics of the training data should be written into output files '
                                  + 'or not. Must be one of ' + format_enum_values(BooleanOption) + '. Does only have '
-                                 + 'an effect if the parameter ' + PARAM_OUTPUT_DIR + ' is specified')
+                                 + 'an effect if the parameter ' + PARAM_OUTPUT_DIR + ' is specified.')
         parser.add_argument(PARAM_ONE_HOT_ENCODING, type=boolean_string,
                             default=ArgumentParserBuilder.__get_or_default('one_hot_encoding', False, **kwargs),
                             help='Whether one-hot-encoding should be used to encode nominal attributes or not. Must be '

--- a/python/runnables.py
+++ b/python/runnables.py
@@ -59,13 +59,16 @@ class RuleLearnerRunnable(Runnable, ABC):
 
     def _run(self, args):
         parameter_input = None if args.parameter_dir is None else ParameterCsvInput(input_dir=args.parameter_dir)
-        evaluation_outputs = [EvaluationLogOutput()]
+        evaluation_outputs = []
         data_characteristics_printer_outputs = []
         model_printer_outputs = []
         output_dir = args.output_dir
 
         if args.print_data_characteristics:
             data_characteristics_printer_outputs.append(DataCharacteristicsLogOutput())
+
+        if args.print_evaluation:
+            evaluation_outputs.append(EvaluationLogOutput())
 
         if args.print_rules:
             model_printer_outputs.append(ModelPrinterLogOutput())
@@ -78,12 +81,14 @@ class RuleLearnerRunnable(Runnable, ABC):
                     DataCharacteristicsCsvOutput(output_dir=output_dir, clear_dir=clear_dir))
                 clear_dir = False
 
-            evaluation_outputs.append(
-                EvaluationCsvOutput(output_dir=output_dir, output_predictions=args.store_predictions,
-                                    clear_dir=clear_dir))
+            if args.store_evaluation:
+                evaluation_outputs.append(
+                    EvaluationCsvOutput(output_dir=output_dir, output_predictions=args.store_predictions,
+                                        clear_dir=clear_dir))
+                clear_dir = False
 
             if args.store_rules:
-                model_printer_outputs.append(ModelPrinterTxtOutput(output_dir=output_dir, clear_dir=False))
+                model_printer_outputs.append(ModelPrinterTxtOutput(output_dir=output_dir, clear_dir=clear_dir))
 
         model_dir = args.model_dir
         persistence = None if model_dir is None else ModelPersistence(model_dir)


### PR DESCRIPTION
Fügt die folgenden Kommandozeilenargumente hinzu, die es erlauben die Ausgabe der Evaluationsergebnisse zu aktivieren oder zu deaktivieren:

* `--print-evaluation`: Gibt an ob die Ergebnisse auf der Konsole ausgegeben werden sollen oder nicht
* `--store-evaluation`: Gibt an ob die Ergebnisse in Ausgabedateien geschrieben werden sollen oder nicht