### PR TITLE
Minimale Qualität von Boosting-Regeln erzwingen

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/rule_evaluation/rule_compare_function.hpp
+++ b/cpp/subprojects/boosting/include/boosting/rule_evaluation/rule_compare_function.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "common/rule_evaluation/rule_compare_function.hpp"
-#include <limits>
 
 
 namespace boosting {
@@ -25,7 +24,6 @@ namespace boosting {
      * An object of type `RuleCompareFunction` that defines the function that should be used for comparing the quality
      * of boosted rules.
      */
-    static const RuleCompareFunction BOOSTED_RULE_COMPARE_FUNCTION(compareBoostedRuleQuality,
-                                                                   std::numeric_limits<float64>::infinity());
+    static const RuleCompareFunction BOOSTED_RULE_COMPARE_FUNCTION(compareBoostedRuleQuality, 0.0);
 
 }


### PR DESCRIPTION
Die Änderungen in Pull-Request #677 erlauben es nun, dass Regeln, die durch den Boosting-Algorithmus gelernt werden, eine minimale Qualität erreichen müssen. Dieser Pull-Request setzt diese Untergrenze auf einen Wert von 0.