### PR TITLE
Anpassung von Funktionen der Klasse DenseLabelWiseStatisticVector 

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/data/statistic_vector_label_wise_dense.hpp
+++ b/cpp/subprojects/boosting/include/boosting/data/statistic_vector_label_wise_dense.hpp
@@ -157,30 +157,30 @@ namespace boosting {
              * and Hessians in two other vectors, considering only the gradients and Hessians in the first vector that
              * correspond to the positions provided by a `CompleteIndexVector`.
              *
-             * @param firstBegin    A `const_iterator` to the beginning of the first vector
-             * @param firstEnd      A `const_iterator` to the end of the first vector
+             * @param first         A reference to an object of type `DenseLabelWiseStatisticVector` that stores the
+             *                      gradients and Hessians in the first vector
              * @param firstIndices  A reference to an object of type `CompleteIndexVector` that provides access to the
              *                      indices
-             * @param secondBegin  A `const_iterator` to the beginning of the second vector
-             * @param secondEnd    A `const_iterator` to the end of the second vector
+             * @param second        A reference to an object of type `DenseLabelWiseStatisticVector` that stores the
+             *                      gradients and Hessians in the second vector
              */
-            void difference(const_iterator firstBegin, const_iterator firstEnd, const CompleteIndexVector& firstIndices,
-                            const_iterator secondBegin, const_iterator secondEnd);
+            void difference(const DenseLabelWiseStatisticVector& first, const CompleteIndexVector& firstIndices,
+                            const DenseLabelWiseStatisticVector& second);
 
             /**
              * Sets the gradients and Hessians in this vector to the difference `first - second` between the gradients
              * and Hessians in two other vectors, considering only the gradients and Hessians in the first vector that
              * correspond to the positions provided by a `PartialIndexVector`.
              *
-             * @param firstBegin    A `const_iterator` to the beginning of the first vector
-             * @param firstEnd      A `const_iterator` to the end of the first vector
+             * @param first         A reference to an object of type `DenseLabelWiseStatisticVector` that stores the
+             *                      gradients and Hessians in the first vector
              * @param firstIndices  A reference to an object of type `PartialIndexVector` that provides access to the
              *                      indices
-             * @param secondBegin   A `const_iterator` to the beginning of the second vector
-             * @param secondEnd     A `const_iterator` to the end of the second vector
+             * @param second        A reference to an object of type `DenseLabelWiseStatisticVector` that stores the
+             *                      gradients and Hessians in the second vector
              */
-            void difference(const_iterator firstBegin, const_iterator firstEnd, const PartialIndexVector& firstIndices,
-                            const_iterator secondBegin, const_iterator secondEnd);
+            void difference(const DenseLabelWiseStatisticVector& first, const PartialIndexVector& firstIndices,
+                            const DenseLabelWiseStatisticVector& second);
 
     };
 

--- a/cpp/subprojects/boosting/src/boosting/data/statistic_vector_label_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/boosting/data/statistic_vector_label_wise_dense.cpp
@@ -79,18 +79,17 @@ namespace boosting {
         addToArray(statistics_, begin, indexIterator, numElements_, weight);
     }
 
-    void DenseLabelWiseStatisticVector::difference(DenseLabelWiseStatisticConstView::const_iterator firstBegin,
-                                                   DenseLabelWiseStatisticConstView::const_iterator firstEnd,
-                                                   const CompleteIndexVector& firstIndices, const_iterator secondBegin,
-                                                   const_iterator secondEnd) {
-        setArrayToDifference(statistics_, firstBegin, secondBegin, numElements_);
+    void DenseLabelWiseStatisticVector::difference(const DenseLabelWiseStatisticVector& first,
+                                                   const CompleteIndexVector& firstIndices,
+                                                   const DenseLabelWiseStatisticVector& second) {
+        setArrayToDifference(statistics_, first.cbegin(), second.cbegin(), numElements_);
     }
 
-    void DenseLabelWiseStatisticVector::difference(const_iterator firstBegin, const_iterator firstEnd,
-                                                   const PartialIndexVector& firstIndices, const_iterator secondBegin,
-                                                   const_iterator secondEnd) {
+    void DenseLabelWiseStatisticVector::difference(const DenseLabelWiseStatisticVector& first,
+                                                   const PartialIndexVector& firstIndices,
+                                                   const DenseLabelWiseStatisticVector& second) {
         PartialIndexVector::const_iterator indexIterator = firstIndices.cbegin();
-        setArrayToDifference(statistics_, firstBegin, secondBegin, indexIterator, numElements_);
+        setArrayToDifference(statistics_, first.cbegin(), second.cbegin(), indexIterator, numElements_);
     }
 
 }

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
@@ -145,8 +145,7 @@ namespace boosting {
                         StatisticVector& sumsOfStatistics = accumulated ? *accumulatedSumVector_ : sumVector_;
 
                         if (uncovered) {
-                            tmpVector_.difference(totalSumVector_->cbegin(), totalSumVector_->cend(), labelIndices_,
-                                                  sumsOfStatistics.cbegin(), sumsOfStatistics.cend());
+                            tmpVector_.difference(*totalSumVector_, labelIndices_, sumsOfStatistics);
                             return ruleEvaluationPtr_->calculatePrediction(tmpVector_);
                         }
 


### PR DESCRIPTION
Passt die Funktionen `add` und `difference` der Klasse `DenseLabelWiseStatisticVector` an, so dass teilweise Referenzen zu einem Vektor statt Iteratoren  übergeben werden. Dies ermöglicht zukünftig die Implementierung eines Vektors, der eine sparse Repräsentation von Gradienten und Hessians nutzt.