### PR TITLE
Refactoring bezüglich der Klasse ConditionList

### DIFF
--- a/cpp/subprojects/common/include/common/model/condition_list.hpp
+++ b/cpp/subprojects/common/include/common/model/condition_list.hpp
@@ -59,7 +59,7 @@ class ConditionList final {
         /**
          * Removes the last condition from the list.
          */
-        void removeLast();
+        void removeLastCondition();
 
         /**
          * Creates and returns a new object of type `ConjunctiveBody` from the conditions that contained by this list.

--- a/cpp/subprojects/common/src/common/model/condition_list.cpp
+++ b/cpp/subprojects/common/src/common/model/condition_list.cpp
@@ -18,7 +18,7 @@ void ConditionList::addCondition(const Condition& condition) {
     vector_.emplace_back(condition);
 }
 
-void ConditionList::removeLast() {
+void ConditionList::removeLastCondition() {
     const Condition& condition = vector_.back();
     numConditionsPerComparator_[condition.comparator] -= 1;
     vector_.pop_back();

--- a/cpp/subprojects/common/src/common/pruning/pruning_irep.cpp
+++ b/cpp/subprojects/common/src/common/pruning/pruning_irep.cpp
@@ -58,7 +58,7 @@ class Irep final : public IPruning {
 
                 // Remove the pruned conditions...
                 while (numPrunedConditions > 0) {
-                    conditions.removeLast();
+                    conditions.removeLastCondition();
                     numPrunedConditions--;
                 }
             }


### PR DESCRIPTION
Enthält folgende Änderungen bezüglich der Klasse `ConditionList`:

* Die Klasse verwendet nun intern die Datenstruktur `std::vector` statt `std::list`.
* Die Funktion `removeLast` wurde umbenannt zu `removeLastCondition`.