### PR TITLE
Anpassung von Funktionen der Klasse DenseLabelWiseStatisticVector (Teil 2)

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/data/statistic_vector_label_wise_dense.hpp
+++ b/cpp/subprojects/boosting/include/boosting/data/statistic_vector_label_wise_dense.hpp
@@ -107,50 +107,50 @@ namespace boosting {
             /**
              * Adds all gradients and Hessians in a single row of a `DenseLabelWiseStatisticConstView` to this vector.
              *
-             * @param begin A `DenseLabelWiseStatisticConstView::const_iterator` to the beginning of the row
-             * @param end   A `DenseLabelWiseStatisticConstView::const_iterator` to the end of the row
+             * @param view  A reference to an object of type `DenseLabelWiseStatisticConstView` that stores the
+             *              gradients and Hessians to be added to this vector
+             * @param row   The index of the row to be added to this vector
              */
-            void add(DenseLabelWiseStatisticConstView::const_iterator begin,
-                     DenseLabelWiseStatisticConstView::const_iterator end);
+            void add(const DenseLabelWiseStatisticConstView& view, uint32 row);
 
             /**
              * Adds all gradients and Hessians in a single row of a `DenseLabelWiseStatisticConstView` to this vector.
              * The gradients and Hessians to be added are multiplied by a specific weight.
              *
-             * @param begin     A `DenseLabelWiseStatisticConstView::const_iterator` to the beginning of the row
-             * @param end       A `DenseLabelWiseStatisticConstView::const_iterator` to the end of the row
+             * @param view      A reference to an object of type `DenseLabelWiseStatisticConstView` that stores the
+             *                  gradients and Hessians to be added to this vector
+             * @param row       The index of the row to be added to this vector
              * @param weight    The weight, the gradients and Hessians should be multiplied by
              */
-            void add(DenseLabelWiseStatisticConstView::const_iterator begin,
-                     DenseLabelWiseStatisticConstView::const_iterator end, float64 weight);
+            void add(const DenseLabelWiseStatisticConstView& view, uint32 row, float64 weight);
 
             /**
              * Adds certain gradients and Hessians in a single row of a `DenseLabelWiseStatisticConstView`, whose
              * positions are given as a `CompleteIndexVector`, to this vector. The gradients and Hessians to be added
              * are multiplied by a specific weight.
              *
-             * @param begin     A `DenseLabelWiseStatisticConstView::const_iterator` to the beginning of the row
-             * @param end       A `DenseLabelWiseStatisticConstView::const_iterator` to the end of the row
+             * @param view      A reference to an object of type `DenseLabelWiseStatisticConstView` that stores the
+             *                  gradients and Hessians to be added to this vector
+             * @param row       The index of the row to be added to this vector
              * @param indices   A reference to a `CompleteIndexVector' that provides access to the indices
              * @param weight    The weight, the gradients and Hessians should be multiplied by
              */
-            void addToSubset(DenseLabelWiseStatisticConstView::const_iterator begin,
-                             DenseLabelWiseStatisticConstView::const_iterator end, const CompleteIndexVector& indices,
-                             float64 weight);
+            void addToSubset(const DenseLabelWiseStatisticConstView& view, uint32 row,
+                             const CompleteIndexVector& indices, float64 weight);
 
             /**
              * Adds certain gradients and Hessians in single row of a `DenseLabelWiseStatisticConstView`, whose
              * positions are given as a `PartialIndexVector`, to this vector. The gradients and Hessians to be added are
              * multiplied by a specific weight.
              *
-             * @param begin     A `DenseLabelWiseStatisticConstView::const_iterator` to the beginning of the row
-             * @param end       A `DenseLabelWiseStatisticConstView::const_iterator` to the end of the row
+             * @param view      A reference to an object of type `DenseLabelWiseStatisticConstView` that stores the
+             *                  gradients and Hessians to be added to this vector
+             * @param row       The index of the row to be added to this vector
              * @param indices   A reference to a `PartialIndexVector' that provides access to the indices
              * @param weight    The weight, the gradients and Hessians should be multiplied by
              */
-            void addToSubset(DenseLabelWiseStatisticConstView::const_iterator begin,
-                             DenseLabelWiseStatisticConstView::const_iterator end, const PartialIndexVector& indices,
-                             float64 weight);
+            void addToSubset(const DenseLabelWiseStatisticConstView& view, uint32 row,
+                             const PartialIndexVector& indices, float64 weight);
 
             /**
              * Sets the gradients and Hessians in this vector to the difference `first - second` between the gradients

--- a/cpp/subprojects/boosting/src/boosting/data/statistic_vector_label_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/boosting/data/statistic_vector_label_wise_dense.cpp
@@ -56,27 +56,23 @@ namespace boosting {
         addToArray(statistics_, vector.statistics_, numElements_);
     }
 
-    void DenseLabelWiseStatisticVector::add(DenseLabelWiseStatisticConstView::const_iterator begin,
-                                            DenseLabelWiseStatisticConstView::const_iterator end) {
-        addToArray(statistics_, begin, numElements_);
+    void DenseLabelWiseStatisticVector::add(const DenseLabelWiseStatisticConstView& view, uint32 row) {
+        addToArray(statistics_, view.row_cbegin(row), numElements_);
     }
 
-    void DenseLabelWiseStatisticVector::add(DenseLabelWiseStatisticConstView::const_iterator begin,
-                                            DenseLabelWiseStatisticConstView::const_iterator end, float64 weight) {
-        addToArray(statistics_, begin, numElements_, weight);
+    void DenseLabelWiseStatisticVector::add(const DenseLabelWiseStatisticConstView& view, uint32 row, float64 weight) {
+        addToArray(statistics_, view.row_cbegin(row), numElements_, weight);
     }
 
-    void DenseLabelWiseStatisticVector::addToSubset(DenseLabelWiseStatisticConstView::const_iterator begin,
-                                                    DenseLabelWiseStatisticConstView::const_iterator end,
+    void DenseLabelWiseStatisticVector::addToSubset(const DenseLabelWiseStatisticConstView& view, uint32 row,
                                                     const CompleteIndexVector& indices, float64 weight) {
-        addToArray(statistics_, begin, numElements_, weight);
+        addToArray(statistics_, view.row_cbegin(row), numElements_, weight);
     }
 
-    void DenseLabelWiseStatisticVector::addToSubset(DenseLabelWiseStatisticConstView::const_iterator begin,
-                                                    DenseLabelWiseStatisticConstView::const_iterator end,
+    void DenseLabelWiseStatisticVector::addToSubset(const DenseLabelWiseStatisticConstView& view, uint32 row,
                                                     const PartialIndexVector& indices, float64 weight) {
         PartialIndexVector::const_iterator indexIterator = indices.cbegin();
-        addToArray(statistics_, begin, indexIterator, numElements_, weight);
+        addToArray(statistics_, view.row_cbegin(row), indexIterator, numElements_, weight);
     }
 
     void DenseLabelWiseStatisticVector::difference(const DenseLabelWiseStatisticVector& first,

--- a/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/boosting/statistics/statistics_label_wise_common.hpp
@@ -111,9 +111,7 @@ namespace boosting {
                      * @see `IStatisticsSubset::addToSubset`
                      */
                     void addToSubset(uint32 statisticIndex, float64 weight) override final {
-                        sumVector_.addToSubset(statistics_.statisticViewPtr_->row_cbegin(statisticIndex),
-                                               statistics_.statisticViewPtr_->row_cend(statisticIndex), labelIndices_,
-                                               weight);
+                        sumVector_.addToSubset(*statistics_.statisticViewPtr_, statisticIndex, labelIndices_, weight);
                     }
 
                     /**
@@ -277,8 +275,7 @@ namespace boosting {
                         // Subtract the gradients and Hessians of the example at the given index (weighted by the given
                         // weight) from the total sums of gradients and Hessians...
                         const StatisticView& originalStatisticView = histogram_.originalStatisticView_;
-                        totalCoverableSumVector_->add(originalStatisticView.row_cbegin(statisticIndex),
-                                                      originalStatisticView.row_cend(statisticIndex), -weight);
+                        totalCoverableSumVector_->add(originalStatisticView, statisticIndex, -weight);
                     }
 
             };
@@ -429,8 +426,7 @@ namespace boosting {
                         // Subtract the gradients and Hessians of the example at the given index (weighted by the given
                         // weight) from the total sums of gradients and Hessians...
                         const StatisticView& statisticView = this->getStatisticView();
-                        totalCoverableSumVector_->add(statisticView.row_cbegin(statisticIndex),
-                                                      statisticView.row_cend(statisticIndex), -weight);
+                        totalCoverableSumVector_->add(statisticView, statisticIndex, -weight);
                     }
 
             };
@@ -513,8 +509,7 @@ namespace boosting {
              */
             void updateCoveredStatistic(uint32 statisticIndex, float64 weight, bool remove) override final {
                 float64 signedWeight = remove ? -weight : weight;
-                totalSumVectorPtr_->add(this->statisticViewPtr_->row_cbegin(statisticIndex),
-                                        this->statisticViewPtr_->row_cend(statisticIndex), signedWeight);
+                totalSumVectorPtr_->add(*this->statisticViewPtr_, statisticIndex, signedWeight);
             }
 
             /**


### PR DESCRIPTION
Passt die Funktionen `add` und `addToSubset` der Klasse `DenseLabelWiseStatisticVector` an, so dass teilweise Referenzen zu einem Objekt des Typs `DenseLabelWiseStatisticConstView`, zusammen mit dem Index einer bestimmten Zeile, statt Iteratoren  übergeben werden. Gemeinsam mit den Änderungen in #561 ermöglicht dies die Implementierung eines Vektors, der eine sparse Repräsentation von Gradienten und Hessians nutzt.