### PR TITLE
Refactoring bezüglich der Klasse RuleList

### DIFF
--- a/cpp/subprojects/common/include/common/model/rule_list.hpp
+++ b/cpp/subprojects/common/include/common/model/rule_list.hpp
@@ -6,8 +6,7 @@
 #include "common/model/rule_model.hpp"
 #include "common/model/body.hpp"
 #include "common/model/head.hpp"
-#include <forward_list>
-#include <iterator>
+#include <vector>
 
 
 /**
@@ -130,94 +129,7 @@ class RuleList final : public IRuleList {
 
     private:
 
-        /**
-         * Allows to iterate only the used rules.
-         */
-        class RuleConstIterator final {
-
-            private:
-
-                std::forward_list<Rule>::const_iterator iterator_;
-
-                uint32 index_;
-
-            public:
-
-                /**
-                 * @param list  A reference to the list that stores all available rules
-                 * @param index The index to start at
-                 */
-                RuleConstIterator(const std::forward_list<Rule>& list, uint32 index);
-
-                /**
-                 * The type that is used to represent the difference between two iterators.
-                 */
-                typedef int difference_type;
-
-                /**
-                 * The type of the elements, the iterator provides access to.
-                 */
-                typedef const Rule value_type;
-
-                /**
-                 * The type of a pointer to an element, the iterator provides access to.
-                 */
-                typedef const Rule* pointer;
-
-                /**
-                 * The type of a reference to an element, the iterator provides access to.
-                 */
-                typedef const Rule& reference;
-
-                /**
-                 * The tag that specifies the capabilities of the iterator.
-                 */
-                typedef std::forward_iterator_tag iterator_category;
-
-                /**
-                 * Returns the element, the iterator currently refers to.
-                 *
-                 * @return The element, the iterator currently refers to
-                 */
-                reference operator*() const;
-
-                /**
-                 * Returns an iterator that refers to the next element.
-                 *
-                 * @return A reference to an iterator that refers to the next element
-                 */
-                RuleConstIterator& operator++();
-
-                /**
-                 * Returns an iterator that refers to the next element.
-                 *
-                 * @return A reference to an iterator that refers to the next element
-                 */
-                RuleConstIterator& operator++(int n);
-
-                /**
-                 * Returns whether this iterator and another one refer to the same element.
-                 *
-                 * @param rhs   A reference to another iterator
-                 * @return      True, if the iterators do not refer to the same element, false otherwise
-                 */
-                bool operator!=(const RuleConstIterator& rhs) const;
-
-                /**
-                 * Returns whether this iterator and another one refer to the same element.
-                 *
-                 * @param rhs   A reference to another iterator
-                 * @return      True, if the iterators refer to the same element, false otherwise
-                 */
-                bool operator==(const RuleConstIterator& rhs) const;
-
-        };
-
-        std::forward_list<Rule> list_;
-
-        std::forward_list<Rule>::iterator it_;
-
-        uint32 numRules_;
+        std::vector<Rule> list_;
 
         uint32 numUsedRules_;
 
