### PR TITLE
Argument "minRules" von Funktion "createIncrementalPredictor" entfernen

### DIFF
--- a/cpp/subprojects/boosting/include/boosting/prediction/predictor_binary_common.hpp
+++ b/cpp/subprojects/boosting/include/boosting/prediction/predictor_binary_common.hpp
@@ -187,7 +187,7 @@ namespace boosting {
              * @see `IPredictor::createIncrementalPredictor`
              */
             std::unique_ptr<IIncrementalPredictor<DensePredictionMatrix<uint8>>> createIncrementalPredictor(
-              uint32 minRules, uint32 maxRules) const override {
+              uint32 maxRules) const override {
                 throw std::runtime_error("The rule learner does not support to predict binary labels incrementally");
             }
     };
@@ -266,7 +266,7 @@ namespace boosting {
              * @see `IPredictor::createIncrementalPredictor`
              */
             std::unique_ptr<IIncrementalPredictor<BinarySparsePredictionMatrix>> createIncrementalPredictor(
-              uint32 minRules, uint32 maxRules) const override {
+              uint32 maxRules) const override {
                 throw std::runtime_error(
                   "The rule learner does not support to predict sparse binary labels incrementally");
             }

--- a/cpp/subprojects/boosting/include/boosting/prediction/predictor_probability_common.hpp
+++ b/cpp/subprojects/boosting/include/boosting/prediction/predictor_probability_common.hpp
@@ -125,7 +125,7 @@ namespace boosting {
              * @see `IPredictor::createIncrementalPredictor`
              */
             std::unique_ptr<IIncrementalPredictor<DensePredictionMatrix<float64>>> createIncrementalPredictor(
-              uint32 minRules, uint32 maxRules) const override {
+              uint32 maxRules) const override {
                 throw std::runtime_error(
                   "The rule learner does not support to predict probability estimates incrementally");
             }

--- a/cpp/subprojects/boosting/include/boosting/prediction/predictor_score_common.hpp
+++ b/cpp/subprojects/boosting/include/boosting/prediction/predictor_score_common.hpp
@@ -213,7 +213,7 @@ namespace boosting {
              * @see `IPredictor::createIncrementalPredictor`
              */
             std::unique_ptr<IIncrementalPredictor<DensePredictionMatrix<float64>>> createIncrementalPredictor(
-              uint32 minRules, uint32 maxRules) const override {
+              uint32 maxRules) const override {
                 throw std::runtime_error(
                   "The rule learner does not support to predict regression scores incrementally");
             }

--- a/cpp/subprojects/boosting/src/boosting/prediction/predictor_probability_label_wise.cpp
+++ b/cpp/subprojects/boosting/src/boosting/prediction/predictor_probability_label_wise.cpp
@@ -75,7 +75,7 @@ namespace boosting {
              * @see `IPredictor::createIncrementalPredictor`
              */
             std::unique_ptr<IIncrementalPredictor<DensePredictionMatrix<float64>>> createIncrementalPredictor(
-              uint32 minRules, uint32 maxRules) const override {
+              uint32 maxRules) const override {
                 throw std::runtime_error(
                   "The rule learner does not support to predict probability estimates incrementally");
             }

--- a/cpp/subprojects/common/include/common/prediction/predictor.hpp
+++ b/cpp/subprojects/common/include/common/prediction/predictor.hpp
@@ -82,14 +82,13 @@ class IPredictor {
          * prediction is not supported, a `std::runtime_error` is thrown.
          *
          * @throws std::runtime_exception   The exception that is thrown if incremental prediction is not supported
-         * @param minRules                  The minimum number of rules to be used for prediction. Must be at least 1
-         * @param maxRules                  The maximum number of rules to be used for prediction. Must be greater than
-         *                                  `minRules` or 0, if the number of rules should not be restricted
+         * @param maxRules                  The maximum number of rules to be used for prediction. Must be at least 1 or
+         *                                  0, if the number of rules should not be restricted
          * @return                          An unique pointer to an object of type `IIncrementalPredictor` that may be
          *                                  used to obtain predictions incrementally
          */
         virtual std::unique_ptr<IIncrementalPredictor<PredictionMatrix>> createIncrementalPredictor(
-          uint32 minRules = 0, uint32 maxRules = 0) const = 0;
+          uint32 maxRules = 0) const = 0;
 };
 
 /**

--- a/cpp/subprojects/seco/src/seco/prediction/predictor_binary_label_wise.cpp
+++ b/cpp/subprojects/seco/src/seco/prediction/predictor_binary_label_wise.cpp
@@ -184,7 +184,7 @@ namespace seco {
              * @see `IPredictor::createIncrementalPredictor`
              */
             std::unique_ptr<IIncrementalPredictor<DensePredictionMatrix<uint8>>> createIncrementalPredictor(
-              uint32 minRules, uint32 maxRules) const override {
+              uint32 maxRules) const override {
                 throw std::runtime_error("The rule learner does not support to predict binary labels incrementally");
             }
     };
@@ -428,7 +428,7 @@ namespace seco {
              * @see `IPredictor::createIncrementalPredictor`
              */
             std::unique_ptr<IIncrementalPredictor<BinarySparsePredictionMatrix>> createIncrementalPredictor(
-              uint32 minRules, uint32 maxRules) const override {
+              uint32 maxRules) const override {
                 throw std::runtime_error(
                   "The rule learner does not support to predict sparse binary labels incrementally");
             }

--- a/python/subprojects/common/mlrl/common/cython/prediction.pxd
+++ b/python/subprojects/common/mlrl/common/cython/prediction.pxd
@@ -62,8 +62,7 @@ cdef extern from "common/prediction/predictor.hpp" nogil:
 
         bool canPredictIncrementally() const
 
-        unique_ptr[IIncrementalPredictor[PredictionMatrix]] createIncrementalPredictor(uint32 minRules,
-                                                                                       uint32 maxRules) except +
+        unique_ptr[IIncrementalPredictor[PredictionMatrix]] createIncrementalPredictor(uint32 maxRules) except +
 
 
 cdef extern from "common/prediction/predictor_binary.hpp" nogil:

--- a/python/subprojects/common/mlrl/common/cython/prediction.pyx
+++ b/python/subprojects/common/mlrl/common/cython/prediction.pyx
@@ -79,21 +79,19 @@ cdef class BinaryPredictor:
         """
         return self.predictor_ptr.get().canPredictIncrementally()
 
-    def create_incremental_predictor(self, uint32 min_rules, uint32 max_rules) -> IncrementalBinaryPredictor:
+    def create_incremental_predictor(self, uint32 max_rules) -> IncrementalBinaryPredictor:
         """
         Creates and returns a predictor that allows to predict binary labels incrementally. If incremental prediction is
         not supported, a `RuntimeError` is thrown.
 
-        :param min_rules:   The minimum number of rules to be used for prediction. Must be at least 1
-        :param max_rules:   The maximum number of rules to be used for prediction. Must be greater than `min_rules` or
-                            0, if the number of rules should not be restricted
+        :param max_rules:   The maximum number of rules to be used for prediction. Must be at least 1 or 0, if the
+                            number of rules should not be restricted
         :return:            A predictor that allows to predict binary labels incrementally
         """
-        assert_greater_or_equal('min_rules', min_rules, 1)
         if max_rules != 0:
-            assert_greater('max_rules', max_rules, min_rules)
+            assert_greater_or_equal('max_rules', max_rules, 1)
         cdef IncrementalBinaryPredictor predictor = IncrementalBinaryPredictor.__new__(IncrementalBinaryPredictor)
-        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(min_rules, max_rules))
+        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(max_rules))
         return predictor
 
 
@@ -164,21 +162,19 @@ cdef class SparseBinaryPredictor:
         """
         return self.predictor_ptr.get().canPredictIncrementally()
 
-    def create_incremental_predictor(self, uint32 min_rules, uint32 max_rules) -> IncrementalSparseBinaryPredictor:
+    def create_incremental_predictor(self, uint32 max_rules) -> IncrementalSparseBinaryPredictor:
         """
         Creates and returns a predictor that allows to predict sparse binary labels incrementally. If incremental
         prediction is not supported, a `RuntimeError` is thrown.
 
-        :param min_rules:   The minimum number of rules to be used for prediction. Must be at least 1
-        :param max_rules:   The maximum number of rules to be used for prediction. Must be greater than `min_rules` or
-                            0, if the number of rules should not be restricted
+        :param max_rules:   The maximum number of rules to be used for prediction. Must be at least 1 or 0, if the
+                            number of rules should not be restricted
         :return:            A predictor that allows to predict sparse binary labels incrementally
         """
-        assert_greater_or_equal('min_rules', min_rules, 1)
         if max_rules != 0:
-            assert_greater('max_rules', max_rules, min_rules)
+            assert_greater_or_equal('max_rules', max_rules, 1)
         cdef IncrementalSparseBinaryPredictor predictor = IncrementalSparseBinaryPredictor.__new__(IncrementalSparseBinaryPredictor)
-        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(min_rules, max_rules))
+        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(max_rules))
         return predictor
 
 
@@ -240,21 +236,19 @@ cdef class ScorePredictor:
         """
         return self.predictor_ptr.get().canPredictIncrementally()
 
-    def create_incremental_predictor(self, uint32 min_rules, uint32 max_rules) -> IncrementalScorePredictor:
+    def create_incremental_predictor(self, uint32 max_rules) -> IncrementalScorePredictor:
         """
         Creates and returns a predictor that allows to predict regression scores incrementally. If incremental
         prediction is not supported, a `RuntimeError` is thrown.
 
-        :param min_rules:   The minimum number of rules to be used for prediction. Must be at least 1
-        :param max_rules:   The maximum number of rules to be used for prediction. Must be greater than `min_rules` or
-                            0, if the number of rules should not be restricted
+        :param max_rules:   The maximum number of rules to be used for prediction. Must be at least 1 or 0, if the
+                            number of rules should not be restricted
         :return:            A predictor that allows to predict regression scores incrementally
         """
-        assert_greater_or_equal('min_rules', min_rules, 1)
         if max_rules != 0:
-            assert_greater('max_rules', max_rules, min_rules)
+            assert_greater_or_equal('max_rules', max_rules, 1)
         cdef IncrementalScorePredictor predictor = IncrementalScorePredictor.__new__(IncrementalScorePredictor)
-        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(min_rules, max_rules))
+        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(max_rules))
         return predictor
 
 
@@ -317,19 +311,17 @@ cdef class ProbabilityPredictor:
         """
         return self.predictor_ptr.get().canPredictIncrementally()
 
-    def create_incremental_predictor(self, uint32 min_rules, uint32 max_rules) -> IncrementalProbabilityPredictor:
+    def create_incremental_predictor(self, uint32 max_rules) -> IncrementalProbabilityPredictor:
         """
         Creates and returns a predictor that allows to predict probability estimates incrementally. If incremental
         prediction is not supported, a `RuntimeError` is thrown.
 
-        :param min_rules:   The minimum number of rules to be used for prediction. Must be at least 1
-        :param max_rules:   The maximum number of rules to be used for prediction. Must be greater than `min_rules` or
-                            0, if the number of rules should not be restricted
+        :param max_rules:   The maximum number of rules to be used for prediction. Must be at least 1 or 0, if the
+                            number of rules should not be restricted
         :return:            A predictor that allows to predict probability estimates incrementally
         """
-        assert_greater_or_equal('min_rules', min_rules, 1)
         if max_rules != 0:
-            assert_greater('max_rules', max_rules, min_rules)
+            assert_greater_or_equal('max_rules', max_rules, 1)
         cdef IncrementalProbabilityPredictor predictor = IncrementalProbabilityPredictor.__new__(IncrementalProbabilityPredictor)
-        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(min_rules, max_rules))
+        predictor.predictor_ptr = move(self.predictor_ptr.get().createIncrementalPredictor(max_rules))
         return predictor

--- a/python/subprojects/testbed/mlrl/testbed/experiments.py
+++ b/python/subprojects/testbed/mlrl/testbed/experiments.py
@@ -205,8 +205,8 @@ class IncrementalEvaluation(Evaluation):
                  max_size: int, step_size: int):
         """
         :param min_size:    The minimum number of ensemble members to be evaluated. Must be at least 1
-        :param max_size:    The maximum number of ensemble members to be evaluated. Must be greater than `min_size` or
-                            0, if all ensemble members should be evaluated
+        :param max_size:    The maximum number of ensemble members to be evaluated. Must be at least `min_size` or 0, if
+                            all ensemble members should be evaluated
         :param step_size:   The number of additional ensemble members to be considered at each repetition. Must be at
                             least 1
         """


### PR DESCRIPTION
Entfernt das Argument `minRules` von der Funktion `createIncrementalPredictor` der Klasse `IPredictor`.