### PR TITLE
Refactoring bezüglich Stop-Kriterien

### DIFF
--- a/cpp/subprojects/common/include/common/stopping/stopping_criterion.hpp
+++ b/cpp/subprojects/common/include/common/stopping/stopping_criterion.hpp
@@ -17,30 +17,22 @@ class IStoppingCriterion {
     public:
 
         /**
-         * An enum that specifies all possible actions that may be executed, based on the result that is returned by a
-         * stopping criterion.
-         */
-        enum Action : uint8 {
-            CONTINUE = 0,
-            STORE_STOP = 1,
-            FORCE_STOP = 2
-        };
-
-        /**
          * The result that is returned by a stopping criterion. It consists of the action to be executed, as well as the
          * number of rules to be used, if the action is not `CONTINUE`.
          */
         struct Result final {
 
+            Result() : stop(false), numUsedRules(0) { };
+
             /**
-             * The action to be executed.
+             True, if the induction of rules should be stopped, false otherwise.
              */
-            Action action;
+            bool stop;
 
             /**
              * The number of rules to be used.
              */
-            uint32 numRules;
+            uint32 numUsedRules;
 
         };
 

--- a/cpp/subprojects/common/src/common/rule_model_assemblage/rule_model_assemblage_sequential.cpp
+++ b/cpp/subprojects/common/src/common/rule_model_assemblage/rule_model_assemblage_sequential.cpp
@@ -145,9 +145,9 @@ class SequentialRuleModelAssemblage final : public IRuleModelAssemblage {
             IStoppingCriterion::Result stoppingCriterionResult;
 
             while (stoppingCriterionResult = stoppingCriterionPtr->test(statisticsProviderPtr->get(), numRules),
-                   stoppingCriterionResult.action != IStoppingCriterion::Action::FORCE_STOP) {
-                if (stoppingCriterionResult.action == IStoppingCriterion::Action::STORE_STOP && numUsedRules == 0) {
-                    numUsedRules = stoppingCriterionResult.numRules;
+                   !stoppingCriterionResult.stop) {
+                if (stoppingCriterionResult.numUsedRules != 0) {
+                    numUsedRules = stoppingCriterionResult.numUsedRules;
                 }
 
                 const IWeightVector& weights = instanceSamplingPtr->sample(rng);

--- a/cpp/subprojects/common/src/common/stopping/stopping_criterion_list.cpp
+++ b/cpp/subprojects/common/src/common/stopping/stopping_criterion_list.cpp
@@ -37,27 +37,15 @@ class StoppingCriterionList final : public IStoppingCriterion {
 
         Result test(const IStatistics& statistics, uint32 numRules) override {
             Result result;
-            result.action = Action::CONTINUE;
 
             for (auto it = stoppingCriteria_.begin(); it != stoppingCriteria_.end(); it++) {
                 std::unique_ptr<IStoppingCriterion>& stoppingCriterionPtr = *it;
                 Result stoppingCriterionResult = stoppingCriterionPtr->test(statistics, numRules);
-                Action action = stoppingCriterionResult.action;
+                result.stop |= stoppingCriterionResult.stop;
+                uint32 numUsedRules = stoppingCriterionResult.numUsedRules;
 
-                switch (action) {
-                    case Action::FORCE_STOP: {
-                        result.action = action;
-                        result.numRules = stoppingCriterionResult.numRules;
-                        return result;
-                    }
-                    case Action::STORE_STOP: {
-                        result.action = action;
-                        result.numRules = stoppingCriterionResult.numRules;
-                        break;
-                    }
-                    default: {
-                        break;
-                    }
+                if (numUsedRules != 0) {
+                    result.numUsedRules = numUsedRules;
                 }
             }
 
@@ -75,7 +63,6 @@ class NoStoppingCriterion final : public IStoppingCriterion {
 
         Result test(const IStatistics& statistics, uint32 numRules) override {
             Result result;
-            result.action = Action::CONTINUE;
             return result;
         }
 

--- a/cpp/subprojects/common/src/common/stopping/stopping_criterion_size.cpp
+++ b/cpp/subprojects/common/src/common/stopping/stopping_criterion_size.cpp
@@ -25,11 +25,8 @@ class SizeStoppingCriterion final : public IStoppingCriterion {
         Result test(const IStatistics& statistics, uint32 numRules) override {
             Result result;
 
-            if (numRules < maxRules_) {
-                result.action = CONTINUE;
-            } else {
-                result.action = FORCE_STOP;
-                result.numRules = numRules;
+            if (numRules >= maxRules_) {
+                result.stop = true;
             }
 
             return result;

--- a/cpp/subprojects/common/src/common/stopping/stopping_criterion_time.cpp
+++ b/cpp/subprojects/common/src/common/stopping/stopping_criterion_time.cpp
@@ -38,16 +38,12 @@ class TimeStoppingCriterion final : public IStoppingCriterion {
                 auto currentTime = timer::now();
                 auto duration = std::chrono::duration_cast<timer_unit>(currentTime - startTime_);
 
-                if (duration < timeLimit_) {
-                    result.action = CONTINUE;
-                } else {
-                    result.action = FORCE_STOP;
-                    result.numRules = numRules;
+                if (duration >= timeLimit_) {
+                    result.stop = true;
                 }
             } else {
                 startTime_ = timer::now();
                 timerStarted_ = true;
-                result.action = CONTINUE;
             }
 
             return result;

--- a/cpp/subprojects/seco/src/seco/stopping/stopping_criterion_coverage.cpp
+++ b/cpp/subprojects/seco/src/seco/stopping/stopping_criterion_coverage.cpp
@@ -30,11 +30,8 @@ namespace seco {
                 Result result;
                 const ICoverageStatistics& coverageStatistics = static_cast<const ICoverageStatistics&>(statistics);
 
-                if (coverageStatistics.getSumOfUncoveredWeights() > threshold_) {
-                    result.action = CONTINUE;
-                } else {
-                    result.action = FORCE_STOP;
-                    result.numRules = numRules;
+                if (coverageStatistics.getSumOfUncoveredWeights() <= threshold_) {
+                    result.stop = true;
                 }
 
                 return result;


### PR DESCRIPTION
Enthält folgende Änderungen um die Implementierung von Stop-Kriterien zu vereinfachen:

* Das Struct `IStoppingCriterion::Result` speichert nun einen Boolean-Wert (statt einen Enum-Wert des Typs `IStoppingCriterion::Action`), um anzugeben, ob die Induktion von weiteren Regeln gestoppt werden sollte oder nicht.
* Das Feld `numRules` des Structs `IStoppingCriterion::Result` wurde umbenannt zu `numUsedRules`.
* Die Felder des Struct `StoppingCriterion::Result` werden nun vorinitialisiert.
* Die Klasse `StoppingCriterionList` wendet nun stets alle Stop-Kriterien an, um sicherzustellen, dass alle die Möglichkeit bekommen das Feld `numUsedRules` zu setzen.