### PR TITLE
Vektoren zur Speicherung akkumulierter Statistiken mittels Copy-Konstructor erstellen

### DIFF
--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_example_wise_common.hpp
@@ -131,16 +131,18 @@ namespace boosting {
                      * @see `IStatisticsSubset::resetSubset`
                      */
                     void resetSubset() override {
-                        // Create a vector for storing the accumulated sums of gradients and Hessians, if necessary...
                         if (!accumulatedSumVector_) {
-                            uint32 numPredictions = labelIndices_.getNumElements();
-                            accumulatedSumVector_ = new StatisticVector(numPredictions, true);
+                            // Create a vector for storing the accumulated sums of gradients and Hessians, if
+                            // necessary...
+                            accumulatedSumVector_ = new StatisticVector(sumVector_);
+                        } else {
+                            // Add the sum of gradients and Hessians to the accumulated sums of gradients and
+                            // Hessians...
+                            accumulatedSumVector_->add(sumVector_.gradients_cbegin(), sumVector_.gradients_cend(),
+                                                       sumVector_.hessians_cbegin(), sumVector_.hessians_cend());
                         }
 
-                        // Reset the sum of gradients and Hessians to zero and add it to the accumulated sums of
-                        // gradients and Hessians...
-                        accumulatedSumVector_->add(sumVector_.gradients_cbegin(), sumVector_.gradients_cend(),
-                                                   sumVector_.hessians_cbegin(), sumVector_.hessians_cend());
+                        // Reset the sum of gradients and Hessians to zero...
                         sumVector_.clear();
                     }
 

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
@@ -126,15 +126,17 @@ namespace boosting {
                      * @see `IStatisticsSubset::resetSubset`
                      */
                     void resetSubset() override {
-                        // Create a vector for storing the accumulated sums of gradients and Hessians, if necessary...
                         if (!accumulatedSumVector_) {
-                            uint32 numPredictions = labelIndices_.getNumElements();
-                            accumulatedSumVector_ = new StatisticVector(numPredictions, true);
+                            // Create a vector for storing the accumulated sums of gradients and Hessians, if
+                            // necessary...
+                            accumulatedSumVector_ = new StatisticVector(sumVector_);
+                        } else {
+                            // Add the sums of gradients and Hessians to the accumulated sums of gradients and
+                            // Hessians...
+                            accumulatedSumVector_->add(sumVector_);
                         }
 
-                        // Reset the sums of gradients and Hessians to zero and add it to the accumulated sums of
-                        // gradients and Hessians...
-                        accumulatedSumVector_->add(sumVector_);
+                        // Reset the sums of gradients and Hessians to zero...
                         sumVector_.clear();
                     }
 

--- a/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/seco/src/seco/statistics/statistics_label_wise_common.hpp
@@ -118,15 +118,15 @@ namespace seco {
                      * @see `IStatisticsSubset::resetSubset`
                      */
                     void resetSubset() override {
-                        // Allocate a vector for storing the accumulated confusion matrices, if necessary...
                         if (!accumulatedSumVector_) {
-                            uint32 numPredictions = labelIndices_.getNumElements();
-                            accumulatedSumVector_ = new ConfusionMatrixVector(numPredictions, true);
+                            // Allocate a vector for storing the accumulated confusion matrices, if necessary...
+                            accumulatedSumVector_ = new ConfusionMatrixVector(sumVector_);
+                        } else {
+                            // Add the confusion matrix for each label to the accumulated confusion matrix...
+                            accumulatedSumVector_->add(sumVector_.cbegin(), sumVector_.cend());
                         }
 
-                        // Reset the confusion matrix for each label to zero and add its elements to the accumulated
-                        // confusion matrix...
-                        accumulatedSumVector_->add(sumVector_.cbegin(), sumVector_.cend());
+                        // Reset the confusion matrix for each label to zero...
                         sumVector_.clear();
                     }
 


### PR DESCRIPTION
Implementierungen der Funktion `resetSubset` der Klasse `IStatisticsSubset` verwenden nun einen Copy-Konstructor, um Vektoren zur Speicherung akkumulierter Statistiken zu erstellen.