### PR TITLE
Factory um Instanzen des Typs IModelBuilder zu erzeugen

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/learner.hpp
+++ b/cpp/subprojects/boosting/include/boosting/learner.hpp
@@ -432,9 +432,9 @@ namespace boosting {
                 const IFeatureMatrix& featureMatrix, const IRowWiseLabelMatrix& labelMatrix) const override;
 
             /**
-             * @see `AbstractRuleLearner::createModelBuilder`
+             * @see `AbstractRuleLearner::createModelBuilderFactory`
              */
-            std::unique_ptr<IModelBuilder> createModelBuilder() const override;
+            std::unique_ptr<IModelBuilderFactory> createModelBuilderFactory() const override;
 
             /**
              * @see `AbstractRuleLearner::createLabelSpaceInfo`

--- a/cpp/subprojects/boosting/include/boosting/model/rule_list_builder.hpp
+++ b/cpp/subprojects/boosting/include/boosting/model/rule_list_builder.hpp
@@ -4,38 +4,19 @@
 #pragma once
 
 #include "common/model/model_builder.hpp"
-#include "common/model/rule_list.hpp"
 
 
 namespace boosting {
 
     /**
-     * Allows to build models that store several rules in the order they have been added.
+     * Allows to create instances of the type `IModelBuilder` that build models that store several rules in the order
+     * they have been added.
      */
