### PR TITLE
Zugriff auf Partition durch IProbabilityCalibrator erlauben

### DIFF
--- a/cpp/subprojects/common/include/common/input/label_matrix_c_contiguous.hpp
+++ b/cpp/subprojects/common/include/common/input/label_matrix_c_contiguous.hpp
@@ -132,7 +132,12 @@ class CContiguousLabelMatrix final : public CContiguousConstView<const uint8>,
                                                                   IStatistics& statistics) const override;
 
         std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
-          const IProbabilityCalibrator& probabilityCalibrator, const IStatistics& statistics) const override;
+          const IProbabilityCalibrator& probabilityCalibrator, const SinglePartition& partition,
+          const IStatistics& statistics) const override;
+
+        std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const IProbabilityCalibrator& probabilityCalibrator, const BiPartition& partition,
+          const IStatistics& statistics) const override;
 };
 
 /**

--- a/cpp/subprojects/common/include/common/input/label_matrix_csr.hpp
+++ b/cpp/subprojects/common/include/common/input/label_matrix_csr.hpp
@@ -125,7 +125,12 @@ class CsrLabelMatrix final : public BinaryCsrConstView,
                                                                   IStatistics& statistics) const override;
 
         std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
-          const IProbabilityCalibrator& probabilityCalibrator, const IStatistics& statistics) const override;
+          const IProbabilityCalibrator& probabilityCalibrator, const SinglePartition& partition,
+          const IStatistics& statistics) const override;
+
+        std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const IProbabilityCalibrator& probabilityCalibrator, const BiPartition& partition,
+          const IStatistics& statistics) const override;
 };
 
 /**

--- a/cpp/subprojects/common/include/common/input/label_matrix_row_wise.hpp
+++ b/cpp/subprojects/common/include/common/input/label_matrix_row_wise.hpp
@@ -101,11 +101,31 @@ class MLRLCOMMON_API IRowWiseLabelMatrix : virtual public ILabelMatrix {
          *
          * @param probabilityCalibrator A reference to an object of type `IProbabilityCalibrator` that should be used to
          *                              fit the calibration model
+         * @param partition             A reference to an object of type `SinglePartition` that provides access to the
+         *                              indices of the training examples that are included in the training set
          * @param statistics            A reference to an object of type `IStatistics` that provides access to
          *                              statistics about the labels of the training examples
          * @return                      An unique pointer to an object of type `IProbabilityCalibrationModel` that has
          *                              been fit
          */
         virtual std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
-          const IProbabilityCalibrator& probabilityCalibrator, const IStatistics& statistics) const = 0;
+          const IProbabilityCalibrator& probabilityCalibrator, const SinglePartition& partition,
+          const IStatistics& statistics) const = 0;
+
+        /**
+         * Fits and returns a model for the calibration of probabilities, based on the type of this label matrix.
+         *
+         * @param probabilityCalibrator A reference to an object of type `IProbabilityCalibrator` that should be used to
+         *                              fit the calibration model
+         * @param partition             A reference to an object of type `BiPartition` that provides access to the
+         *                              indices of the training examples that are included in the training set and the
+         *                              holdout set, respectively
+         * @param statistics            A reference to an object of type `IStatistics` that provides access to
+         *                              statistics about the labels of the training examples
+         * @return                      An unique pointer to an object of type `IProbabilityCalibrationModel` that has
+         *                              been fit
+         */
+        virtual std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const IProbabilityCalibrator& probabilityCalibrator, const BiPartition& partition,
+          const IStatistics& statistics) const = 0;
 };

--- a/cpp/subprojects/common/include/common/prediction/probability_calibration.hpp
+++ b/cpp/subprojects/common/include/common/prediction/probability_calibration.hpp
@@ -7,6 +7,8 @@
 #include "common/input/label_matrix_c_contiguous.hpp"
 #include "common/input/label_matrix_csr.hpp"
 #include "common/macros.hpp"
+#include "common/sampling/partition_bi.hpp"
+#include "common/sampling/partition_single.hpp"
 #include "common/statistics/statistics.hpp"
 
 #include <memory>
