### PR TITLE
Möglichen Überlauf in Funktion "adjustSplit" verhindern

### DIFF
--- a/cpp/subprojects/common/src/common/thresholds/thresholds_exact.cpp
+++ b/cpp/subprojects/common/src/common/thresholds/thresholds_exact.cpp
@@ -26,9 +26,9 @@ struct FilteredCacheEntry {
 
 };
 
-static inline uint32 adjustSplit(FeatureVector::const_iterator iterator, uint32 start, uint32 end, float32 threshold) {
-    while (start <= end) {
-        uint32 pivot = start + ((end - start) / 2);
+static inline int64 adjustSplit(FeatureVector::const_iterator iterator, int64 start, int64 end, float32 threshold) {
+    while (start < end) {
+        int64 pivot = start + ((end - start) / 2);
         float32 featureValue = iterator[pivot].value;
 
         if (featureValue <= threshold) {


### PR DESCRIPTION
Enthält Änderungen, um einen möglichen Überlauf in der Funktion `adjustSplit` in der Datei `thresholds_exact.cpp` zu verhindern.