### PR TITLE
Neue Klasse EqualFeatureVector

### DIFF
--- a/cpp/subprojects/common/include/mlrl/common/input/feature_vector_equal.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/input/feature_vector_equal.hpp
@@ -1,0 +1,16 @@
+/*
+ * @author Michael Rapp (michael.rapp.ml@gmail.com)
+ */
+#pragma once
+
+#include "mlrl/common/input/feature_vector_common.hpp"
+
+/**
+ * A feature vector that does not actually store any values. It is used in cases where all training examples have the
+ * same value for a certain feature.
+ */
+class EqualFeatureVector final : public AbstractFeatureVector {
+    public:
+
+        uint32 getNumElements() const override;
+};

--- a/cpp/subprojects/common/meson.build
+++ b/cpp/subprojects/common/meson.build
@@ -41,6 +41,7 @@ source_files = [
     'src/mlrl/common/input/feature_type_ordinal.cpp',
     'src/mlrl/common/input/feature_vector.cpp',
     'src/mlrl/common/input/feature_vector_common.cpp',
+    'src/mlrl/common/input/feature_vector_equal.cpp',
     'src/mlrl/common/input/feature_vector_numerical.cpp',
     'src/mlrl/common/input/label_matrix_c_contiguous.cpp',
     'src/mlrl/common/input/label_matrix_csc.cpp',

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_vector_equal.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_vector_equal.cpp
@@ -1,0 +1,5 @@
+#include "mlrl/common/input/feature_vector_equal.hpp"
+
+uint32 EqualFeatureVector::getNumElements() const {
+    return 0;
+}


### PR DESCRIPTION
Fügt eine neue Klasse `EqualFeatureVector` hinzu, die von der Klasse `IFeatureVector` erbt und zukünftig verwendet werden wird wenn, unabhängig vom Attributtyp, die Werte aller Beispiele für ein Feature identisch sind.