@@ -48,6 +50,8 @@ class IProbabilityCalibrator {
         /**
          * Fits and returns a model for the calibration of probabilities.
          *
+         * @param partition     A reference to an object of type `SinglePartition` that provides access to the indices
+         *                      of the training examples that are included in the training set
          * @param labelMatrix   A reference to an object of type `CContiguousLabelMatrix` that provides row-wise access
          *                      to the labels of the training examples
          * @param statistics    A reference to an object of type `IStatistics` that provides access to statistics about
@@ -55,11 +59,14 @@ class IProbabilityCalibrator {
          * @return              An unique pointer to an object of type `IProbabilityCalibrationModel` that has been fit
          */
         virtual std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
-          const CContiguousLabelMatrix& labelMatrix, const IStatistics& statistics) const = 0;
+          const SinglePartition& partition, const CContiguousLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const = 0;
 
         /**
          * Fits and returns a model for the calibration of probabilities.
          *
+         * @param partition     A reference to an object of type `SinglePartition` that provides access to the indices
+         *                      of the training examples that are included in the training set
          * @param labelMatrix   A reference to an object of type `CsrLabelMatrix` that provides row-wise access to the
          *                      labels of the training examples
          * @param statistics    A reference to an object of type `IStatistics` that provides access to statistics about
@@ -67,7 +74,38 @@ class IProbabilityCalibrator {
          * @return              An unique pointer to an object of type `IProbabilityCalibrationModel` that has been fit
          */
         virtual std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
-          const CsrLabelMatrix& labelMatrix, const IStatistics& statistics) const = 0;
+          const SinglePartition& partition, const CsrLabelMatrix& labelMatrix, const IStatistics& statistics) const = 0;
+
+        /**
+         * Fits and returns a model for the calibration of probabilities.
+         *
+         * @param partition     A reference to an object of type `BiPartition` that provides access to the indices of
+         *                      the training examples that are included in the training set and the holdout set,
+         *                      respectively
+         * @param labelMatrix   A reference to an object of type `CContiguousLabelMatrix` that provides row-wise access
+         *                      to the labels of the training examples
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to statistics about
+         *                      the labels of the training examples
+         * @return              An unique pointer to an object of type `IProbabilityCalibrationModel` that has been fit
+         */
+        virtual std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const BiPartition& partition, const CContiguousLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const = 0;
+
+        /**
+         * Fits and returns a model for the calibration of probabilities.
+         *
+         * @param partition     A reference to an object of type `BiPartition` that provides access to the indices of
+         *                      the training examples that are included in the training set and the holdout set,
+         *                      respectively
+         * @param labelMatrix   A reference to an object of type `CsrLabelMatrix` that provides row-wise access to the
+         *                      labels of the training examples
+         * @param statistics    A reference to an object of type `IStatistics` that provides access to statistics about
+         *                      the labels of the training examples
+         * @return              An unique pointer to an object of type `IProbabilityCalibrationModel` that has been fit
+         */
+        virtual std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const BiPartition& partition, const CsrLabelMatrix& labelMatrix, const IStatistics& statistics) const = 0;
 };
 
 /**

--- a/cpp/subprojects/common/include/common/sampling/partition.hpp
+++ b/cpp/subprojects/common/include/common/sampling/partition.hpp
@@ -17,6 +17,8 @@ class IStatistics;
 class IThresholdsSubset;
 class ICoverageState;
 class AbstractPrediction;
+class IProbabilityCalibrationModel;
+class IProbabilityCalibrator;
 
 /**
  * Defines an interface for all classes that provide access to the indices of training examples that have been split
@@ -80,4 +82,20 @@ class IPartition {
          */
         virtual void recalculatePrediction(const IThresholdsSubset& thresholdsSubset,
                                            const ICoverageState& coverageState, AbstractPrediction& head) = 0;
+
+        /**
+         * Fits and returns a model for the calibration of probabilities, based on the type of this partition.
+         *
+         * @param probabilityCalibrator A reference to an object of type `IProbabilityCalibrator` that should be used to
+         *                              fit the calibration model
+         * @param labelMatrix           A reference to an object of type `IRowWiseLabelMatrix` that provides row-wise
+         *                              access to the labels of the training examples
+         * @param statistics            A reference to an object of type `IStatistics` that provides access to
+         *                              statistics about the labels of the training examples
+         * @return                      An unique pointer to an object of type `IProbabilityCalibrationModel` that has
+         *                              been fit
+         */
+        virtual std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const IProbabilityCalibrator& probabilityCalibrator, const IRowWiseLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const = 0;
 };

