### PR TITLE
Post-Optimierung

### DIFF
--- a/cpp/subprojects/common/include/common/learner.hpp
+++ b/cpp/subprojects/common/include/common/learner.hpp
@@ -16,6 +16,7 @@
 #include "common/output/predictor_classification.hpp"
 #include "common/output/predictor_regression.hpp"
 #include "common/output/predictor_probability.hpp"
+#include "common/post_optimization/post_optimization.hpp"
 #include "common/rule_induction/default_rule.hpp"
 #include "common/rule_induction/rule_induction_top_down.hpp"
 #include "common/rule_induction/rule_model_assemblage.hpp"
@@ -183,6 +184,14 @@ class MLRLCOMMON_API IRuleLearner {
                  *         of the method that post-processes the predictions of rules once they have been learned
                  */
                 virtual const IPostProcessorConfig& getPostProcessorConfig() const = 0;
+
+                /**
+                 * Returns the configuration of the method for post-optimizing a model once it has been learned.
+                 *
+                 * @return A reference to an object of type `IPostOptimizationConfig` that specifies the configuration
+                 *         of the method that post-optimizes a model once it has been learned
+                 */
+                virtual const IPostOptimizationConfig& getPostOptimizationConfig() const = 0;
 
                 /**
                  * Returns the configuration of the multi-threading behavior that is used for the parallel refinement of
@@ -415,6 +424,11 @@ class MLRLCOMMON_API IRuleLearner {
                  * Configures the rule learner to not use any post processor.
                  */
                 virtual void useNoPostProcessor() = 0;
+
+                /**
+                 * Configures the rule learner to not optimize a model once it has been learned.
+                 */
+                virtual void useNoPostOptimization() = 0;
 
                 /**
                  * Configures the rule learner to not use any multi-threading for the parallel refinement of rules.
@@ -765,6 +779,12 @@ class AbstractRuleLearner : virtual public IRuleLearner {
                 std::unique_ptr<IPostProcessorConfig> postProcessorConfigPtr_;
 
                 /**
+                 * An unique pointer that stores the configuration of the method for post-optimizing a model once it has
+                 * been learned.
+                 */
+                std::unique_ptr<IPostOptimizationConfig> postOptimizationConfigPtr_;
+
+                /**
                  * An unique pointer that stores the configuration of the multi-threading behavior that is used for the
                  * parallel refinement of rules.
                  */
@@ -821,6 +841,8 @@ class AbstractRuleLearner : virtual public IRuleLearner {
                 const IPruningConfig& getPruningConfig() const override final;
 
                 const IPostProcessorConfig& getPostProcessorConfig() const override final;
+
+                const IPostOptimizationConfig& getPostOptimizationConfig() const override final;
 
                 const IMultiThreadingConfig& getParallelRuleRefinementConfig() const override final;
 
@@ -882,6 +904,8 @@ class AbstractRuleLearner : virtual public IRuleLearner {
 
                 void useNoPostProcessor() override final;
 
+                void useNoPostOptimization() override final;
+
                 void useNoParallelRuleRefinement() override final;
 
                 IManualMultiThreadingConfig& useParallelRuleRefinement() override;
@@ -933,6 +957,8 @@ class AbstractRuleLearner : virtual public IRuleLearner {
         std::unique_ptr<IPruningFactory> createPruningFactory() const;
 
         std::unique_ptr<IPostProcessorFactory> createPostProcessorFactory() const;
+
+        std::unique_ptr<IPostOptimizationFactory> createPostOptimizationFactory() const;
 
         std::unique_ptr<IStoppingCriterionFactory> createSizeStoppingCriterionFactory() const;
 

--- a/cpp/subprojects/common/include/common/post_optimization/post_optimization.hpp
+++ b/cpp/subprojects/common/include/common/post_optimization/post_optimization.hpp
@@ -1,0 +1,86 @@
+/*
+ * @author Michael Rapp (michael.rapp.ml@gmail.com)
+ */
+#pragma once
+
+#include "common/model/model_builder.hpp"
+#include "common/post_processing/post_processor.hpp"
+#include "common/pruning/pruning.hpp"
+#include "common/rule_induction/rule_induction.hpp"
+#include "common/sampling/feature_sampling.hpp"
+#include "common/thresholds/thresholds.hpp"
+
+
+/**
+ * Defines an interface for all classes that allow to optimize a rule-based model globally once it has been learned.
+ */
+class IPostOptimization : public IModelBuilder {
+
+    public:
+
+        virtual ~IPostOptimization() override { };
+
+        /**
+         * Optimizes a rule-based model globally once it has been learned.
+         *
+         * @param thresholds        A reference to an object of type `IThresholds` that provides access to the
+         *                          thresholds that may be used by the conditions of the rule
+         * @param ruleInduction     A reference to an object of type `IRuleInduction` that should be used for inducing
+         *                          new rules
+         * @param partition         A reference to an object of type `IPartition` that provides access to the indices of
+         *                          the training examples that belong to the training set and the holdout set,
+         *                          respectively
+         * @param instanceSampling  A reference to an object of type `IInstanceSampling` that should be used for
+         *                          sampling examples
+         * @param featureSampling   A reference to an object of type `IFeatureSampling` that should be used for sampling
+         *                          the features that may be used by the conditions of new rules
+         * @param pruning           A reference to an object of type `IPruning` that should be used to prune new rules
+         * @param postProcessor     A reference to an object of type `IPostProcessor` that should be used to
+         *                          post-process the predictions of new rules
+         * @param rng               A reference to an object of type `RNG` that implements the random number generator
+         *                          to be used
+         */
+        virtual void optimizeModel(IThresholds& thresholds, const IRuleInduction& ruleInduction, IPartition& partition,
+                                   IInstanceSampling& instanceSampling, IFeatureSampling& featureSampling,
+                                   const IPruning& pruning, const IPostProcessor& postProcessor, RNG& rng) = 0;
+
+};
+
+/**
+ * Defines an interface for all factories that allow to create instances of the type `IPostOptimization`.
+ */
+class IPostOptimizationFactory {
+
+    public:
+
+        virtual ~IPostOptimizationFactory() { };
+
+        /**
+         * Creates and returns a new object of type `PostOptimization`.
+         *
+         * @param modelBuilderFactory   A reference to an object of type `IModelBuilderFactory` that allows to create
+         *                              the builder to be used for assembling a model
+         * @return                      An unique pointer to an object of type `IPostOptimization` that has been created
+         */
+        virtual std::unique_ptr<IPostOptimization> create(const IModelBuilderFactory& modelBuilderFactory) const = 0;
+
+};
+
+/**
+ * Defines an interface for all classes that allow to configure a method that optimizes a rule-based model globally once
+ * it has been learned.
+ */
+class IPostOptimizationConfig {
+
+    public:
+
+        virtual ~IPostOptimizationConfig() { };
+
+        /**
+         * Creates and returns a new object of type `IPostOptimizationFactory` according to the specified configuration.
+         *
+         * @return An unique pointer to an object of type `IPostOptimizationFactory` that has been created
+         */
+        virtual std::unique_ptr<IPostOptimizationFactory> createPostOptimizationFactory() const = 0;
+
+};

--- a/cpp/subprojects/common/include/common/post_optimization/post_optimization_no.hpp
+++ b/cpp/subprojects/common/include/common/post_optimization/post_optimization_no.hpp
@@ -1,0 +1,19 @@
+/*
+ * @author Michael Rapp (michael.rapp.ml@gmail.com)
+ */
+#pragma once
+
+#include "common/post_optimization/post_optimization.hpp"
+
+
+/**
+ * Allows to configure a method that does not perform any optimizations, but retains a previously learned rule-based
+ * model.
+ */
+class NoPostOptimizationConfig final : public IPostOptimizationConfig {
+
+    public:
+
+        std::unique_ptr<IPostOptimizationFactory> createPostOptimizationFactory() const override;
+
+};

--- a/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage.hpp
+++ b/cpp/subprojects/common/include/common/rule_induction/rule_model_assemblage.hpp
@@ -8,6 +8,7 @@
 #include "common/input/label_matrix_row_wise.hpp"
 #include "common/model/model_builder.hpp"
 #include "common/rule_induction/rule_induction.hpp"
+#include "common/post_optimization/post_optimization.hpp"
 #include "common/sampling/label_sampling.hpp"
 #include "common/sampling/instance_sampling.hpp"
 #include "common/sampling/feature_sampling.hpp"
@@ -88,6 +89,9 @@ class IRuleModelAssemblageFactory {
          * @param postProcessorFactoryPtr       An unique pointer to an object of type `IPostProcessorFactory` that
          *                                      allows to create the implementation to be used for post-processing the
          *                                      predictions of rules
+         * @param postOptimizationFactoryPtr    An unique pointer to an object of type `IPostOptimizationFactory` that
+         *                                      allows to create the implementation to be used for optimizing a
+         *                                      rule-based model once it has been learned
          * @param stoppingCriterionFactories    A reference to a `std::forward_list` that stores unique pointers to
          *                                      objects of type `IStoppingCriterionFactory` that allow to create the
          *                                      implementations to be used to decide whether additional rules should be
@@ -104,6 +108,7 @@ class IRuleModelAssemblageFactory {
             std::unique_ptr<IPartitionSamplingFactory> partitionSamplingFactoryPtr,
             std::unique_ptr<IPruningFactory> pruningFactoryPtr,
             std::unique_ptr<IPostProcessorFactory> postProcessorFactoryPtr,
+            std::unique_ptr<IPostOptimizationFactory> postOptimizationFactoryPtr,
             std::forward_list<std::unique_ptr<IStoppingCriterionFactory>>& stoppingCriterionFactories) const = 0;
 
 };

--- a/cpp/subprojects/common/meson.build
+++ b/cpp/subprojects/common/meson.build
@@ -52,6 +52,7 @@ source_files = [
     'src/common/output/label_vector_set.cpp',
     'src/common/output/prediction_matrix_dense.cpp',
     'src/common/output/prediction_matrix_sparse_binary.cpp',
+    'src/common/post_optimization/post_optimization_no.cpp',
     'src/common/post_processing/post_processor_no.cpp',
     'src/common/pruning/pruning_irep.cpp',
     'src/common/pruning/pruning_no.cpp',

--- a/cpp/subprojects/common/src/common/post_optimization/post_optimization_no.cpp
+++ b/cpp/subprojects/common/src/common/post_optimization/post_optimization_no.cpp
@@ -1,0 +1,63 @@
+#include "common/post_optimization/post_optimization_no.hpp"
+
+
+/**
+ * An implementation of the class `IPostOptimization` that does not perform any optimizations, but retains a previously
+ * learned rule-based model.
+ */
+class NoPostOptimization final : public IPostOptimization {
+
+    private:
+
+        std::unique_ptr<IModelBuilder> modelBuilderPtr_;
+
+    public:
+
+        /**
+         * @param modelBuilderPtr An unique pointer to an object of type `IModelBuilder` that should be used to build
+         *                        the model
+         */
+        NoPostOptimization(std::unique_ptr<IModelBuilder> modelBuilderPtr)
+            : modelBuilderPtr_(std::move(modelBuilderPtr)) {
+
+        }
+
+        void setDefaultRule(std::unique_ptr<AbstractEvaluatedPrediction>& predictionPtr) override {
+            modelBuilderPtr_->setDefaultRule(predictionPtr);
+        }
+
+        void addRule(std::unique_ptr<ConditionList>& conditionListPtr,
+                     std::unique_ptr<AbstractEvaluatedPrediction>& predictionPtr) override {
+            modelBuilderPtr_->addRule(conditionListPtr, predictionPtr);
+        }
+
+        void optimizeModel(IThresholds& thresholds, const IRuleInduction& ruleInduction, IPartition& partition,
+                           IInstanceSampling& instanceSampling, IFeatureSampling& featureSampling,
+                           const IPruning& pruning, const IPostProcessor& postProcessor, RNG& rng) override {
+            return;
+        }
+
+        std::unique_ptr<IRuleModel> buildModel(uint32 numUsedRules) override {
+            return modelBuilderPtr_->buildModel(numUsedRules);
+        }
+
+};
+
+/**
+ * Allows to create instances of the type `IPostOptimization` that do not perform any optimizations, but retain a
+ * previously learned rule-based model.
+ */
+class NoPostOptimizationFactory final : public IPostOptimizationFactory {
+
+    public:
+
+        std::unique_ptr<IPostOptimization> create(const IModelBuilderFactory& modelBuilderFactory) const override {
+            std::unique_ptr<IModelBuilder> modelBuilderPtr = modelBuilderFactory.create();
+            return std::make_unique<NoPostOptimization>(std::move(modelBuilderPtr));
+        }
+
+};
+
+std::unique_ptr<IPostOptimizationFactory> NoPostOptimizationConfig::createPostOptimizationFactory() const {
+    return std::make_unique<NoPostOptimizationFactory>();
+}

--- a/doc/quickstart/parameters.inc.rst
+++ b/doc/quickstart/parameters.inc.rst
@@ -167,6 +167,10 @@ The following parameters allow to control the behavior of the algorithm:
   * ``'none'`` No pruning is used.
   * ``'irep'`` Subsequent conditions of rules may be pruned on a holdout set, similar to the IREP algorithm. Does only have an effect if the parameter ``instance_sampling`` is not set to ``'none'``.
 
+* ``post_optimization`` (Default value = ``'none'``)
+
+  * ``'none'`` No post-optimization is used.
+
 * ``head_type`` (Default value = ``'auto'``)
 
   * ``'auto'`` The most suitable type of rule heads is chosen automatically, depending on the loss function.

--- a/python/subprojects/boosting/mlrl/boosting/boosting_learners.py
+++ b/python/subprojects/boosting/mlrl/boosting/boosting_learners.py
@@ -14,7 +14,7 @@ from mlrl.common.rule_learners import AUTOMATIC, NONE, ARGUMENT_BIN_RATIO, \
 from mlrl.common.rule_learners import MLRuleLearner, SparsePolicy
 from mlrl.common.rule_learners import configure_rule_model_assemblage, configure_rule_induction, \
     configure_feature_binning, configure_label_sampling, configure_instance_sampling, configure_feature_sampling, \
-    configure_partition_sampling, configure_pruning, configure_parallel_rule_refinement, \
+    configure_partition_sampling, configure_pruning, configure_post_optimization, configure_parallel_rule_refinement, \
     configure_parallel_statistic_update, configure_parallel_prediction, configure_size_stopping_criterion, \
     configure_time_stopping_criterion
 from mlrl.common.rule_learners import parse_param, parse_param_and_options
@@ -179,6 +179,7 @@ class Boomer(MLRuleLearner, ClassifierMixin):
                  feature_binning: Optional[str] = None,
                  label_binning: Optional[str] = None,
                  pruning: Optional[str] = None,
+                 post_optimization: Optional[str] = None,
                  shrinkage: Optional[float] = 0.3,
                  l1_regularization_weight: Optional[float] = None,
                  l2_regularization_weight: Optional[float] = None,
@@ -245,6 +246,8 @@ class Boomer(MLRuleLearner, ClassifierMixin):
                                             the documentation
         :param pruning:                     The strategy that should be used to prune individual rules. Must be 'irep'
                                             or 'none', if no pruning should be used
+        :param post_optimization:           The strategy that should be used to optimize a model globally once it has
+                                            been learned. Must be `none`, if no post-optimization should be used
         :param shrinkage:                   The shrinkage parameter, a.k.a. the "learning rate", that should be used to
                                             shrink the weight of individual rules. Must be in (0, 1]
         :param l1_regularization_weight:    The weight of the L1 regularization. Must be at least 0
@@ -280,6 +283,7 @@ class Boomer(MLRuleLearner, ClassifierMixin):
         self.feature_binning = feature_binning
         self.label_binning = label_binning
         self.pruning = pruning
+        self.post_optimization = post_optimization
         self.shrinkage = shrinkage
         self.l1_regularization_weight = l1_regularization_weight
         self.l2_regularization_weight = l2_regularization_weight
@@ -333,6 +337,8 @@ class Boomer(MLRuleLearner, ClassifierMixin):
             name += '_label-binning=' + str(self.label_binning)
         if self.pruning is not None:
             name += '_pruning=' + str(self.pruning)
+        if self.post_optimization is not None:
+            name += '_post-optimization=' + str(self.post_optimization)
         if self.shrinkage is not None:
             name += '_shrinkage=' + str(self.shrinkage)
         if self.l1_regularization_weight is not None:
@@ -358,6 +364,7 @@ class Boomer(MLRuleLearner, ClassifierMixin):
         configure_feature_sampling(config, self.feature_sampling)
         configure_partition_sampling(config, self.holdout)
         configure_pruning(config, self.pruning)
+        configure_post_optimization(config, self.post_optimization)
         self.__configure_parallel_rule_refinement(config)
         self.__configure_parallel_statistic_update(config)
         configure_parallel_prediction(config, self.parallel_prediction)

--- a/python/subprojects/common/mlrl/common/cython/learner.pxd
+++ b/python/subprojects/common/mlrl/common/cython/learner.pxd
@@ -104,6 +104,8 @@ cdef extern from "common/learner.hpp" nogil:
 
         void useNoPostProcessor()
 
+        void useNoPostOptimization()
+
         void useNoParallelRuleRefinement()
 
         IManualMultiThreadingConfig& useParallelRuleRefinement()

--- a/python/subprojects/common/mlrl/common/cython/learner.pyx
+++ b/python/subprojects/common/mlrl/common/cython/learner.pyx
@@ -296,6 +296,13 @@ cdef class RuleLearnerConfig:
         cdef IRuleLearnerConfig* rule_learner_config_ptr = self.get_rule_learner_config_ptr()
         rule_learner_config_ptr.useNoPostProcessor()
 
+    def use_no_post_optimization(self):
+        """
+        Configures the rule learner to not optimize a model once it has been learned.
+        """
+        cdef IRuleLearnerConfig* rule_learner_config_ptr = self.get_rule_learner_config_ptr()
+        rule_learner_config_ptr.useNoPostOptimization()
+
     def use_no_parallel_rule_refinement(self):
         """
         Configures the rule learner to not use any multi-threading for the parallel refinement of rules.

--- a/python/subprojects/common/mlrl/common/rule_learners.py
+++ b/python/subprojects/common/mlrl/common/rule_learners.py
@@ -114,6 +114,10 @@ PRUNING_VALUES: Set[str] = {
     PRUNING_IREP
 }
 
+POST_OPTIMIZATION_VALUES: Set[str] = {
+    NONE
+}
+
 PARALLEL_VALUES: Dict[str, Set[str]] = {
     str(BooleanOption.TRUE.value): {ARGUMENT_NUM_THREADS},
     str(BooleanOption.FALSE.value): {}
@@ -245,6 +249,14 @@ def configure_pruning(config: RuleLearnerConfig, pruning: Optional[str]):
             config.use_no_pruning()
         elif value == PRUNING_IREP:
             config.use_irep_pruning()
+
+
+def configure_post_optimization(config: RuleLearnerConfig, post_optimization: Optional[str]):
+    if post_optimization is not None:
+        value = parse_param('post_optimization', post_optimization, POST_OPTIMIZATION_VALUES)
+
+        if value == NONE:
+            config.use_no_post_optimization()
 
 
 def configure_parallel_rule_refinement(config: RuleLearnerConfig, parallel_rule_refinement: Optional[str]):

--- a/python/subprojects/seco/mlrl/seco/seco_learners.py
+++ b/python/subprojects/seco/mlrl/seco/seco_learners.py
@@ -9,8 +9,9 @@ from mlrl.common.cython.learner import RuleLearner as RuleLearnerWrapper
 from mlrl.common.rule_learners import MLRuleLearner, SparsePolicy
 from mlrl.common.rule_learners import configure_rule_model_assemblage, configure_rule_induction, \
     configure_label_sampling, configure_instance_sampling, configure_feature_sampling, configure_partition_sampling, \
-    configure_pruning, configure_parallel_rule_refinement, configure_parallel_statistic_update, \
-    configure_parallel_prediction, configure_size_stopping_criterion, configure_time_stopping_criterion
+    configure_pruning, configure_post_optimization, configure_parallel_rule_refinement, \
+    configure_parallel_statistic_update, configure_parallel_prediction, configure_size_stopping_criterion, \
+    configure_time_stopping_criterion
 from mlrl.common.rule_learners import parse_param, parse_param_and_options
 from mlrl.seco.cython.learner import SeCoRuleLearner as SeCoRuleLearnerWrapper, SeCoRuleLearnerConfig
 from sklearn.base import ClassifierMixin
@@ -93,6 +94,7 @@ class SeCoRuleLearner(MLRuleLearner, ClassifierMixin):
                  feature_sampling: Optional[str] = None,
                  holdout: Optional[str] = None,
                  pruning: Optional[str] = None,
+                 post_optimization: Optional[str] = None,
                  parallel_rule_refinement: Optional[str] = None,
                  parallel_statistic_update: Optional[str] = None,
                  parallel_prediction: Optional[str] = None):
@@ -134,6 +136,8 @@ class SeCoRuleLearner(MLRuleLearner, ClassifierMixin):
                                             documentation
         :param pruning:                     The strategy that should be used to prune individual rules. Must be 'irep'
                                             or 'none', if no pruning should be used
+        :param post_optimization:           The strategy that should be used to optimize a model globally once it has
+                                            been learned. Must be `none`, if no post-optimization should be used
         :param parallel_rule_refinement:    Whether potential refinements of rules should be searched for in parallel or
                                             not. Must be 'true', 'false' or 'auto', if the most suitable strategy should
                                             be chosen automatically depending on the loss function. For additional
@@ -160,6 +164,7 @@ class SeCoRuleLearner(MLRuleLearner, ClassifierMixin):
         self.feature_sampling = feature_sampling
         self.holdout = holdout
         self.pruning = pruning
+        self.post_optimization = post_optimization
         self.parallel_rule_refinement = parallel_rule_refinement
         self.parallel_statistic_update = parallel_statistic_update
         self.parallel_prediction = parallel_prediction
@@ -200,6 +205,8 @@ class SeCoRuleLearner(MLRuleLearner, ClassifierMixin):
             name += '_holdout=' + str(self.holdout)
         if self.pruning is not None:
             name += '_pruning=' + str(self.pruning)
+        if self.post_optimization is not None:
+            name += '_post-optimization=' + str(self.post_optimization)
         if self.parallel_rule_refinement is not None:
             name += '_parallel-rule-refinement=' + str(self.parallel_rule_refinement)
         if self.parallel_statistic_update is not None:
@@ -217,6 +224,7 @@ class SeCoRuleLearner(MLRuleLearner, ClassifierMixin):
         configure_feature_sampling(config, self.feature_sampling)
         configure_partition_sampling(config, self.holdout)
         configure_pruning(config, self.pruning)
+        configure_post_optimization(config, self.post_optimization)
         configure_parallel_rule_refinement(config, self.parallel_rule_refinement)
         configure_parallel_statistic_update(config, self.parallel_statistic_update)
         configure_parallel_prediction(config, self.parallel_prediction)

--- a/python/subprojects/testbed/mlrl/testbed/args.py
+++ b/python/subprojects/testbed/mlrl/testbed/args.py
@@ -10,7 +10,7 @@ from enum import Enum
 from mlrl.common.options import BooleanOption
 from mlrl.common.rule_learners import SparsePolicy, RULE_MODEL_ASSEMBLAGE_VALUES, RULE_INDUCTION_VALUES, \
     LABEL_SAMPLING_VALUES, FEATURE_SAMPLING_VALUES, INSTANCE_SAMPLING_VALUES, PARTITION_SAMPLING_VALUES, \
-    PRUNING_VALUES, PARALLEL_VALUES
+    PRUNING_VALUES, POST_OPTIMIZATION_VALUES, PARALLEL_VALUES
 from mlrl.common.strings import format_enum_values, format_string_set, format_dict_keys
 
 PARAM_LOG_LEVEL = '--log-level'
@@ -82,6 +82,8 @@ PARAM_PARTITION_SAMPLING = '--holdout'
 PARAM_PRUNING = '--pruning'
 
 PARAM_RULE_MODEL_ASSEMBLAGE = '--rule-model-assemblage'
+
+PARAM_POST_OPTIMIZATION = '--post-optimization'
 
 PARAM_RULE_INDUCTION = '--rule-induction'
 
@@ -276,6 +278,9 @@ def add_rule_learner_arguments(parser: ArgumentParser):
     parser.add_argument(PARAM_RULE_MODEL_ASSEMBLAGE, type=str,
                         help='The name of the algorithm to be used for the induction of several rule. Must be one of '
                              + format_string_set(RULE_MODEL_ASSEMBLAGE_VALUES) + '.')
+    parser.add_argument(PARAM_POST_OPTIMIZATION, type=str,
+                        help='The name of the strategy to be used for optimizing a model globally once it has been '
+                             + 'learned. Must be one of ' + format_string_set(POST_OPTIMIZATION_VALUES) + '.')
     parser.add_argument(PARAM_RULE_INDUCTION, type=str,
                         help='The name of the algorithm to be used for the induction of individual rules. Must be one '
                              + 'of ' + format_string_set(RULE_INDUCTION_VALUES) + '. For additional options refer to '

--- a/python/subprojects/testbed/mlrl/testbed/main_boomer.py
+++ b/python/subprojects/testbed/mlrl/testbed/main_boomer.py
@@ -53,6 +53,7 @@ class BoomerRunnable(RuleLearnerRunnable):
                       classification_predictor=args.classification_predictor,
                       probability_predictor=args.probability_predictor,
                       pruning=args.pruning,
+                      post_optimization=args.post_optimization,
                       label_sampling=args.label_sampling,
                       instance_sampling=args.instance_sampling,
                       shrinkage=args.shrinkage,

--- a/python/subprojects/testbed/mlrl/testbed/main_seco.py
+++ b/python/subprojects/testbed/mlrl/testbed/main_seco.py
@@ -33,6 +33,7 @@ class SeCoRunnable(RuleLearnerRunnable):
                                heuristic=args.heuristic,
                                pruning_heuristic=args.pruning_heuristic,
                                pruning=args.pruning,
+                               post_optimization=args.post_optimization,
                                label_sampling=args.label_sampling,
                                instance_sampling=args.instance_sampling,
                                feature_sampling=args.feature_sampling,


### PR DESCRIPTION
Fügt die Möglichkeit hinzu, ein zuvor gelerntes Modell abschließend zu optimieren. Aktuell sind jedoch noch keine dementsprechenden Methoden implementiert. Dieser Pull-Request ergänzt stattdessen die dafür notwendigen Klassen und Konfigurationsmöglichkeiten, einschließlich eines neuen Kommandozeilenarguments `--post-optimization` (aktuell ist der einzige zugelassene Wert `none`).