### PR TITLE
Iteratoren für Vorhersage verwenden

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/prediction/predictor_probability_common.hpp
+++ b/cpp/subprojects/boosting/include/boosting/prediction/predictor_probability_common.hpp
@@ -41,10 +41,11 @@ namespace boosting {
             /**
              * @see `PredictionDispatcher::IPredictionDelegate::predictForExample`
              */
-            void predictForExample(const FeatureMatrix& featureMatrix, const Model& model, uint32 maxRules,
-                                   uint32 threadIndex, uint32 exampleIndex, uint32 predictionIndex) const override {
+            void predictForExample(const FeatureMatrix& featureMatrix, typename Model::const_iterator rulesBegin,
+                                   typename Model::const_iterator rulesEnd, uint32 threadIndex, uint32 exampleIndex,
+                                   uint32 predictionIndex) const override {
                 ScorePredictionDelegate<FeatureMatrix, Model>(scoreMatrix_)
-                  .predictForExample(featureMatrix, model, maxRules, threadIndex, exampleIndex, predictionIndex);
+                  .predictForExample(featureMatrix, rulesBegin, rulesEnd, threadIndex, exampleIndex, predictionIndex);
                 probabilityTransformation_.apply(scoreMatrix_.row_values_begin(predictionIndex),
                                                  scoreMatrix_.row_values_end(predictionIndex));
             }
@@ -106,8 +107,8 @@ namespace boosting {
                 if (probabilityTransformationPtr_) {
                     ProbabilityPredictionDelegate<FeatureMatrix, Model> delegate(*predictionMatrixPtr,
                                                                                  *probabilityTransformationPtr_);
-                    PredictionDispatcher<float64, FeatureMatrix, Model>().predict(delegate, featureMatrix_, model_,
-                                                                                  maxRules, numThreads_);
+                    PredictionDispatcher<float64, FeatureMatrix, Model>().predict(
+                      delegate, featureMatrix_, model_.used_cbegin(maxRules), model_.used_cend(maxRules), numThreads_);
                 }
 
                 return predictionMatrixPtr;


### PR DESCRIPTION
Die `predict`-Funktion der Klasse `PredictionDispatcher` und `BinarySparsePredictionDispatcher` erwarten nun, dass Iteratoren zu der ersten und letzten Regel, die für die Vorhersage verwendet werden sollen, als Argumente übergeben werden. Dies ermöglicht zukünftig, dass nur ein Teil der Regeln einem Modell für die Vorhersage berücksichtigt werden, wie es bei der inkrementellen Vorhersage der Fall ist.