### PR TITLE
Refactoring bezüglich der Ausgabe von Vorhersagen

### DIFF
--- a/python/subprojects/testbed/mlrl/testbed/predictions.py
+++ b/python/subprojects/testbed/mlrl/testbed/predictions.py
@@ -105,7 +105,6 @@ class PredictionPrinter:
         :param current_fold:    The current fold
         :param num_folds:       The total number of folds
         """
-        if len(self.outputs) > 0:
-            for output in self.outputs:
-                output.write_predictions(experiment_name, meta_data, predictions, ground_truth, num_folds,
-                                         current_fold if num_folds > 1 else None)
+        for output in self.outputs:
+            output.write_predictions(experiment_name, meta_data, predictions, ground_truth, num_folds,
+                                     current_fold if num_folds > 1 else None)

--- a/python/subprojects/testbed/mlrl/testbed/runnables.py
+++ b/python/subprojects/testbed/mlrl/testbed/runnables.py
@@ -19,6 +19,7 @@ from mlrl.testbed.model_characteristics import RulePrinter, ModelPrinterLogOutpu
     RuleModelCharacteristicsPrinter, RuleModelCharacteristicsLogOutput, RuleModelCharacteristicsCsvOutput
 from mlrl.testbed.parameters import ParameterCsvInput
 from mlrl.testbed.persistence import ModelPersistence
+from mlrl.testbed.predictions import PredictionPrinter, PredictionLogOutput, PredictionArffOutput
 from mlrl.testbed.training import DataSet
 
 LOG_FORMAT = '%(levelname)s %(message)s'
@@ -62,6 +63,7 @@ class RuleLearnerRunnable(Runnable, ABC):
     def _run(self, args):
         parameter_input = None if args.parameter_dir is None else ParameterCsvInput(input_dir=args.parameter_dir)
         evaluation_outputs = []
+        prediction_printer_outputs = []
         data_characteristics_printer_outputs = []
         model_characteristics_printer_outputs = []
         model_printer_outputs = []
@@ -70,9 +72,11 @@ class RuleLearnerRunnable(Runnable, ABC):
         if args.print_data_characteristics:
             data_characteristics_printer_outputs.append(DataCharacteristicsLogOutput())
 
-        if args.print_evaluation or args.print_predictions:
-            evaluation_outputs.append(EvaluationLogOutput(output_evaluation=args.print_evaluation,
-                                                          output_predictions=args.print_predictions))
+        if args.print_evaluation:
+            evaluation_outputs.append(EvaluationLogOutput())
+
+        if args.print_predictions:
+            prediction_printer_outputs.append(PredictionLogOutput())
 
         if args.print_model_characteristics:
             model_characteristics_printer_outputs.append(RuleModelCharacteristicsLogOutput())
@@ -90,8 +94,11 @@ class RuleLearnerRunnable(Runnable, ABC):
 
             if args.store_evaluation:
                 evaluation_outputs.append(
-                    EvaluationCsvOutput(output_dir=output_dir, output_predictions=args.store_predictions,
-                                        clear_dir=clear_dir))
+                    EvaluationCsvOutput(output_dir=output_dir, clear_dir=clear_dir))
+                clear_dir = False
+
+            if args.store_predictions:
+                prediction_printer_outputs.append(PredictionArffOutput(output_dir=output_dir, clear_dir=clear_dir))
                 clear_dir = False
 
             if args.store_model_characteristics:
@@ -113,15 +120,22 @@ class RuleLearnerRunnable(Runnable, ABC):
         model_characteristics_printer = RuleModelCharacteristicsPrinter(model_characteristics_printer_outputs) if len(
             model_characteristics_printer_outputs) > 0 else None
         predict_probabilities = args.predict_probabilities
+        evaluate_training_data = args.evaluate_training_data
+
+        if len(prediction_printer_outputs) > 0:
+            train_prediction_printer = PredictionPrinter(prediction_printer_outputs) if evaluate_training_data else None
+            test_prediction_printer = PredictionPrinter(prediction_printer_outputs)
+        else:
+            train_prediction_printer = None
+            test_prediction_printer = None
 
         if len(evaluation_outputs) > 0:
             if predict_probabilities:
-                train_evaluation = RankingEvaluation(*evaluation_outputs) if args.evaluate_training_data else None
-                test_evaluation = RankingEvaluation(*evaluation_outputs)
+                train_evaluation = RankingEvaluation(evaluation_outputs) if evaluate_training_data else None
+                test_evaluation = RankingEvaluation(evaluation_outputs)
             else:
-                train_evaluation = ClassificationEvaluation(
-                    *evaluation_outputs) if args.evaluate_training_data else None
-                test_evaluation = ClassificationEvaluation(*evaluation_outputs)
+                train_evaluation = ClassificationEvaluation(evaluation_outputs) if evaluate_training_data else None
+                test_evaluation = ClassificationEvaluation(evaluation_outputs)
         else:
             train_evaluation = None
             test_evaluation = None
@@ -129,8 +143,9 @@ class RuleLearnerRunnable(Runnable, ABC):
         data_set = DataSet(data_dir=args.data_dir, data_set_name=args.dataset,
                            use_one_hot_encoding=args.one_hot_encoding)
         experiment = Experiment(learner, predict_probabilities=predict_probabilities, test_evaluation=test_evaluation,
-                                train_evaluation=train_evaluation, data_set=data_set, num_folds=args.folds,
-                                current_fold=args.current_fold, parameter_input=parameter_input,
+                                train_evaluation=train_evaluation, train_prediction_printer=train_prediction_printer,
+                                test_prediction_printer=test_prediction_printer, data_set=data_set,
+                                num_folds=args.folds, current_fold=args.current_fold, parameter_input=parameter_input,
                                 model_printer=model_printer,
                                 model_characteristics_printer=model_characteristics_printer,
                                 data_characteristics_printer=data_characteristics_printer, persistence=persistence)


### PR DESCRIPTION
Überarbeitet den Code zur Ausgabe von Vorhersagen und der Evaluation von Vorhersagen, so dass diese beiden Funktionalitäten in unterschiedlichen Klassen implmentiert werden. Durch diese Trennung müssen Evaluationmaße nur noch berechnet werden, falls diese tatsächlich ausgegeben oder in Dateien gespeichert werden sollen.