### PR TITLE
MacOS-Pakete mit Hilfe von "cibuildwheel" bauen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,6 +43,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.0
         env:
           CIBW_BEFORE_ALL: make install_cpp
+          CIBW_BEFORE_ALL_MACOS: brew install libomp
           CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
           CIBW_BUILD_FRONTEND: build
           CIBW_ARCHS: auto64
@@ -53,6 +54,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.0
         env:
           CIBW_BEFORE_ALL: make install_cpp
+          CIBW_BEFORE_ALL_MACOS: brew install libomp
           CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
           CIBW_BUILD_FRONTEND: build
           CIBW_ARCHS: auto64


### PR DESCRIPTION
Ergänzt den Github-Workflow zum Bauen vorkompilierter Pakete um die Möglichkeit, Pakete für MacOS (aktuell nur für die x86_64-Architektur) zu erstellen.