### PR TITLE
Refactoring bezüglich Klasse AbstractRuleInduction

### DIFF
--- a/cpp/subprojects/common/src/common/rule_induction/rule_induction_common.hpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_induction_common.hpp
@@ -13,7 +13,51 @@
  */
 class AbstractRuleInduction : public IRuleInduction {
 
+    private:
+
+        bool recalculatePredictions_;
+
+    protected:
+
+        /**
+         * Must be implemented by subclasses in order to grow rule.
+         *
+         * @param thresholds        A reference to an object of type `IThresholds` that provides access to the
+         *                          thresholds that may be used by the conditions of the rule
+         * @param labelIndices      A reference to an object of type `IIndexVector` that provides access to the indices
+         *                          of the labels for which the rule may predict
+         * @param weights           A reference to an object of type `IWeightVector` that provides access to the weights
+         *                          of individual training examples
+         * @param partition         A reference to an object of type `IPartition` that provides access to the indices of
+         *                          the training examples that belong to the training set and the holdout set,
+         *                          respectively
+         * @param featureSampling   A reference to an object of type `IFeatureSampling` that should be used for sampling
+         *                          the features that may be used by a new condition
+         * @param rng               A reference to an object of type `RNG` that implements the random number generator
+         *                          to be used
+         * @param conditionListPtr  A reference to an unique pointer of type `ConditionList` that should be used to
+         *                          store the conditions of the rule
+         * @param headPtr           A reference to an unique pointer of type `AbstractEvaluatedPrediction` that should
+         *                          be used to store the head of the rule
+         * @return                  An unique pointer to an object of type `IThresholdsSubset` that has been used to
+         *                          grow the rule
+         */
+        virtual std::unique_ptr<IThresholdsSubset> growRule(
+            IThresholds& thresholds, const IIndexVector& labelIndices, const IWeightVector& weights,
+            IPartition& partition, IFeatureSampling& featureSampling, RNG& rng,
+            std::unique_ptr<ConditionList>& conditionListPtr,
+            std::unique_ptr<AbstractEvaluatedPrediction>& headPtr) const = 0;
+
     public:
+
+        /**
+         * @param recalculatePredictions True, if the predictions of rules should be recalculated on all training
+         *                               examples, if some of the examples have zero weights, false otherwise
+         */
+        AbstractRuleInduction(bool recalculatePredictions)
+            : recalculatePredictions_(recalculatePredictions) {
+
+        }
 
         virtual ~AbstractRuleInduction() override { };
 
@@ -38,6 +82,49 @@ class AbstractRuleInduction : public IRuleInduction {
             }
 
             modelBuilder.setDefaultRule(defaultPredictionPtr);
+        }
+
+        bool induceRule(IThresholds& thresholds, const IIndexVector& labelIndices, const IWeightVector& weights,
+                        IPartition& partition, IFeatureSampling& featureSampling, const IPruning& pruning,
+                        const IPostProcessor& postProcessor, RNG& rng,
+                        IModelBuilder& modelBuilder) const override final {
+            std::unique_ptr<ConditionList> conditionListPtr;
+            std::unique_ptr<AbstractEvaluatedPrediction> headPtr;
+            std::unique_ptr<IThresholdsSubset> thresholdsSubsetPtr = this->growRule(thresholds, labelIndices, weights,
+                                                                                    partition, featureSampling, rng,
+                                                                                    conditionListPtr, headPtr);
+
+            if (headPtr) {
+                if (weights.hasZeroWeights()) {
+                    // Prune rule...
+                    IStatisticsProvider& statisticsProvider = thresholds.getStatisticsProvider();
+                    statisticsProvider.switchToPruningRuleEvaluation();
+                    std::unique_ptr<ICoverageState> coverageStatePtr = pruning.prune(*thresholdsSubsetPtr, partition,
+                                                                                     *conditionListPtr, *headPtr);
+                    statisticsProvider.switchToRegularRuleEvaluation();
+
+                    // Re-calculate the scores in the head based on the entire training data...
+                    if (recalculatePredictions_) {
+                        const ICoverageState& coverageState =
+                            coverageStatePtr ? *coverageStatePtr : thresholdsSubsetPtr->getCoverageState();
+                        partition.recalculatePrediction(*thresholdsSubsetPtr, coverageState, *headPtr);
+                    }
+                }
+
+                // Apply post-processor...
+                postProcessor.postProcess(*headPtr);
+
+                // Update the statistics by applying the predictions of the new rule...
+                thresholdsSubsetPtr->applyPrediction(*headPtr);
+
+                // Add the induced rule to the model...
+                modelBuilder.addRule(conditionListPtr, headPtr);
+                return true;
+            } else {
+                // No rule could be induced, because no useful condition could be found. This might be the case, if all
+                // examples have the same values for the considered features.
+                return false;
+            }
         }
 
 };

