### PR TITLE
Projekt "common" nur als Shared-Library kompilieren

### DIFF
--- a/cpp/subprojects/common/meson.build
+++ b/cpp/subprojects/common/meson.build
@@ -187,7 +187,7 @@ endif
 
 # Library declaration
 common_lib = library(lib_name, source_files, include_directories : include_directories, cpp_args : cpp_args,
-                     link_args : link_args)
+                     link_args : link_args, version : version, install : true, install_dir : install_dir)
 common_dep = declare_dependency(include_directories : include_directories, link_with : common_lib)
 
 # Test declaration


### PR DESCRIPTION
Ändert die Meson-Konfiguration des Subpackages "common", so dass in Zukunft nur noch eine Shared-Library, keine Static Library, gebaut wird. Das reduziert die zum Kompilieren benötigte Zeit drastisch.