### PR TITLE
aarch64-Pakete mit Hilfe von "cibuildwheel" bauen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,3 +78,52 @@ jobs:
           python3 -m pip install twine
           python3 -m twine upload --non-interactive wheelhouse/*
         continue-on-error: true
+  build_non_native_platform_wheels:
+    name: Build non-native platform wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Build package mlrl-common
+        uses: pypa/cibuildwheel@v2.3.0
+        env:
+          CIBW_BEFORE_ALL: make install_cpp
+          CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
+          CIBW_BUILD_FRONTEND: build
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_SKIP: 'pp* *musllinux*'
+        with:
+          package-dir: python/subprojects/common
+      - name: Build package mlrl-boosting
+        uses: pypa/cibuildwheel@v2.3.0
+        env:
+          CIBW_BEFORE_ALL: make install_cpp
+          CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
+          CIBW_BUILD_FRONTEND: build
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_SKIP: 'pp* *musllinux*'
+        with:
+          package-dir: python/subprojects/boosting
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: './wheelhouse/*.whl'
+          if-no-files-found: error
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install twine
+          python3 -m twine upload --non-interactive wheelhouse/*
+        continue-on-error: true


### PR DESCRIPTION
Ergänzt den Github-Workflow zum Bauen vorkompilierter Pakete um die Möglichkeit, Linux-Pakete für die aarch64-Architektur zu bauen.