--- a/cpp/subprojects/common/include/common/sampling/partition_bi.hpp
+++ b/cpp/subprojects/common/include/common/sampling/partition_bi.hpp
@@ -148,4 +148,8 @@ class BiPartition final : public IPartition {
 
         void recalculatePrediction(const IThresholdsSubset& thresholdsSubset, const ICoverageState& coverageState,
                                    AbstractPrediction& head) override;
+
+        std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const IProbabilityCalibrator& probabilityCalibrator, const IRowWiseLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const override;
 };

--- a/cpp/subprojects/common/include/common/sampling/partition_single.hpp
+++ b/cpp/subprojects/common/include/common/sampling/partition_single.hpp
@@ -59,4 +59,8 @@ class SinglePartition final : public IPartition {
 
         void recalculatePrediction(const IThresholdsSubset& thresholdsSubset, const ICoverageState& coverageState,
                                    AbstractPrediction& head) override;
+
+        std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const IProbabilityCalibrator& probabilityCalibrator, const IRowWiseLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const override;
 };

--- a/cpp/subprojects/common/src/common/input/label_matrix_c_contiguous.cpp
+++ b/cpp/subprojects/common/src/common/input/label_matrix_c_contiguous.cpp
@@ -80,8 +80,15 @@ std::unique_ptr<IInstanceSampling> CContiguousLabelMatrix::createInstanceSamplin
 }
 
 std::unique_ptr<IProbabilityCalibrationModel> CContiguousLabelMatrix::fitProbabilityCalibrationModel(
-  const IProbabilityCalibrator& probabilityCalibrator, const IStatistics& statistics) const {
-    return probabilityCalibrator.fitProbabilityCalibrationModel(*this, statistics);
+  const IProbabilityCalibrator& probabilityCalibrator, const SinglePartition& partition,
+  const IStatistics& statistics) const {
+    return probabilityCalibrator.fitProbabilityCalibrationModel(partition, *this, statistics);
+}
+
+std::unique_ptr<IProbabilityCalibrationModel> CContiguousLabelMatrix::fitProbabilityCalibrationModel(
+  const IProbabilityCalibrator& probabilityCalibrator, const BiPartition& partition,
+  const IStatistics& statistics) const {
+    return probabilityCalibrator.fitProbabilityCalibrationModel(partition, *this, statistics);
 }
 
 std::unique_ptr<ICContiguousLabelMatrix> createCContiguousLabelMatrix(uint32 numRows, uint32 numCols,

--- a/cpp/subprojects/common/src/common/input/label_matrix_csr.cpp
+++ b/cpp/subprojects/common/src/common/input/label_matrix_csr.cpp
@@ -69,8 +69,15 @@ std::unique_ptr<IInstanceSampling> CsrLabelMatrix::createInstanceSampling(const 
 }
 
 std::unique_ptr<IProbabilityCalibrationModel> CsrLabelMatrix::fitProbabilityCalibrationModel(
-  const IProbabilityCalibrator& probabilityCalibrator, const IStatistics& statistics) const {
-    return probabilityCalibrator.fitProbabilityCalibrationModel(*this, statistics);
+  const IProbabilityCalibrator& probabilityCalibrator, const SinglePartition& partition,
+  const IStatistics& statistics) const {
+    return probabilityCalibrator.fitProbabilityCalibrationModel(partition, *this, statistics);
+}
+
+std::unique_ptr<IProbabilityCalibrationModel> CsrLabelMatrix::fitProbabilityCalibrationModel(
+  const IProbabilityCalibrator& probabilityCalibrator, const BiPartition& partition,
+  const IStatistics& statistics) const {
+    return probabilityCalibrator.fitProbabilityCalibrationModel(partition, *this, statistics);
 }
 
 std::unique_ptr<ICsrLabelMatrix> createCsrLabelMatrix(uint32 numRows, uint32 numCols, uint32* rowIndices,

--- a/cpp/subprojects/common/src/common/learner.cpp
+++ b/cpp/subprojects/common/src/common/learner.cpp
@@ -509,7 +509,7 @@ std::unique_ptr<ITrainingResult> AbstractRuleLearner::fit(const IFeatureInfo& fe
     // Fit model for the calibration of probabilities...
     std::unique_ptr<IProbabilityCalibrator> probabilityCalibratorPtr = this->createProbabilityCalibrator();
     std::unique_ptr<IProbabilityCalibrationModel> probabilityCalibrationModelPtr =
-      labelMatrix.fitProbabilityCalibrationModel(*probabilityCalibratorPtr, statisticsProviderPtr->get());
+      partition.fitProbabilityCalibrationModel(*probabilityCalibratorPtr, labelMatrix, statisticsProviderPtr->get());
 
     return std::make_unique<TrainingResult>(labelMatrix.getNumCols(), modelBuilder.buildModel(),
                                             std::move(labelSpaceInfoPtr), std::move(probabilityCalibrationModelPtr));

--- a/cpp/subprojects/common/src/common/prediction/probability_calibration_no.cpp
+++ b/cpp/subprojects/common/src/common/prediction/probability_calibration_no.cpp
@@ -23,12 +23,26 @@ class NoProbabilityCalibrator final : public IProbabilityCalibrator {
     public:
 
         std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
-          const CContiguousLabelMatrix& labelMatrix, const IStatistics& statistics) const override {
+          const SinglePartition& partition, const CContiguousLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const override {
             return std::make_unique<NoProbabilityCalibrationModel>();
         }
 
         std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
-          const CsrLabelMatrix& labelMatrix, const IStatistics& statistics) const override {
+          const SinglePartition& partition, const CsrLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const override {
+            return std::make_unique<NoProbabilityCalibrationModel>();
+        }
+
+        std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const BiPartition& partition, const CContiguousLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const override {
+            return std::make_unique<NoProbabilityCalibrationModel>();
+        }
+
+        std::unique_ptr<IProbabilityCalibrationModel> fitProbabilityCalibrationModel(
+          const BiPartition& partition, const CsrLabelMatrix& labelMatrix,
+          const IStatistics& statistics) const override {
             return std::make_unique<NoProbabilityCalibrationModel>();
         }
 };

--- a/cpp/subprojects/common/src/common/sampling/partition_bi.cpp
+++ b/cpp/subprojects/common/src/common/sampling/partition_bi.cpp
@@ -1,5 +1,6 @@
 #include "common/sampling/partition_bi.hpp"
 
+#include "common/prediction/probability_calibration.hpp"
 #include "common/rule_refinement/prediction.hpp"
 #include "common/sampling/instance_sampling.hpp"
 #include "common/stopping/stopping_criterion.hpp"
@@ -104,4 +105,10 @@ Quality BiPartition::evaluateOutOfSample(const IThresholdsSubset& thresholdsSubs
 void BiPartition::recalculatePrediction(const IThresholdsSubset& thresholdsSubset, const ICoverageState& coverageState,
                                         AbstractPrediction& head) {
     coverageState.recalculatePrediction(thresholdsSubset, *this, head);
+}
+
+std::unique_ptr<IProbabilityCalibrationModel> BiPartition::fitProbabilityCalibrationModel(
+  const IProbabilityCalibrator& probabilityCalibrator, const IRowWiseLabelMatrix& labelMatrix,
+  const IStatistics& statistics) const {
+    return labelMatrix.fitProbabilityCalibrationModel(probabilityCalibrator, *this, statistics);
 }

--- a/cpp/subprojects/common/src/common/sampling/partition_single.cpp
+++ b/cpp/subprojects/common/src/common/sampling/partition_single.cpp
@@ -1,5 +1,6 @@
 #include "common/sampling/partition_single.hpp"
 
+#include "common/prediction/probability_calibration.hpp"
 #include "common/rule_refinement/prediction.hpp"
 #include "common/sampling/instance_sampling.hpp"
 #include "common/stopping/stopping_criterion.hpp"
@@ -37,4 +38,10 @@ Quality SinglePartition::evaluateOutOfSample(const IThresholdsSubset& thresholds
 void SinglePartition::recalculatePrediction(const IThresholdsSubset& thresholdsSubset,
                                             const ICoverageState& coverageState, AbstractPrediction& head) {
     coverageState.recalculatePrediction(thresholdsSubset, *this, head);
+}
+
+std::unique_ptr<IProbabilityCalibrationModel> SinglePartition::fitProbabilityCalibrationModel(
+  const IProbabilityCalibrator& probabilityCalibrator, const IRowWiseLabelMatrix& labelMatrix,
+  const IStatistics& statistics) const {
+    return labelMatrix.fitProbabilityCalibrationModel(probabilityCalibrator, *this, statistics);
 }


### PR DESCRIPTION
Ergänzt die Änderungen in #732 so dass neben der Label-Matrix und den Statistiken auch Informationen über die Einteilung der Trainingsbeispiele in Trainings- und Holdout-Set in Form eines Objekts vom Typ `SinglePartition` oder `BiPartition` an die `fitProbabilityCalibrationModel`-Funktionen der Klasse `IProbabilityCalibrator` übergeben werden.