### PR TITLE
Integrationstests für Early-Stopping

### DIFF
--- a/python/subprojects/testbed/tests/res/out/boomer/early-stopping_no-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/early-stopping_no-holdout.txt
@@ -1,0 +1,40 @@
+INFO Starting experiment...
+INFO Using separate training and test sets...
+DEBUG Parsing meta data from file "python/subprojects/testbed/tests/res/data/emotions.xml"...
+DEBUG Loading data set from file "python/subprojects/testbed/tests/res/data/emotions.arff"...
+INFO Fitting model to 397 training examples...
+DEBUG A dense matrix is used to store the feature values of the training examples
+DEBUG A dense matrix is used to store the labels of the training examples
+INFO Successfully fit model in 0.4215254269656725 seconds
+INFO Predicting for 196 test examples...
+DEBUG A dense matrix is used to store the feature values of the query examples
+DEBUG A dense matrix is used to store the predicted labels
+INFO Successfully predicted in 0.0019687419990077615 seconds
+INFO Overall evaluation result on test data:
+
+Ex.-based F1: 0.564625850340136
+Ex.-based Jacc.: 0.4906462585034013
+Ex.-based Prec.: 0.8001700680272108
+Ex.-based Rec.: 0.5620748299319728
+Hamm. Acc.: 0.8035714285714286
+Hamm. Loss: 0.19642857142857142
+Ma. F1: 0.6258820572489588
+Ma. Jacc.: 0.4695418730921544
+Ma. Prec.: 0.7620437751691581
+Ma. Rec.: 0.5507086145146604
+Mi. F1: 0.6451612903225807
+Mi. Jacc.: 0.47619047619047616
+Mi. Prec.: 0.7608695652173914
+Mi. Rec.: 0.56
+Subs. 0/1 Loss: 0.7448979591836735
+Subs. Acc.: 0.25510204081632654
+
+INFO Model characteristics:
+
+Rules: 999 (plus a default rule with 0 positive and 6 negative predictions that is excluded from the following statistics)
+Conditions per rule: avg. 5.568568568568568, min. 1, max. 16
+Conditions total: 5563 (50.386482113967276% use <= operator, 49.61351788603272% use > operator, 0.0% use == operator, 0.0% use != operator)
+Predictions per rule: avg. 1.0, min. 1, max. 1
+Predictions total: 999 (45.845845845845844% positive, 54.154154154154156% negative)
+
+INFO Successfully finished after 0.49612353899283335 seconds

--- a/python/subprojects/testbed/tests/res/out/boomer/early-stopping_random-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/early-stopping_random-holdout.txt
@@ -1,0 +1,40 @@
+INFO Starting experiment...
+INFO Using separate training and test sets...
+DEBUG Parsing meta data from file "python/subprojects/testbed/tests/res/data/emotions.xml"...
+DEBUG Loading data set from file "python/subprojects/testbed/tests/res/data/emotions.arff"...
+INFO Fitting model to 397 training examples...
+DEBUG A dense matrix is used to store the feature values of the training examples
+DEBUG A dense matrix is used to store the labels of the training examples
+INFO Successfully fit model in 0.11534521001158282 seconds
+INFO Predicting for 196 test examples...
+DEBUG A dense matrix is used to store the feature values of the query examples
+DEBUG A dense matrix is used to store the predicted labels
+INFO Successfully predicted in 0.000917620025575161 seconds
+INFO Overall evaluation result on test data:
+
+Ex.-based F1: 0.5462585034013605
+Ex.-based Jacc.: 0.4736394557823129
+Ex.-based Prec.: 0.7619047619047619
+Ex.-based Rec.: 0.53656462585034
+Hamm. Acc.: 0.7916666666666666
+Hamm. Loss: 0.20833333333333334
+Ma. F1: 0.5865215502995011
+Ma. Jacc.: 0.4312750392765879
+Ma. Prec.: 0.7431273660450518
+Ma. Rec.: 0.5133212663594079
+Mi. F1: 0.6213292117465224
+Mi. Jacc.: 0.45067264573991034
+Mi. Prec.: 0.7389705882352942
+Mi. Rec.: 0.536
+Subs. 0/1 Loss: 0.75
+Subs. Acc.: 0.25
+
+INFO Model characteristics:
+
+Rules: 161 (plus a default rule with 0 positive and 6 negative predictions that is excluded from the following statistics)
+Conditions per rule: avg. 4.565217391304348, min. 1, max. 13
+Conditions total: 735 (50.61224489795918% use <= operator, 49.38775510204081% use > operator, 0.0% use == operator, 0.0% use != operator)
+Predictions per rule: avg. 1.0, min. 1, max. 1
+Predictions total: 161 (47.20496894409938% positive, 52.79503105590062% negative)
+
+INFO Successfully finished after 0.1737417600234039 seconds

