### PR TITLE
Korrekte Python-Version beim Bauen von Paketen verwenden

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,9 +52,8 @@ jobs:
       - name: Build package mlrl-common
         uses: pypa/cibuildwheel@v2.3.0
         env:
-          CIBW_BEFORE_ALL: make install_cpp
           CIBW_BEFORE_ALL_MACOS: brew install libomp
-          CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
+          CIBW_BEFORE_BUILD: make clean install_cpp install_cython
           CIBW_BUILD_FRONTEND: build
           CIBW_ARCHS: auto64
           CIBW_SKIP: 'pp* *musllinux*'
@@ -63,9 +62,8 @@ jobs:
       - name: Build package mlrl-boosting
         uses: pypa/cibuildwheel@v2.3.0
         env:
-          CIBW_BEFORE_ALL: make install_cpp
           CIBW_BEFORE_ALL_MACOS: brew install libomp
-          CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
+          CIBW_BEFORE_BUILD: make clean install_cpp install_cython
           CIBW_BUILD_FRONTEND: build
           CIBW_ARCHS: auto64
           CIBW_SKIP: 'pp* *musllinux*'
@@ -103,8 +101,7 @@ jobs:
       - name: Build package mlrl-common
         uses: pypa/cibuildwheel@v2.3.0
         env:
-          CIBW_BEFORE_ALL: make install_cpp
-          CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
+          CIBW_BEFORE_BUILD: make clean install_cpp install_cython
           CIBW_BUILD_FRONTEND: build
           CIBW_ARCHS_LINUX: aarch64
           CIBW_SKIP: 'pp* *musllinux*'
@@ -113,8 +110,7 @@ jobs:
       - name: Build package mlrl-boosting
         uses: pypa/cibuildwheel@v2.3.0
         env:
-          CIBW_BEFORE_ALL: make install_cpp
-          CIBW_BEFORE_BUILD: make clean_install clean_wheel clean_cython install_cpp install_cython
+          CIBW_BEFORE_BUILD: make clean install_cpp install_cython
           CIBW_BUILD_FRONTEND: build
           CIBW_ARCHS_LINUX: aarch64
           CIBW_SKIP: 'pp* *musllinux*'


### PR DESCRIPTION
Enthält Änderungen bezüglich der Konfiguration von `cibuildwheel` so dass zukünftig die jeweils korrekte Python-Version für das Bauen von Paketen mit unterschiedlichen Zielplatformen verwendet wird.