--- a/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down_greedy.cpp
+++ b/cpp/subprojects/common/src/common/rule_induction/rule_induction_top_down_greedy.cpp
@@ -31,8 +31,6 @@ class GreedyTopDownRuleInduction final : public AbstractRuleInduction {
 
         uint32 maxHeadRefinements_;
 
-        bool recalculatePredictions_;
-
         uint32 numThreads_;
 
     public:
@@ -52,18 +50,23 @@ class GreedyTopDownRuleInduction final : public AbstractRuleInduction {
          */
         GreedyTopDownRuleInduction(uint32 minCoverage, uint32 maxConditions, uint32 maxHeadRefinements,
                                    bool recalculatePredictions, uint32 numThreads)
-            : minCoverage_(minCoverage), maxConditions_(maxConditions), maxHeadRefinements_(maxHeadRefinements),
-              recalculatePredictions_(recalculatePredictions), numThreads_(numThreads) {
+            : AbstractRuleInduction(recalculatePredictions),
+              minCoverage_(minCoverage), maxConditions_(maxConditions), maxHeadRefinements_(maxHeadRefinements),
+              numThreads_(numThreads) {
 
         }
 
-        bool induceRule(IThresholds& thresholds, const IIndexVector& labelIndices, const IWeightVector& weights,
-                        IPartition& partition, IFeatureSampling& featureSampling, const IPruning& pruning,
-                        const IPostProcessor& postProcessor, RNG& rng, IModelBuilder& modelBuilder) const override {
+    protected:
+
+        std::unique_ptr<IThresholdsSubset> growRule(
+                IThresholds& thresholds, const IIndexVector& labelIndices, const IWeightVector& weights,
+                IPartition& partition, IFeatureSampling& featureSampling, RNG& rng,
+                std::unique_ptr<ConditionList>& conditionListPtr,
+                std::unique_ptr<AbstractEvaluatedPrediction>& headPtr) const override {
             // The label indices for which the next refinement of the rule may predict
             const IIndexVector* currentLabelIndices = &labelIndices;
             // A list that contains the conditions in the rule's body (in the order they have been learned)
-            std::unique_ptr<ConditionList> conditionListPtr = std::make_unique<ConditionList>();
+            conditionListPtr = std::make_unique<ConditionList>();
             // The comparator that is used to keep track of the best refinement of the rule
             SingleRefinementComparator refinementComparator;
             // Whether a refinement of the current rule has been found
@@ -132,41 +135,9 @@ class GreedyTopDownRuleInduction final : public AbstractRuleInduction {
                 }
             }
 
-
-            if (refinementComparator.getNumElements() > 0) {
-                Refinement& bestRefinement = *refinementComparator.begin();
-
-                if (weights.hasZeroWeights()) {
-                    // Prune rule...
-                    IStatisticsProvider& statisticsProvider = thresholds.getStatisticsProvider();
-                    statisticsProvider.switchToPruningRuleEvaluation();
-                    std::unique_ptr<ICoverageState> coverageStatePtr = pruning.prune(*thresholdsSubsetPtr, partition,
-                                                                                     *conditionListPtr,
-                                                                                     *bestRefinement.headPtr);
-                    statisticsProvider.switchToRegularRuleEvaluation();
-
-                    // Re-calculate the scores in the head based on the entire training data...
-                    if (recalculatePredictions_) {
-                        const ICoverageState& coverageState =
-                            coverageStatePtr ? *coverageStatePtr : thresholdsSubsetPtr->getCoverageState();
-                        partition.recalculatePrediction(*thresholdsSubsetPtr, coverageState, *bestRefinement.headPtr);
-                    }
-                }
-
-                // Apply post-processor...
-                postProcessor.postProcess(*bestRefinement.headPtr);
-
-                // Update the statistics by applying the predictions of the new rule...
-                thresholdsSubsetPtr->applyPrediction(*bestRefinement.headPtr);
-
-                // Add the induced rule to the model...
-                modelBuilder.addRule(conditionListPtr, bestRefinement.headPtr);
-                return true;
-            } else {
-                // No rule could be induced, because no useful condition could be found. This might be the case, if all
-                // examples have the same values for the considered features.
-                return false;
-            }
+            Refinement& bestRefinement = *refinementComparator.begin();
+            headPtr = std::move(bestRefinement.headPtr);
+            return thresholdsSubsetPtr;
         }
 
 };


### PR DESCRIPTION
Führt die Änderungen in #618 fort, indem die dort hinzugefügt Klasse `AbstractRuleInduction` erweitert wird. Sie implementiert nun neben der Funktion `induceDefaultRule` auch die Funktion `induceRule` der Klasse `IRuleInduction`. Für das eigentliche Lernen der Regel wird eine neue abstrakte Methode `growRule` verwendet, die von Unterklassen auf verschiedene Art und Weise implementiert werden kann. Anschließend kann die durch diese Funktion gebildetete Regel durch die Implementierung in `AbstractRuleInduction` weitervearbeitet werden. Je nach Bedarf wird die Regel dabei geprunt oder ihre Vorhersagen werden angepasst, bevor die Regel letztendlich zum Modell hinzugefügt wird.