@@ -228,42 +140,37 @@ class RuleList final : public IRuleList {
         RuleList();
 
         /**
-         * An iterator that provides read-only access to all rules.
+         * An iterator that provides read-only access to the rules.
          */
-        typedef std::forward_list<Rule>::const_iterator const_iterator;
+        typedef std::vector<Rule>::const_iterator const_iterator;
 
         /**
-         * An iterator that provides read-only access to the used rules.
-         */
-        typedef RuleConstIterator used_const_iterator;
-
-        /**
-         * Returns a `const_iterator` to the beginning of the rules.
+         * Returns a `const_iterator` to the beginning of all rules.
          *
          * @return A `const_iterator` to the beginning
          */
         const_iterator cbegin() const;
 
         /**
-         * Returns a `const_iterator` to the end of the rules.
+         * Returns a `const_iterator` to the end of all rules.
          *
          * @return A `const_iterator` to the end
          */
         const_iterator cend() const;
 
         /**
-         * Returns an `used_const_iterator` to the beginning of the used rules.
+         * Returns a `const_iterator` to the beginning of the used rules.
          *
-         * @return An `used_const_iterator` to the beginning
+         * @return A `const_iterator` to the beginning
          */
-        used_const_iterator used_cbegin() const;
+        const_iterator used_cbegin() const;
 
         /**
-         * Returns an `used_const_iterator` to the end of the used rules.
+         * Returns a `const_iterator` to the end of the used rules.
          *
-         * @return An `used_const_iterator` to the end
+         * @return A `const_iterator` to the end
          */
-        used_const_iterator used_cend() const;
+        const_iterator used_cend() const;
 
         uint32 getNumRules() const override;
 

--- a/cpp/subprojects/common/src/common/model/rule_list.cpp
+++ b/cpp/subprojects/common/src/common/model/rule_list.cpp
@@ -27,37 +27,8 @@ void RuleList::Rule::visit(IBody::EmptyBodyVisitor emptyBodyVisitor,
     headPtr_->visit(completeHeadVisitor, partialHeadVisitor);
 }
 
-RuleList::RuleConstIterator::RuleConstIterator(const std::forward_list<Rule>& list, uint32 index)
-    : iterator_(list.cbegin()), index_(index) {
-
-}
-
-RuleList::RuleConstIterator::reference RuleList::RuleConstIterator::operator*() const {
-    return *iterator_;
-}
-
-RuleList::RuleConstIterator& RuleList::RuleConstIterator::operator++() {
-    ++iterator_;
-    ++index_;
-    return *this;
-}
-
-RuleList::RuleConstIterator& RuleList::RuleConstIterator::operator++(int n) {
-    iterator_++;
-    index_++;
-    return *this;
-}
-
-bool RuleList::RuleConstIterator::operator!=(const RuleConstIterator& rhs) const {
-    return index_ != rhs.index_;
-}
-
-bool RuleList::RuleConstIterator::operator==(const RuleConstIterator& rhs) const {
-    return index_ == rhs.index_;
-}
-
 RuleList::RuleList()
-    : it_(list_.begin()), numRules_(0), numUsedRules_(0), containsDefaultRule_(false) {
+    : numUsedRules_(0), containsDefaultRule_(false) {
 
 }
 
@@ -69,20 +40,20 @@ RuleList::const_iterator RuleList::cend() const {
     return list_.cend();
 }
 
-RuleList::used_const_iterator RuleList::used_cbegin() const {
-    return RuleConstIterator(list_, 0);
+RuleList::const_iterator RuleList::used_cbegin() const {
+    return list_.cbegin();
 }
 
-RuleList::used_const_iterator RuleList::used_cend() const {
-    return RuleConstIterator(list_, this->getNumUsedRules());
+RuleList::const_iterator RuleList::used_cend() const {
+    return list_.cbegin() + this->getNumUsedRules();
 }
 
 uint32 RuleList::getNumRules() const {
-    return numRules_;
+    return (uint32) list_.size();
 }
 
 uint32 RuleList::getNumUsedRules() const {
-    return numUsedRules_ > 0 ? numUsedRules_ : numRules_;;
+    return numUsedRules_ > 0 ? numUsedRules_ : this->getNumRules();
 }
 
 void RuleList::setNumUsedRules(uint32 numUsedRules) {
@@ -95,14 +66,7 @@ void RuleList::addDefaultRule(std::unique_ptr<IHead> headPtr) {
 }
 
 void RuleList::addRule(std::unique_ptr<IBody> bodyPtr, std::unique_ptr<IHead> headPtr) {
-    if (numRules_ > 0) {
-        it_ = list_.emplace_after(it_, std::move(bodyPtr), std::move(headPtr));
-    } else {
-        list_.emplace_front(std::move(bodyPtr), std::move(headPtr));
-        it_ = list_.begin();
-    }
-
-    numRules_++;
+    list_.emplace_back(std::move(bodyPtr), std::move(headPtr));
 }
 
 bool RuleList::containsDefaultRule() const {


### PR DESCRIPTION
Ändert die Implementierung der Klasse `RuleList` ab, so dass zukünftig die  Datenstruktur `std::vector` statt `std::forward_list` verwendet wird um die Regeln in einem Modell zu speichern.