--- a/python/subprojects/testbed/tests/res/out/boomer/early-stopping_stratified-example-wise-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/early-stopping_stratified-example-wise-holdout.txt
@@ -1,0 +1,40 @@
+INFO Starting experiment...
+INFO Using separate training and test sets...
+DEBUG Parsing meta data from file "python/subprojects/testbed/tests/res/data/emotions.xml"...
+DEBUG Loading data set from file "python/subprojects/testbed/tests/res/data/emotions.arff"...
+INFO Fitting model to 397 training examples...
+DEBUG A dense matrix is used to store the feature values of the training examples
+DEBUG A dense matrix is used to store the labels of the training examples
+INFO Successfully fit model in 0.1402127710171044 seconds
+INFO Predicting for 196 test examples...
+DEBUG A dense matrix is used to store the feature values of the query examples
+DEBUG A dense matrix is used to store the predicted labels
+INFO Successfully predicted in 0.0008720110054127872 seconds
+INFO Overall evaluation result on test data:
+
+Ex.-based F1: 0.5539115646258503
+Ex.-based Jacc.: 0.4736394557823129
+Ex.-based Prec.: 0.7882653061224489
+Ex.-based Rec.: 0.5442176870748299
+Hamm. Acc.: 0.7882653061224489
+Hamm. Loss: 0.21173469387755103
+Ma. F1: 0.5890870849641114
+Ma. Jacc.: 0.4321308974153719
+Ma. Prec.: 0.7260125421106336
+Ma. Rec.: 0.5149984493614034
+Mi. F1: 0.6127527216174182
+Mi. Jacc.: 0.44170403587443946
+Mi. Prec.: 0.7350746268656716
+Mi. Rec.: 0.5253333333333333
+Subs. 0/1 Loss: 0.7704081632653061
+Subs. Acc.: 0.22959183673469388
+
+INFO Model characteristics:
+
+Rules: 277 (plus a default rule with 0 positive and 6 negative predictions that is excluded from the following statistics)
+Conditions per rule: avg. 4.364620938628159, min. 1, max. 18
+Conditions total: 1209 (51.36476426799007% use <= operator, 48.635235732009924% use > operator, 0.0% use == operator, 0.0% use != operator)
+Predictions per rule: avg. 1.0, min. 1, max. 1
+Predictions total: 277 (45.48736462093863% positive, 54.51263537906137% negative)
+
+INFO Successfully finished after 0.20119999395683408 seconds

--- a/python/subprojects/testbed/tests/res/out/boomer/early-stopping_stratified-label-wise-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/early-stopping_stratified-label-wise-holdout.txt
@@ -1,0 +1,40 @@
+INFO Starting experiment...
+INFO Using separate training and test sets...
+DEBUG Parsing meta data from file "python/subprojects/testbed/tests/res/data/emotions.xml"...
+DEBUG Loading data set from file "python/subprojects/testbed/tests/res/data/emotions.arff"...
+INFO Fitting model to 397 training examples...
+DEBUG A dense matrix is used to store the feature values of the training examples
+DEBUG A dense matrix is used to store the labels of the training examples
+INFO Successfully fit model in 0.1345250679878518 seconds
+INFO Predicting for 196 test examples...
+DEBUG A dense matrix is used to store the feature values of the query examples
+DEBUG A dense matrix is used to store the predicted labels
+INFO Successfully predicted in 0.0008700449834577739 seconds
+INFO Overall evaluation result on test data:
+
+Ex.-based F1: 0.5712585034013605
+Ex.-based Jacc.: 0.49574829931972786
+Ex.-based Prec.: 0.7797619047619048
+Ex.-based Rec.: 0.5688775510204082
+Hamm. Acc.: 0.8027210884353742
+Hamm. Loss: 0.19727891156462585
+Ma. F1: 0.62542772726505
+Ma. Jacc.: 0.4661541119632077
+Ma. Prec.: 0.751218765557001
+Ma. Rec.: 0.559008134363176
+Mi. F1: 0.6506024096385542
+Mi. Jacc.: 0.48214285714285715
+Mi. Prec.: 0.7474048442906575
+Mi. Rec.: 0.576
+Subs. 0/1 Loss: 0.7346938775510203
+Subs. Acc.: 0.2653061224489796
+
+INFO Model characteristics:
+
+Rules: 207 (plus a default rule with 0 positive and 6 negative predictions that is excluded from the following statistics)
+Conditions per rule: avg. 4.57487922705314, min. 1, max. 14
+Conditions total: 947 (55.01583949313622% use <= operator, 44.98416050686378% use > operator, 0.0% use == operator, 0.0% use != operator)
+Predictions per rule: avg. 1.0, min. 1, max. 1
+Predictions total: 207 (45.893719806763286% positive, 54.106280193236714% negative)
+
+INFO Successfully finished after 0.19326081301551312 seconds

--- a/python/subprojects/testbed/tests/test_boosting.py
+++ b/python/subprojects/testbed/tests/test_boosting.py
@@ -4,7 +4,8 @@ Author: Michael Rapp (michael.rapp.ml@gmail.com)
 from os import path
 
 from test_common import CommonIntegrationTests, CmdBuilder, DIR_OUT, DIR_DATA, DATASET_EMOTIONS, \