-    class RuleListBuilder final : public IModelBuilder {
-
-        private:
-
-            std::unique_ptr<RuleList> modelPtr_;
+    class RuleListBuilderFactory final : public IModelBuilderFactory {
 
         public:
 
-            RuleListBuilder();
-
-            /**
-             * @see `IModelBuilder::setDefaultRule`
-             */
-            void setDefaultRule(const AbstractPrediction& prediction) override;
-
-            /**
-             * @see `IModelBuilder::addRule`
-             */
-            void addRule(const ConditionList& conditions, const AbstractPrediction& prediction) override;
-
-            /**
-             * @see `IModelBuilder::build`
-             */
-            std::unique_ptr<IRuleModel> build(uint32 numUsedRules) override;
+            std::unique_ptr<IModelBuilder> create() const override;
 
     };
 

--- a/cpp/subprojects/boosting/src/boosting/learner.cpp
+++ b/cpp/subprojects/boosting/src/boosting/learner.cpp
@@ -241,8 +241,8 @@ namespace boosting {
         return configPtr_->getLossConfig().createStatisticsProviderFactory(featureMatrix, labelMatrix, blas_, lapack_);
     }
 
-    std::unique_ptr<IModelBuilder> BoostingRuleLearner::createModelBuilder() const {
-        return std::make_unique<RuleListBuilder>();
+    std::unique_ptr<IModelBuilderFactory> BoostingRuleLearner::createModelBuilderFactory() const {
+        return std::make_unique<RuleListBuilderFactory>();
     }
 
     std::unique_ptr<IClassificationPredictorFactory> BoostingRuleLearner::createClassificationPredictorFactory(

--- a/cpp/subprojects/boosting/src/boosting/model/rule_list_builder.cpp
+++ b/cpp/subprojects/boosting/src/boosting/model/rule_list_builder.cpp
@@ -1,24 +1,42 @@
 #include "boosting/model/rule_list_builder.hpp"
+#include "common/model/rule_list.hpp"
 
 
 namespace boosting {
 
-    RuleListBuilder::RuleListBuilder()
-        : modelPtr_(std::make_unique<RuleList>()) {
+    /**
+     * Allows to build models that store several rules in the order they have been added.
+     */
+    class RuleListBuilder final : public IModelBuilder {
 
-    }
+        private:
 
-    void RuleListBuilder::setDefaultRule(const AbstractPrediction& prediction) {
-        modelPtr_->addDefaultRule(prediction.createHead());
-    }
+            std::unique_ptr<RuleList> modelPtr_;
 
-    void RuleListBuilder::addRule(const ConditionList& conditions, const AbstractPrediction& prediction) {
-        modelPtr_->addRule(conditions.createConjunctiveBody(), prediction.createHead());
-    }
+        public:
 
-    std::unique_ptr<IRuleModel> RuleListBuilder::build(uint32 numUsedRules) {
-        modelPtr_->setNumUsedRules(numUsedRules);
-        return std::move(modelPtr_);
+            RuleListBuilder()
+                : modelPtr_(std::make_unique<RuleList>()) {
+
+            }
+
+            void setDefaultRule(const AbstractPrediction& prediction) override {
+                modelPtr_->addDefaultRule(prediction.createHead());
+            }
+
+            void addRule(const ConditionList& conditions, const AbstractPrediction& prediction) override {
+                modelPtr_->addRule(conditions.createConjunctiveBody(), prediction.createHead());
+            }
+
+            std::unique_ptr<IRuleModel> build(uint32 numUsedRules) override {
+                modelPtr_->setNumUsedRules(numUsedRules);
+                return std::move(modelPtr_);
+            }
+
+    };
+
+    std::unique_ptr<IModelBuilder> RuleListBuilderFactory::create() const {
+        return std::make_unique<RuleListBuilder>();
     }
 
 }

--- a/cpp/subprojects/common/include/common/learner.hpp
+++ b/cpp/subprojects/common/include/common/learner.hpp
@@ -946,11 +946,12 @@ class AbstractRuleLearner : virtual public IRuleLearner {
             const IFeatureMatrix& featureMatrix, const IRowWiseLabelMatrix& labelMatrix) const = 0;
 
         /**
-         * Must be implemented by subclasses in order to create `IModelBuilder` to be used by the rule learner.
+         * Must be implemented by subclasses in order to create the `IModelBuilderFactory` to be used by the rule
+         * learner.
          *
-         * @return An unique pointer to an object of type `IModelBuilder` that has been created
+         * @return An unique pointer to an object of type `IModelBuilderFactory` that has been created
          */
-        virtual std::unique_ptr<IModelBuilder> createModelBuilder() const = 0;
+        virtual std::unique_ptr<IModelBuilderFactory> createModelBuilderFactory() const = 0;
 
         /**
          * Must be overridden by subclasses in order to create the `ILabelSpaceInfo` to be used by the rule learner as a

--- a/cpp/subprojects/common/include/common/model/model_builder.hpp
+++ b/cpp/subprojects/common/include/common/model/model_builder.hpp
@@ -43,3 +43,21 @@ class IModelBuilder {
         virtual std::unique_ptr<IRuleModel> build(uint32 numUsedRules) = 0;
 
 };
+
+/**
+ * Defines an interface for all factories that allow to create instances of the type `IModelBuilder`.
+ */
+class IModelBuilderFactory {
+
+    public:
+
+        virtual ~IModelBuilderFactory() { };
+
+        /**
+         * Creates and returns a new instance of type `IModelBuilder`.
+         *
+         * @return An unique pointer to an object of type `IModelBuilder` that has been created
+         */
+        virtual std::unique_ptr<IModelBuilder> create() const = 0;
+
+};

--- a/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage.hpp
+++ b/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage.hpp
@@ -38,15 +38,13 @@ class IRuleModelAssemblage {
          * @param labelMatrix           A reference to an object of type `IRowWiseLabelMatrix` that provides row-wise
          *                              access to the labels of individual training examples
          * @param randomState           The seed to be used by the random number generators
-         * @param modelBuilder          A reference to an object of type `IModelBuilder`, the induced rules should be
-         *                              added to
          * @return                      An unique pointer to an object of type `IRuleModel` that consists of the rules
          *                              that have been induced
          */
         virtual std::unique_ptr<IRuleModel> induceRules(const INominalFeatureMask& nominalFeatureMask,
                                                         const IColumnWiseFeatureMatrix& featureMatrix,
-                                                        const IRowWiseLabelMatrix& labelMatrix, uint32 randomState,
-                                                        IModelBuilder& modelBuilder) const = 0;
+                                                        const IRowWiseLabelMatrix& labelMatrix,
+                                                        uint32 randomState) const = 0;
 
 };
 
@@ -62,6 +60,8 @@ class IRuleModelAssemblageFactory {
         /**
          * Creates and returns a new object of the type `IRuleModelAssemblage`.
          *
+         * @param modelBuilderFactoryPtr        An unique pointer to an object of type `IModelBuilderFactory` that
+         *                                      allows to create the builder to be used for assembling a model
          * @param statisticsProviderFactoryPtr  An unique pointer to an object of type `IStatisticsProviderFactory` that
          *                                      provides access to the statistics which serve as the basis for learning
          *                                      rules
@@ -94,6 +94,7 @@ class IRuleModelAssemblageFactory {
          *                                      induced or not
          */
         virtual std::unique_ptr<IRuleModelAssemblage> create(
+            std::unique_ptr<IModelBuilderFactory> modelBuilderFactoryPtr,
             std::unique_ptr<IStatisticsProviderFactory> statisticsProviderFactoryPtr,
             std::unique_ptr<IThresholdsFactory> thresholdsFactoryPtr,
             std::unique_ptr<IRuleInductionFactory> ruleInductionFactoryPtr,

--- a/cpp/subprojects/common/src/common/learner.cpp
+++ b/cpp/subprojects/common/src/common/learner.cpp
@@ -448,16 +448,15 @@ std::unique_ptr<ITrainingResult> AbstractRuleLearner::fit(
     std::unique_ptr<ILabelSpaceInfo> labelSpaceInfoPtr = this->createLabelSpaceInfo(labelMatrix);
     std::unique_ptr<IRuleModelAssemblageFactory> ruleModelAssemblageFactoryPtr =
         this->createRuleModelAssemblageFactory();
-    std::unique_ptr<IModelBuilder> modelBuilderPtr = this->createModelBuilder();
     std::unique_ptr<IRuleModelAssemblage> ruleModelAssemblagePtr = ruleModelAssemblageFactoryPtr->create(
-        this->createStatisticsProviderFactory(featureMatrix, labelMatrix),
+        this->createModelBuilderFactory(), this->createStatisticsProviderFactory(featureMatrix, labelMatrix),
         this->createThresholdsFactory(featureMatrix, labelMatrix),
         this->createRuleInductionFactory(featureMatrix, labelMatrix), this->createLabelSamplingFactory(labelMatrix),
         this->createInstanceSamplingFactory(), this->createFeatureSamplingFactory(featureMatrix),
         this->createPartitionSamplingFactory(), this->createPruningFactory(), this->createPostProcessorFactory(),
         stoppingCriterionFactories);
     std::unique_ptr<IRuleModel> ruleModelPtr = ruleModelAssemblagePtr->induceRules(
-        nominalFeatureMask, featureMatrix, labelMatrix, randomState, *modelBuilderPtr);
+        nominalFeatureMask, featureMatrix, labelMatrix, randomState);
     return std::make_unique<TrainingResult>(labelMatrix.getNumCols(), std::move(ruleModelPtr),
                                             std::move(labelSpaceInfoPtr));
 }

--- a/cpp/subprojects/seco/include/seco/learner.hpp
+++ b/cpp/subprojects/seco/include/seco/learner.hpp
@@ -341,7 +341,7 @@ namespace seco {
             std::unique_ptr<IStatisticsProviderFactory> createStatisticsProviderFactory(
                 const IFeatureMatrix& featureMatrix, const IRowWiseLabelMatrix& labelMatrix) const override;
 
-            std::unique_ptr<IModelBuilder> createModelBuilder() const override;
+            std::unique_ptr<IModelBuilderFactory> createModelBuilderFactory() const override;
 
             std::unique_ptr<ILabelSpaceInfo> createLabelSpaceInfo(
                 const IRowWiseLabelMatrix& labelMatrix) const override;

--- a/cpp/subprojects/seco/include/seco/model/decision_list_builder.hpp
+++ b/cpp/subprojects/seco/include/seco/model/decision_list_builder.hpp
@@ -4,41 +4,19 @@
 #pragma once
 
 #include "common/model/model_builder.hpp"
-#include "common/model/rule_list.hpp"
 
 
 namespace seco {
 
     /**
-     * Allows to build models that store several rules in the order they have been added, except for the default rule, which
-     * is always located at the end.
+     * Allows to create instances of the type `IModelBuilder` that build models that store several rules in the order
+     * they have been added, except for the default rule, which is always located at the end.
      */
-    class DecisionListBuilder final : public IModelBuilder {
-
-        private:
-
-            std::unique_ptr<IHead> defaultHeadPtr_;
-
-            std::unique_ptr<RuleList> modelPtr_;
+    class DecisionListBuilderFactory : public IModelBuilderFactory {
 
         public:
 
-            DecisionListBuilder();
-
-            /**
-             * @see `IModelBuilder::setDefaultRule`
-             */
-            void setDefaultRule(const AbstractPrediction& prediction) override;
-
-            /**
-             * @see `IModelBuilder::addRule`
-             */
-            void addRule(const ConditionList& conditions, const AbstractPrediction& prediction) override;
-
-            /**
-             * @see `IModelBuilder::build`
-             */
-            std::unique_ptr<IRuleModel> build(uint32 numUsedRules) override;
+            std::unique_ptr<IModelBuilder> create() const override;
 
     };
 

--- a/cpp/subprojects/seco/src/seco/learner.cpp
+++ b/cpp/subprojects/seco/src/seco/learner.cpp
@@ -196,8 +196,8 @@ namespace seco {
         return configPtr_->getHeadConfig().createStatisticsProviderFactory(labelMatrix);
     }
 
-    std::unique_ptr<IModelBuilder> SeCoRuleLearner::createModelBuilder() const {
-        return std::make_unique<DecisionListBuilder>();
+    std::unique_ptr<IModelBuilderFactory> SeCoRuleLearner::createModelBuilderFactory() const {
+        return std::make_unique<DecisionListBuilderFactory>();
     }
 
     std::unique_ptr<ILabelSpaceInfo> SeCoRuleLearner::createLabelSpaceInfo(

--- a/cpp/subprojects/seco/src/seco/model/decision_list_builder.cpp
+++ b/cpp/subprojects/seco/src/seco/model/decision_list_builder.cpp
@@ -1,29 +1,49 @@
 #include "seco/model/decision_list_builder.hpp"
+#include "common/model/rule_list.hpp"
 
 
 namespace seco {
 
-    DecisionListBuilder::DecisionListBuilder()
-        : modelPtr_(std::make_unique<RuleList>()){
+    /**
+     * Allows to build models that store several rules in the order they have been added, except for the default rule,
+     * which is always located at the end.
+     */
+    class DecisionListBuilder final : public IModelBuilder {
 
-    }
+        private:
 
-    void DecisionListBuilder::setDefaultRule(const AbstractPrediction& prediction) {
-        defaultHeadPtr_ = prediction.createHead();
-    }
+            std::unique_ptr<IHead> defaultHeadPtr_;
 
-    void DecisionListBuilder::addRule(const ConditionList& conditions, const AbstractPrediction& prediction) {
-        modelPtr_->addRule(conditions.createConjunctiveBody(), prediction.createHead());
-    }
+            std::unique_ptr<RuleList> modelPtr_;
 
-    std::unique_ptr<IRuleModel> DecisionListBuilder::build(uint32 numUsedRules) {
-        if (defaultHeadPtr_) {
-            modelPtr_->addDefaultRule(std::move(defaultHeadPtr_));
-        }
+        public:
 
-        modelPtr_->setNumUsedRules(numUsedRules);
-        return std::move(modelPtr_);
+            DecisionListBuilder()
+                : modelPtr_(std::make_unique<RuleList>()) {
+
+            }
+
+            void setDefaultRule(const AbstractPrediction& prediction) override {
+                defaultHeadPtr_ = prediction.createHead();
+            }
+
+            void addRule(const ConditionList& conditions, const AbstractPrediction& prediction) override {
+                modelPtr_->addRule(conditions.createConjunctiveBody(), prediction.createHead());
+            }
+
+            std::unique_ptr<IRuleModel> build(uint32 numUsedRules) override {
+                if (defaultHeadPtr_) {
+                    modelPtr_->addDefaultRule(std::move(defaultHeadPtr_));
+                }
+
+                modelPtr_->setNumUsedRules(numUsedRules);
+                return std::move(modelPtr_);
+            }
+
+    };
+
+    std::unique_ptr<IModelBuilder> DecisionListBuilderFactory::create() const {
+        return std::make_unique<DecisionListBuilder>();
     }
 
 }
-


### PR DESCRIPTION
Fügt das Interface `IModelBuilderFactory` hinzu, das es erlaubt, Instanzen des Typs `IModelBuilder` zu erzeugen. Statt wie bisher ein Objekt vom Typ `IModelBuilder` an die `induceRules`-Funktion der Klasse `IRuleModelAssemblage` zu übergeben, wird nun ein Objekt vom Typ `IModelBuilderFactory` and die `create`-Funktion der Klasse `IRuleModelAssemblageFactory` übergeben.