-    PREDICTION_TYPE_SCORES, PREDICTION_TYPE_PROBABILITIES
+    PREDICTION_TYPE_SCORES, PREDICTION_TYPE_PROBABILITIES, HOLDOUT_NO, HOLDOUT_RANDOM, HOLDOUT_STRATIFIED_LABEL_WISE, \
+    HOLDOUT_STRATIFIED_EXAMPLE_WISE
 
 CMD_BOOMER = 'boomer'
 
@@ -47,6 +48,8 @@ PROBABILITY_PREDICTOR_AUTO = 'auto'
 PROBABILITY_PREDICTOR_LABEL_WISE = 'label-wise'
 
 PROBABILITY_PREDICTOR_MARGINALIZED = 'marginalized'
+
+EARLY_STOPPING_OBJECTIVE = 'objective'
 
 
 class BoostingCmdBuilder(CmdBuilder):
@@ -143,6 +146,17 @@ class BoostingCmdBuilder(CmdBuilder):
         """
         self.args.append('--statistic-format')
         self.args.append('sparse' if sparse else 'dense')
+        return self
+
+    def early_stopping(self, early_stopping: str = EARLY_STOPPING_OBJECTIVE):
+        """
+        Configures the algorithm to use a specific method for early stopping.
+
+        :param early_stopping:  The name of the method that should be used for early stopping
+        :return:                The builder itself
+        """
+        self.args.append('--early-stopping')
+        self.args.append(early_stopping)
         return self
 
 
@@ -560,3 +574,45 @@ class BoostingIntegrationTests(CommonIntegrationTests):
             .label_binning(LABEL_BINNING_EQUAL_WIDTH) \
             .print_model_characteristics(True)
         self.run_cmd(builder, 'example-wise-partial-dynamic-heads_equal-width-label-binning')
+
+    def test_early_stopping_no_holdout(self):
+        """
+        Tests the BOOMER algorithm when using no holdout for early stopping.
+        """
+        builder = BoostingCmdBuilder() \
+            .early_stopping() \
+            .holdout(HOLDOUT_NO) \
+            .print_model_characteristics(True)
+        self.run_cmd(builder, 'early-stopping_no-holdout')
+
+    def test_early_stopping_random_holdout(self):
+        """
+        Tests the BOOMER algorithm when using a holdout set that is created via random sampling for early stopping.
+        """
+        builder = BoostingCmdBuilder() \
+            .early_stopping() \
+            .holdout(HOLDOUT_RANDOM) \
+            .print_model_characteristics(True)
+        self.run_cmd(builder, 'early-stopping_random-holdout')
+
+    def test_early_stopping_stratified_label_wise_holdout(self):
+        """
+        Tests the BOOMER algorithm when using a holdout set that is created via label-wise stratified sampling for early
+        stopping.
+        """
+        builder = BoostingCmdBuilder() \
+            .early_stopping() \
+            .holdout(HOLDOUT_STRATIFIED_LABEL_WISE) \
+            .print_model_characteristics(True)
+        self.run_cmd(builder, 'early-stopping_stratified-label-wise-holdout')
+
+    def test_early_stopping_stratified_example_wise_holdout(self):
+        """
+        Tests the BOOMER algorithm when using a holdout set that is created via example-wise stratified sampling for
+        early stopping.
+        """
+        builder = BoostingCmdBuilder() \
+            .early_stopping() \
+            .holdout(HOLDOUT_STRATIFIED_EXAMPLE_WISE) \
+            .print_model_characteristics(True)
+        self.run_cmd(builder, 'early-stopping_stratified-example-wise-holdout')

--- a/python/subprojects/testbed/tests/test_common.py
+++ b/python/subprojects/testbed/tests/test_common.py
@@ -65,6 +65,14 @@ LABEL_SAMPLING_NO = 'none'
 
 LABEL_SAMPLING_WITHOUT_REPLACEMENT = 'without-replacement'
 
+HOLDOUT_NO = 'none'
+
+HOLDOUT_RANDOM = 'random'
+
+HOLDOUT_STRATIFIED_LABEL_WISE = 'stratified-label-wise'
+
+HOLDOUT_STRATIFIED_EXAMPLE_WISE = 'stratified-example-wise'
+
 
 class CmdBuilder:
     """
@@ -465,6 +473,17 @@ class CmdBuilder:
         """
         self.args.append('--sequential-post-optimization')
         self.args.append(str(sequential_post_optimization).lower())
+        return self
+
+    def holdout(self, holdout: str = HOLDOUT_RANDOM):
+        """
+        Configures the algorithm to use a holdout set.
+
+        :param holdout: The name of the sampling method that should be used to create the holdout set
+        :return:        The builder itself
+        """
+        self.args.append('--holdout')
+        self.args.append(holdout)
         return self
 
     def build(self) -> List[str]:


### PR DESCRIPTION
Fügt, wie in #588 gefordert, Integrationstests hinzu, die die Verwendung von Early-Stopping durch den Boosting-Algorithmus überprüfen.