### PR TITLE
"Direct initialization" für Klassenvariablen verwenden

### DIFF
--- a/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_binary_common.hpp
+++ b/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_binary_common.hpp
@@ -88,12 +88,10 @@ namespace boosting {
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, DensePredictionMatrix<uint8>>(
                           predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
                           binaryTransformationPtr_(binaryTransformationPtr),
-                          realMatrix_(DensePredictionMatrix<float64>(predictor.featureMatrix_.getNumRows(),
-                                                                     predictor.numLabels_,
-                                                                     binaryTransformationPtr_ != nullptr)),
-                          predictionMatrix_(DensePredictionMatrix<uint8>(predictor.featureMatrix_.getNumRows(),
-                                                                         predictor.numLabels_,
-                                                                         binaryTransformationPtr_ == nullptr)) {}
+                          realMatrix_(predictor.featureMatrix_.getNumRows(), predictor.numLabels_,
+                                      binaryTransformationPtr_ != nullptr),
+                          predictionMatrix_(predictor.featureMatrix_.getNumRows(), predictor.numLabels_,
+                                            binaryTransformationPtr_ == nullptr) {}
             };
 
             class PredictionDelegate final
@@ -280,10 +278,9 @@ namespace boosting {
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, BinarySparsePredictionMatrix>(
                           predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
                           binaryTransformationPtr_(binaryTransformationPtr),
-                          realMatrix_(DensePredictionMatrix<float64>(predictor.featureMatrix_.getNumRows(),
-                                                                     predictor.numLabels_,
-                                                                     binaryTransformationPtr_ != nullptr)),
-                          predictionMatrix_(BinaryLilMatrix(predictor.featureMatrix_.getNumRows())) {}
+                          realMatrix_(predictor.featureMatrix_.getNumRows(), predictor.numLabels_,
+                                      binaryTransformationPtr_ != nullptr),
+                          predictionMatrix_(predictor.featureMatrix_.getNumRows()) {}
             };
 
             class PredictionDelegate final

--- a/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_probability_common.hpp
+++ b/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_probability_common.hpp
@@ -87,12 +87,10 @@ namespace boosting {
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, DensePredictionMatrix<float64>>(
                           predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
                           probabilityTransformationPtr_(probabilityTransformationPtr),
-                          scoreMatrix_(DensePredictionMatrix<float64>(predictor.featureMatrix_.getNumRows(),
-                                                                      predictor.numLabels_,
-                                                                      probabilityTransformationPtr_ != nullptr)),
-                          predictionMatrix_(DensePredictionMatrix<float64>(predictor.featureMatrix_.getNumRows(),
-                                                                           predictor.numLabels_,
-                                                                           probabilityTransformationPtr_ == nullptr)) {}
+                          scoreMatrix_(predictor.featureMatrix_.getNumRows(), predictor.numLabels_,
+                                       probabilityTransformationPtr_ != nullptr),
+                          predictionMatrix_(predictor.featureMatrix_.getNumRows(), predictor.numLabels_,
+                                            probabilityTransformationPtr_ == nullptr) {}
             };
 
             const FeatureMatrix& featureMatrix_;

--- a/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_score_common.hpp
+++ b/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_score_common.hpp
@@ -188,8 +188,7 @@ namespace boosting {
                     IncrementalPredictor(const ScorePredictor& predictor, uint32 maxRules)
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, DensePredictionMatrix<float64>>(
                           predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
-                          predictionMatrix_(DensePredictionMatrix<float64>(predictor.featureMatrix_.getNumRows(),
-                                                                           predictor.numLabels_, true)) {}
+                          predictionMatrix_(predictor.featureMatrix_.getNumRows(), predictor.numLabels_, true) {}
             };
 
             const FeatureMatrix& featureMatrix_;

--- a/cpp/subprojects/boosting/src/mlrl/boosting/learner.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/learner.cpp
@@ -44,8 +44,7 @@ namespace boosting {
                                                              Blas::DdotFunction ddotFunction,
                                                              Blas::DspmvFunction dspmvFunction,
                                                              Lapack::DsysvFunction dsysvFunction)
-        : AbstractRuleLearner(config), config_(config), blas_(Blas(ddotFunction, dspmvFunction)),
-          lapack_(Lapack(dsysvFunction)) {}
+        : AbstractRuleLearner(config), config_(config), blas_(ddotFunction, dspmvFunction), lapack_(dsysvFunction) {}
 
     std::unique_ptr<IStatisticsProviderFactory> AbstractBoostingRuleLearner::createStatisticsProviderFactory(
       const IFeatureMatrix& featureMatrix, const IRowWiseLabelMatrix& labelMatrix) const {

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_binned_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_binned_common.hpp
@@ -252,8 +252,7 @@ namespace boosting {
                                                     std::unique_ptr<ILabelBinning> binningPtr, const Blas& blas,
                                                     const Lapack& lapack)
                 : AbstractExampleWiseRuleEvaluation<DenseExampleWiseStatisticVector, IndexVector>(maxBins, lapack),
-                  maxBins_(maxBins),
-                  scoreVector_(DenseBinnedScoreVector<IndexVector>(labelIndices, maxBins + 1, indicesSorted)),
+                  maxBins_(maxBins), scoreVector_(labelIndices, maxBins + 1, indicesSorted),
                   aggregatedGradients_(new float64[maxBins]),
                   aggregatedHessians_(new float64[triangularNumber(maxBins)]), binIndices_(new uint32[maxBins]),
                   numElementsPerBin_(new uint32[maxBins]), criteria_(new float64[labelIndices.getNumElements()]),

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_complete_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_complete_common.hpp
@@ -173,9 +173,8 @@ namespace boosting {
                                                    const Lapack& lapack)
                 : AbstractExampleWiseRuleEvaluation<DenseExampleWiseStatisticVector, IndexVector>(
                   labelIndices.getNumElements(), lapack),
-                  scoreVector_(DenseScoreVector<IndexVector>(labelIndices, true)),
-                  l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight),
-                  blas_(blas), lapack_(lapack) {}
+                  scoreVector_(labelIndices, true), l1RegularizationWeight_(l1RegularizationWeight),
+                  l2RegularizationWeight_(l2RegularizationWeight), blas_(blas), lapack_(lapack) {}
 
             /**
              * @see `IRuleEvaluation::evaluate`

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_dynamic.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_dynamic.cpp
@@ -61,10 +61,10 @@ namespace boosting {
                                                          const Lapack& lapack)
                 : AbstractExampleWiseRuleEvaluation<DenseExampleWiseStatisticVector, IndexVector>(
                   labelIndices.getNumElements(), lapack),
-                  labelIndices_(labelIndices), indexVector_(PartialIndexVector(labelIndices.getNumElements())),
-                  scoreVector_(DenseScoreVector<PartialIndexVector>(indexVector_, true)), threshold_(1.0 - threshold),
-                  exponent_(exponent), l1RegularizationWeight_(l1RegularizationWeight),
-                  l2RegularizationWeight_(l2RegularizationWeight), blas_(blas), lapack_(lapack) {}
+                  labelIndices_(labelIndices), indexVector_(labelIndices.getNumElements()),
+                  scoreVector_(indexVector_, true), threshold_(1.0 - threshold), exponent_(exponent),
+                  l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight),
+                  blas_(blas), lapack_(lapack) {}
 
             /**
              * @see `IRuleEvaluation::evaluate`

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_fixed.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_fixed.cpp
@@ -55,10 +55,9 @@ namespace boosting {
                                                        const Blas& blas, const Lapack& lapack)
                 : AbstractExampleWiseRuleEvaluation<DenseExampleWiseStatisticVector, IndexVector>(numPredictions,
                                                                                                   lapack),
-                  labelIndices_(labelIndices), indexVector_(PartialIndexVector(numPredictions)),
-                  scoreVector_(DenseScoreVector<PartialIndexVector>(indexVector_, false)),
+                  labelIndices_(labelIndices), indexVector_(numPredictions), scoreVector_(indexVector_, false),
                   l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight),
-                  blas_(blas), lapack_(lapack), tmpVector_(SparseArrayVector<float64>(labelIndices.getNumElements())) {}
+                  blas_(blas), lapack_(lapack), tmpVector_(labelIndices.getNumElements()) {}
 
             /**
              * @see `IRuleEvaluation::evaluate`

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_fixed_binned.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_fixed_binned.cpp
@@ -79,7 +79,7 @@ namespace boosting {
                   *indexVectorPtr, false, maxBins, l1RegularizationWeight, l2RegularizationWeight,
                   std::move(binningPtr), blas, lapack),
                   labelIndices_(labelIndices), indexVectorPtr_(std::move(indexVectorPtr)),
-                  tmpVector_(SparseArrayVector<float64>(labelIndices.getNumElements())) {}
+                  tmpVector_(labelIndices.getNumElements()) {}
     };
 
     ExampleWiseFixedPartialBinnedRuleEvaluationFactory::ExampleWiseFixedPartialBinnedRuleEvaluationFactory(

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_binned_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_binned_common.hpp
@@ -106,8 +106,7 @@ namespace boosting {
                                                   float64 l1RegularizationWeight, float64 l2RegularizationWeight,
                                                   std::unique_ptr<ILabelBinning> binningPtr)
                 : maxBins_(binningPtr->getMaxBins(labelIndices.getNumElements())),
-                  scoreVector_(DenseBinnedScoreVector<IndexVector>(labelIndices, maxBins_ + 1, indicesSorted)),
-                  aggregatedStatisticVector_(DenseLabelWiseStatisticVector(maxBins_)),
+                  scoreVector_(labelIndices, maxBins_ + 1, indicesSorted), aggregatedStatisticVector_(maxBins_),
                   numElementsPerBin_(new uint32[maxBins_]), criteria_(new float64[labelIndices.getNumElements()]),
                   l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight),
                   binningPtr_(std::move(binningPtr)) {

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_complete_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_complete_common.hpp
@@ -38,8 +38,8 @@ namespace boosting {
              */
             LabelWiseCompleteRuleEvaluation(const IndexVector& labelIndices, float64 l1RegularizationWeight,
                                             float64 l2RegularizationWeight)
-                : scoreVector_(DenseScoreVector<IndexVector>(labelIndices, true)),
-                  l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight) {}
+                : scoreVector_(labelIndices, true), l1RegularizationWeight_(l1RegularizationWeight),
+                  l2RegularizationWeight_(l2RegularizationWeight) {}
 
             const IScoreVector& calculateScores(StatisticVector& statisticVector) override {
                 uint32 numElements = statisticVector.getNumElements();

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_dynamic.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_dynamic.cpp
@@ -48,10 +48,9 @@ namespace boosting {
              */
             LabelWiseDynamicPartialRuleEvaluation(const IndexVector& labelIndices, float32 threshold, float32 exponent,
                                                   float64 l1RegularizationWeight, float64 l2RegularizationWeight)
-                : labelIndices_(labelIndices), indexVector_(PartialIndexVector(labelIndices.getNumElements())),
-                  scoreVector_(DenseScoreVector<PartialIndexVector>(indexVector_, true)), threshold_(1.0 - threshold),
-                  exponent_(exponent), l1RegularizationWeight_(l1RegularizationWeight),
-                  l2RegularizationWeight_(l2RegularizationWeight) {}
+                : labelIndices_(labelIndices), indexVector_(labelIndices.getNumElements()),
+                  scoreVector_(indexVector_, true), threshold_(1.0 - threshold), exponent_(exponent),
+                  l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight) {}
 
             const IScoreVector& calculateScores(StatisticVector& statisticVector) override {
                 uint32 numElements = statisticVector.getNumElements();

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_fixed.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_fixed.cpp
@@ -43,10 +43,9 @@ namespace boosting {
              */
             LabelWiseFixedPartialRuleEvaluation(const IndexVector& labelIndices, uint32 numPredictions,
                                                 float64 l1RegularizationWeight, float64 l2RegularizationWeight)
-                : labelIndices_(labelIndices), indexVector_(PartialIndexVector(numPredictions)),
-                  scoreVector_(DenseScoreVector<PartialIndexVector>(indexVector_, false)),
+                : labelIndices_(labelIndices), indexVector_(numPredictions), scoreVector_(indexVector_, false),
                   l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight),
-                  tmpVector_(SparseArrayVector<float64>(labelIndices.getNumElements())) {}
+                  tmpVector_(labelIndices.getNumElements()) {}
 
             const IScoreVector& calculateScores(StatisticVector& statisticVector) override {
                 uint32 numElements = statisticVector.getNumElements();

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_fixed_binned.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_fixed_binned.cpp
@@ -68,7 +68,7 @@ namespace boosting {
                 : AbstractLabelWiseBinnedRuleEvaluation<StatisticVector, PartialIndexVector>(
                   *indexVectorPtr, false, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr)),
                   labelIndices_(labelIndices), indexVectorPtr_(std::move(indexVectorPtr)),
-                  tmpVector_(SparseArrayVector<float64>(labelIndices.getNumElements())) {}
+                  tmpVector_(labelIndices.getNumElements()) {}
     };
 
     LabelWiseFixedPartialBinnedRuleEvaluationFactory::LabelWiseFixedPartialBinnedRuleEvaluationFactory(

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_single.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_single.cpp
@@ -39,8 +39,7 @@ namespace boosting {
              */
             LabelWiseSingleLabelRuleEvaluation(const IndexVector& labelIndices, float64 l1RegularizationWeight,
                                                float64 l2RegularizationWeight)
-                : labelIndices_(labelIndices), indexVector_(PartialIndexVector(1)),
-                  scoreVector_(DenseScoreVector<PartialIndexVector>(indexVector_, true)),
+                : labelIndices_(labelIndices), indexVector_(1), scoreVector_(indexVector_, true),
                   l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight) {}
 
             const IScoreVector& calculateScores(StatisticVector& statisticVector) override {

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_example_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_example_wise_common.hpp
@@ -100,8 +100,8 @@ namespace boosting {
             ExampleWiseStatisticsSubset(const StatisticView& statisticView,
                                         const RuleEvaluationFactory& ruleEvaluationFactory, const WeightVector& weights,
                                         const IndexVector& labelIndices)
-                : sumVector_(StatisticVector(labelIndices.getNumElements(), true)), statisticView_(statisticView),
-                  weights_(weights), labelIndices_(labelIndices),
+                : sumVector_(labelIndices.getNumElements(), true), statisticView_(statisticView), weights_(weights),
+                  labelIndices_(labelIndices),
                   ruleEvaluationPtr_(ruleEvaluationFactory.create(sumVector_, labelIndices)) {}
 
             /**
@@ -186,8 +186,7 @@ namespace boosting {
                                                       WeightVector, IndexVector>(statistics.statisticView_,
                                                                                  statistics.ruleEvaluationFactory_,
                                                                                  statistics.weights_, labelIndices),
-                          tmpVector_(StatisticVector(labelIndices.getNumElements())), totalSumVector_(&totalSumVector) {
-                    }
+                          tmpVector_(labelIndices.getNumElements()), totalSumVector_(&totalSumVector) {}
 
                     /**
                      * @see `IWeightedStatisticsSubset::resetSubset`

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_common.hpp
@@ -96,8 +96,8 @@ namespace boosting {
             LabelWiseStatisticsSubset(const StatisticView& statisticView,
                                       const RuleEvaluationFactory& ruleEvaluationFactory, const WeightVector& weights,
                                       const IndexVector& labelIndices)
-                : sumVector_(StatisticVector(labelIndices.getNumElements(), true)), statisticView_(statisticView),
-                  weights_(weights), labelIndices_(labelIndices),
+                : sumVector_(labelIndices.getNumElements(), true), statisticView_(statisticView), weights_(weights),
+                  labelIndices_(labelIndices),
                   ruleEvaluationPtr_(ruleEvaluationFactory.create(sumVector_, labelIndices)) {}
 
             /**
@@ -182,8 +182,7 @@ namespace boosting {
                                                     IndexVector>(statistics.statisticView_,
                                                                  statistics.ruleEvaluationFactory_, statistics.weights_,
                                                                  labelIndices),
-                          tmpVector_(StatisticVector(labelIndices.getNumElements())), totalSumVector_(&totalSumVector) {
-                    }
+                          tmpVector_(labelIndices.getNumElements()), totalSumVector_(&totalSumVector) {}
 
                     /**
                      * @see `IWeightedStatisticsSubset::resetSubset`

--- a/cpp/subprojects/common/src/mlrl/common/binning/bin_index_vector_dense.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/binning/bin_index_vector_dense.cpp
@@ -2,7 +2,7 @@
 
 #include "mlrl/common/statistics/statistics_weighted.hpp"
 
-DenseBinIndexVector::DenseBinIndexVector(uint32 numElements) : vector_(DenseVector<uint32>(numElements)) {}
+DenseBinIndexVector::DenseBinIndexVector(uint32 numElements) : vector_(numElements) {}
 
 uint32 DenseBinIndexVector::getBinIndex(uint32 exampleIndex) const {
     return vector_[exampleIndex];

--- a/cpp/subprojects/common/src/mlrl/common/binning/bin_index_vector_dok.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/binning/bin_index_vector_dok.cpp
@@ -2,7 +2,7 @@
 
 #include "mlrl/common/statistics/statistics_weighted.hpp"
 
-DokBinIndexVector::DokBinIndexVector() : vector_(DokVector<uint32>(BIN_INDEX_SPARSE)) {}
+DokBinIndexVector::DokBinIndexVector() : vector_(BIN_INDEX_SPARSE) {}
 
 DokBinIndexVector::iterator DokBinIndexVector::begin() {
     return vector_.begin();

--- a/cpp/subprojects/common/src/mlrl/common/binning/bin_weight_vector.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/binning/bin_weight_vector.cpp
@@ -2,7 +2,7 @@
 
 #include "mlrl/common/data/arrays.hpp"
 
-BinWeightVector::BinWeightVector(uint32 numElements) : vector_(DenseVector<uint32>(numElements)) {}
+BinWeightVector::BinWeightVector(uint32 numElements) : vector_(numElements) {}
 
 void BinWeightVector::clear() {
     setArrayToZeros(vector_.begin(), vector_.getNumElements());

--- a/cpp/subprojects/common/src/mlrl/common/binning/threshold_vector.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/binning/threshold_vector.cpp
@@ -4,8 +4,7 @@ ThresholdVector::ThresholdVector(MissingFeatureVector& missingFeatureVector, uin
     : ThresholdVector(missingFeatureVector, numElements, false) {}
 
 ThresholdVector::ThresholdVector(MissingFeatureVector& missingFeatureVector, uint32 numElements, bool init)
-    : MissingFeatureVector(missingFeatureVector), vector_(DenseVector<float32>(numElements, init)),
-      sparseBinIndex_(numElements) {}
+    : MissingFeatureVector(missingFeatureVector), vector_(numElements, init), sparseBinIndex_(numElements) {}
 
 ThresholdVector::iterator ThresholdVector::begin() {
     return vector_.begin();

--- a/cpp/subprojects/common/src/mlrl/common/data/matrix_sparse_set.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/data/matrix_sparse_set.cpp
@@ -129,7 +129,7 @@ void SparseSetMatrix<T>::Row::clear() {
 
 template<typename T>
 SparseSetMatrix<T>::SparseSetMatrix(uint32 numRows, uint32 numCols)
-    : lilMatrix_(LilMatrix<T>(numRows)), indexMatrix_(CContiguousMatrix<uint32>(numRows, numCols)) {
+    : lilMatrix_(numRows), indexMatrix_(numRows, numCols) {
     setArrayToValue(indexMatrix_.values_begin(0), numRows * numCols, MAX_INDEX);
 }
 

--- a/cpp/subprojects/common/src/mlrl/common/data/vector_binned_dense.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/data/vector_binned_dense.cpp
@@ -61,7 +61,7 @@ typename DenseBinnedVector<T>::ValueConstIterator::difference_type DenseBinnedVe
 
 template<typename T>
 DenseBinnedVector<T>::DenseBinnedVector(uint32 numElements, uint32 numBins)
-    : binIndices_(DenseVector<uint32>(numElements)), values_(DenseVector<T>(numBins)) {}
+    : binIndices_(numElements), values_(numBins) {}
 
 template<typename T>
 typename DenseBinnedVector<T>::const_iterator DenseBinnedVector<T>::cbegin() const {

--- a/cpp/subprojects/common/src/mlrl/common/data/vector_sparse_arrays.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/data/vector_sparse_arrays.cpp
@@ -1,8 +1,7 @@
 #include "mlrl/common/data/vector_sparse_arrays.hpp"
 
 template<typename T>
-SparseArraysVector<T>::SparseArraysVector(uint32 numElements)
-    : indices_(DenseVector<uint32>(numElements)), values_(DenseVector<T>(numElements)) {}
+SparseArraysVector<T>::SparseArraysVector(uint32 numElements) : indices_(numElements), values_(numElements) {}
 
 template<typename T>
 typename SparseArraysVector<T>::index_iterator SparseArraysVector<T>::indices_begin() {

--- a/cpp/subprojects/common/src/mlrl/common/indices/index_vector_partial.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/indices/index_vector_partial.cpp
@@ -4,8 +4,7 @@
 
 PartialIndexVector::PartialIndexVector(uint32 numElements) : PartialIndexVector(numElements, false) {}
 
-PartialIndexVector::PartialIndexVector(uint32 numElements, bool init)
-    : vector_(DenseVector<uint32>(numElements, init)) {}
+PartialIndexVector::PartialIndexVector(uint32 numElements, bool init) : vector_(numElements, init) {}
 
 bool PartialIndexVector::isPartial() const {
     return true;

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_info_mixed.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_info_mixed.cpp
@@ -22,7 +22,7 @@ class BitFeatureInfo final : public IMixedFeatureInfo {
          * @param numFeatures The total number of available features
          */
         BitFeatureInfo(uint32 numFeatures)
-            : ordinalBitVector_(BitVector(numFeatures, true)), nominalBitVector_(BitVector(numFeatures, true)) {}
+            : ordinalBitVector_(numFeatures, true), nominalBitVector_(numFeatures, true) {}
 
         std::unique_ptr<IFeatureType> createFeatureType(uint32 featureIndex) const override {
             if (ordinalBitVector_[featureIndex]) {

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_vector.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_vector.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-FeatureVector::FeatureVector(uint32 numElements) : vector_(SparseArrayVector<float32>(numElements)) {}
+FeatureVector::FeatureVector(uint32 numElements) : vector_(numElements) {}
 
 FeatureVector::iterator FeatureVector::begin() {
     return vector_.begin();

--- a/cpp/subprojects/common/src/mlrl/common/model/body_conjunctive.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/model/body_conjunctive.cpp
@@ -49,12 +49,8 @@ bool ConjunctiveBody::ConditionVector<Threshold, Compare>::covers(
 
 ConjunctiveBody::ConjunctiveBody(uint32 numNumericalLeq, uint32 numNumericalGr, uint32 numOrdinalLeq,
                                  uint32 numOrdinalGr, uint32 numNominalEq, uint32 numNominalNeq)
-    : numericalLeqVector_(ConditionVector<float32, CompareNumericalLeq>(numNumericalLeq)),
-      numericalGrVector_(ConditionVector<float32, CompareNumericalGr>(numNumericalGr)),
-      ordinalLeqVector_(ConditionVector<float32, CompareOrdinalLeq>(numOrdinalLeq)),
-      ordinalGrVector_(ConditionVector<float32, CompareOrdinalGr>(numOrdinalGr)),
-      nominalEqVector_(ConditionVector<float32, CompareNominalEq>(numNominalEq)),
-      nominalNeqVector_(ConditionVector<float32, CompareNominalNeq>(numNominalNeq)) {}
+    : numericalLeqVector_(numNumericalLeq), numericalGrVector_(numNumericalGr), ordinalLeqVector_(numOrdinalLeq),
+      ordinalGrVector_(numOrdinalGr), nominalEqVector_(numNominalEq), nominalNeqVector_(numNominalNeq) {}
 
 uint32 ConjunctiveBody::getNumNumericalLeq() const {
     return numericalLeqVector_.getNumElements();

--- a/cpp/subprojects/common/src/mlrl/common/model/head_complete.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/model/head_complete.cpp
@@ -1,6 +1,6 @@
 #include "mlrl/common/model/head_complete.hpp"
 
-CompleteHead::CompleteHead(uint32 numElements) : vector_(DenseVector<float64>(numElements)) {}
+CompleteHead::CompleteHead(uint32 numElements) : vector_(numElements) {}
 
 uint32 CompleteHead::getNumElements() const {
     return vector_.getNumElements();

--- a/cpp/subprojects/common/src/mlrl/common/model/head_partial.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/model/head_partial.cpp
@@ -1,6 +1,6 @@
 #include "mlrl/common/model/head_partial.hpp"
 
-PartialHead::PartialHead(uint32 numElements) : vector_(SparseArraysVector<float64>(numElements)) {}
+PartialHead::PartialHead(uint32 numElements) : vector_(numElements) {}
 
 uint32 PartialHead::getNumElements() const {
     return vector_.getNumElements();

--- a/cpp/subprojects/common/src/mlrl/common/prediction/probability_calibration_isotonic.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/prediction/probability_calibration_isotonic.cpp
@@ -130,8 +130,7 @@ static inline float64 calibrateProbability(ListOfLists<Tuple<float64>>::const_ro
     return lowerBound.second + (t * (upperBound.second - lowerBound.second));
 }
 
-IsotonicProbabilityCalibrationModel::IsotonicProbabilityCalibrationModel(uint32 numLists)
-    : binsPerList_(ListOfLists<Tuple<float64>>(numLists)) {}
+IsotonicProbabilityCalibrationModel::IsotonicProbabilityCalibrationModel(uint32 numLists) : binsPerList_(numLists) {}
 
 IsotonicProbabilityCalibrationModel::bin_list IsotonicProbabilityCalibrationModel::operator[](uint32 listIndex) {
     return binsPerList_[listIndex];

--- a/cpp/subprojects/common/src/mlrl/common/rule_evaluation/score_vector_binned_dense.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_evaluation/score_vector_binned_dense.cpp
@@ -8,8 +8,7 @@
 template<typename IndexVector>
 DenseBinnedScoreVector<IndexVector>::DenseBinnedScoreVector(const IndexVector& labelIndices, uint32 numBins,
                                                             bool sorted)
-    : labelIndices_(labelIndices), binnedVector_(DenseBinnedVector<float64>(labelIndices.getNumElements(), numBins)),
-      sorted_(sorted) {}
+    : labelIndices_(labelIndices), binnedVector_(labelIndices.getNumElements(), numBins), sorted_(sorted) {}
 
 template<typename IndexVector>
 typename DenseBinnedScoreVector<IndexVector>::index_const_iterator DenseBinnedScoreVector<IndexVector>::indices_cbegin()

--- a/cpp/subprojects/common/src/mlrl/common/rule_evaluation/score_vector_dense.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_evaluation/score_vector_dense.cpp
@@ -7,8 +7,7 @@
 
 template<typename IndexVector>
 DenseScoreVector<IndexVector>::DenseScoreVector(const IndexVector& labelIndices, bool sorted)
-    : labelIndices_(labelIndices), predictedScoreVector_(DenseVector<float64>(labelIndices.getNumElements())),
-      sorted_(sorted) {}
+    : labelIndices_(labelIndices), predictedScoreVector_(labelIndices.getNumElements()), sorted_(sorted) {}
 
 template<typename IndexVector>
 typename DenseScoreVector<IndexVector>::index_const_iterator DenseScoreVector<IndexVector>::indices_cbegin() const {

--- a/cpp/subprojects/common/src/mlrl/common/rule_refinement/prediction.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_refinement/prediction.cpp
@@ -2,7 +2,7 @@
 
 #include "mlrl/common/data/arrays.hpp"
 
-AbstractPrediction::AbstractPrediction(uint32 numElements) : predictedScoreVector_(DenseVector<float64>(numElements)) {}
+AbstractPrediction::AbstractPrediction(uint32 numElements) : predictedScoreVector_(numElements) {}
 
 uint32 AbstractPrediction::getNumElements() const {
     return predictedScoreVector_.getNumElements();

--- a/cpp/subprojects/common/src/mlrl/common/rule_refinement/prediction_complete.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_refinement/prediction_complete.cpp
@@ -6,7 +6,7 @@
 #include "mlrl/common/statistics/statistics.hpp"
 
 CompletePrediction::CompletePrediction(uint32 numElements)
-    : AbstractEvaluatedPrediction(numElements), indexVector_(CompleteIndexVector(numElements)) {}
+    : AbstractEvaluatedPrediction(numElements), indexVector_(numElements) {}
 
 CompletePrediction::index_const_iterator CompletePrediction::indices_cbegin() const {
     return indexVector_.cbegin();

--- a/cpp/subprojects/common/src/mlrl/common/rule_refinement/prediction_partial.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_refinement/prediction_partial.cpp
@@ -7,7 +7,7 @@
 #include "mlrl/common/statistics/statistics.hpp"
 
 PartialPrediction::PartialPrediction(uint32 numElements, bool sorted)
-    : AbstractEvaluatedPrediction(numElements), indexVector_(PartialIndexVector(numElements)), sorted_(sorted) {}
+    : AbstractEvaluatedPrediction(numElements), indexVector_(numElements), sorted_(sorted) {}
 
 PartialPrediction::index_iterator PartialPrediction::indices_begin() {
     return indexVector_.begin();

--- a/cpp/subprojects/common/src/mlrl/common/rule_refinement/refinement_comparator_single.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_refinement/refinement_comparator_single.cpp
@@ -2,11 +2,11 @@
 
 SingleRefinementComparator::SingleRefinementComparator(RuleCompareFunction ruleCompareFunction)
     : ruleCompareFunction_(ruleCompareFunction), bestQuality_(ruleCompareFunction.minQuality),
-      scoreProcessor_(ScoreProcessor(bestRefinement_.headPtr)) {}
+      scoreProcessor_(bestRefinement_.headPtr) {}
 
 SingleRefinementComparator::SingleRefinementComparator(const SingleRefinementComparator& comparator)
     : ruleCompareFunction_(comparator.ruleCompareFunction_), bestQuality_(comparator.bestQuality_),
-      scoreProcessor_(ScoreProcessor(bestRefinement_.headPtr)) {}
+      scoreProcessor_(bestRefinement_.headPtr) {}
 
 SingleRefinementComparator::iterator SingleRefinementComparator::begin() {
     return &bestRefinement_;

--- a/cpp/subprojects/common/src/mlrl/common/sampling/feature_sampling_no.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/feature_sampling_no.cpp
@@ -16,7 +16,7 @@ class NoFeatureSampling final : public IFeatureSampling {
         /**
          * @param numFeatures The total number of available features
          */
-        NoFeatureSampling(uint32 numFeatures) : indexVector_(CompleteIndexVector(numFeatures)) {}
+        NoFeatureSampling(uint32 numFeatures) : indexVector_(numFeatures) {}
 
         const IIndexVector& sample(RNG& rng) override {
             return indexVector_;

--- a/cpp/subprojects/common/src/mlrl/common/sampling/feature_sampling_without_replacement.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/feature_sampling_without_replacement.cpp
@@ -29,7 +29,7 @@ class FeatureSamplingWithoutReplacement final : public IFeatureSampling {
          */
         FeatureSamplingWithoutReplacement(uint32 numFeatures, uint32 numSamples, uint32 numRetained)
             : numFeatures_(numFeatures), numSamples_(numSamples), numRetained_(numRetained),
-              indexVector_(PartialIndexVector(numSamples + numRetained)) {
+              indexVector_(numSamples + numRetained) {
             if (numRetained > 0) {
                 PartialIndexVector::iterator iterator = indexVector_.begin();
                 uint32 offset = numFeatures - numRetained;

--- a/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_no.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_no.cpp
@@ -44,8 +44,7 @@ class NoInstanceSampling final : public IInstanceSampling {
          * @param partition A reference to an object of template type `Partition` that provides access to the indices of
          *                  the examples that are included in the training set
          */
-        NoInstanceSampling(Partition& partition)
-            : partition_(partition), weightVector_(WeightVector(partition.getNumElements())) {}
+        NoInstanceSampling(Partition& partition) : partition_(partition), weightVector_(partition.getNumElements()) {}
 
         const IWeightVector& sample(RNG& rng) override {
             sampleInternally(partition_, weightVector_, rng);

--- a/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_stratified_example_wise.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_stratified_example_wise.cpp
@@ -38,10 +38,8 @@ class ExampleWiseStratifiedSampling final : public IInstanceSampling {
         ExampleWiseStratifiedSampling(const LabelMatrix& labelMatrix, IndexIterator indicesBegin,
                                       IndexIterator indicesEnd, float32 sampleSize)
             : sampleSize_(sampleSize),
-              weightVector_(BitWeightVector(labelMatrix.getNumRows(),
-                                            (uint32) (indicesEnd - indicesBegin) < labelMatrix.getNumRows())),
-              stratification_(
-                ExampleWiseStratification<LabelMatrix, IndexIterator>(labelMatrix, indicesBegin, indicesEnd)) {}
+              weightVector_(labelMatrix.getNumRows(), (uint32) (indicesEnd - indicesBegin) < labelMatrix.getNumRows()),
+              stratification_(labelMatrix, indicesBegin, indicesEnd) {}
 
         const IWeightVector& sample(RNG& rng) override {
             stratification_.sampleWeights(weightVector_, sampleSize_, rng);

--- a/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_stratified_label_wise.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_stratified_label_wise.cpp
@@ -39,10 +39,8 @@ class LabelWiseStratifiedSampling final : public IInstanceSampling {
         LabelWiseStratifiedSampling(const LabelMatrix& labelMatrix, IndexIterator indicesBegin,
                                     IndexIterator indicesEnd, float32 sampleSize)
             : sampleSize_(sampleSize),
-              weightVector_(BitWeightVector(labelMatrix.getNumRows(),
-                                            (uint32) (indicesEnd - indicesBegin) < labelMatrix.getNumRows())),
-              stratification_(
-                LabelWiseStratification<LabelMatrix, IndexIterator>(labelMatrix, indicesBegin, indicesEnd)) {}
+              weightVector_(labelMatrix.getNumRows(), (uint32) (indicesEnd - indicesBegin) < labelMatrix.getNumRows()),
+              stratification_(labelMatrix, indicesBegin, indicesEnd) {}
 
         const IWeightVector& sample(RNG& rng) override {
             stratification_.sampleWeights(weightVector_, sampleSize_, rng);

--- a/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_with_replacement.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_with_replacement.cpp
@@ -82,8 +82,7 @@ class InstanceSamplingWithReplacement final : public IInstanceSampling {
          *                   60 % of the available examples). Must be in (0, 1]
          */
         InstanceSamplingWithReplacement(Partition& partition, float32 sampleSize)
-            : partition_(partition), sampleSize_(sampleSize),
-              weightVector_(DenseWeightVector<uint32>(partition.getNumElements())) {}
+            : partition_(partition), sampleSize_(sampleSize), weightVector_(partition.getNumElements()) {}
 
         const IWeightVector& sample(RNG& rng) override {
             sampleInternally(partition_, sampleSize_, weightVector_, rng);

--- a/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_without_replacement.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/instance_sampling_without_replacement.cpp
@@ -47,8 +47,7 @@ class InstanceSamplingWithoutReplacement final : public IInstanceSampling {
          *                   60 % of the available examples). Must be in (0, 1)
          */
         InstanceSamplingWithoutReplacement(Partition& partition, float32 sampleSize)
-            : partition_(partition), sampleSize_(sampleSize),
-              weightVector_(BitWeightVector(partition.getNumElements())) {}
+            : partition_(partition), sampleSize_(sampleSize), weightVector_(partition.getNumElements()) {}
 
         const IWeightVector& sample(RNG& rng) override {
             sampleInternally(partition_, sampleSize_, weightVector_, rng);

--- a/cpp/subprojects/common/src/mlrl/common/sampling/label_sampling_round_robin.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/label_sampling_round_robin.cpp
@@ -19,8 +19,7 @@ class RoundRobinLabelSampling final : public ILabelSampling {
         /**
          * @param numLabels The total number of available labels
          */
-        RoundRobinLabelSampling(uint32 numLabels)
-            : numLabels_(numLabels), indexVector_(PartialIndexVector(1)), nextIndex_(0) {}
+        RoundRobinLabelSampling(uint32 numLabels) : numLabels_(numLabels), indexVector_(1), nextIndex_(0) {}
 
         const IIndexVector& sample(RNG& rng) override {
             indexVector_.begin()[0] = nextIndex_;

--- a/cpp/subprojects/common/src/mlrl/common/sampling/label_sampling_without_replacement.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/label_sampling_without_replacement.cpp
@@ -22,7 +22,7 @@ class LabelSamplingWithoutReplacement final : public ILabelSampling {
          * @param numSamples    The number of labels to be included in the sample
          */
         LabelSamplingWithoutReplacement(uint32 numLabels, uint32 numSamples)
-            : numLabels_(numLabels), indexVector_(PartialIndexVector(numSamples)) {}
+            : numLabels_(numLabels), indexVector_(numSamples) {}
 
         const IIndexVector& sample(RNG& rng) override {
             sampleIndicesWithoutReplacement<IndexIterator>(indexVector_.begin(), indexVector_.getNumElements(),

--- a/cpp/subprojects/common/src/mlrl/common/sampling/partition_bi.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/partition_bi.cpp
@@ -9,8 +9,7 @@
 #include <algorithm>
 
 BiPartition::BiPartition(uint32 numFirst, uint32 numSecond)
-    : vector_(DenseVector<uint32>(numFirst + numSecond)), numFirst_(numFirst), firstSorted_(false),
-      secondSorted_(false) {}
+    : vector_(numFirst + numSecond), numFirst_(numFirst), firstSorted_(false), secondSorted_(false) {}
 
 BiPartition::iterator BiPartition::first_begin() {
     return vector_.begin();

--- a/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_bi_random.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_bi_random.cpp
@@ -19,8 +19,7 @@ class RandomBiPartitionSampling final : public IPartitionSampling {
          * @param numTraining   The number of examples to be included in the training set
          * @param numHoldout    The number of examples to be included in the holdout set
          */
-        RandomBiPartitionSampling(uint32 numTraining, uint32 numHoldout)
-            : partition_(BiPartition(numTraining, numHoldout)) {}
+        RandomBiPartitionSampling(uint32 numTraining, uint32 numHoldout) : partition_(numTraining, numHoldout) {}
 
         IPartition& partition(RNG& rng) override {
             uint32 numTraining = partition_.getNumFirst();

--- a/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_bi_stratified_example_wise.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_bi_stratified_example_wise.cpp
@@ -28,9 +28,8 @@ class ExampleWiseStratifiedBiPartitionSampling final : public IPartitionSampling
          * @param numHoldout    The number of examples to be included in the holdout set
          */
         ExampleWiseStratifiedBiPartitionSampling(const LabelMatrix& labelMatrix, uint32 numTraining, uint32 numHoldout)
-            : partition_(BiPartition(numTraining, numHoldout)),
-              stratification_(ExampleWiseStratification<LabelMatrix, IndexIterator>(
-                labelMatrix, IndexIterator(), IndexIterator(labelMatrix.getNumRows()))) {}
+            : partition_(numTraining, numHoldout),
+              stratification_(labelMatrix, IndexIterator(), IndexIterator(labelMatrix.getNumRows())) {}
 
         IPartition& partition(RNG& rng) override {
             stratification_.sampleBiPartition(partition_, rng);

--- a/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_bi_stratified_label_wise.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_bi_stratified_label_wise.cpp
@@ -29,9 +29,8 @@ class LabelWiseStratifiedBiPartitionSampling final : public IPartitionSampling {
          * @param numHoldout    The number of examples to be included in the holdout set
          */
         LabelWiseStratifiedBiPartitionSampling(const LabelMatrix& labelMatrix, uint32 numTraining, uint32 numHoldout)
-            : partition_(BiPartition(numTraining, numHoldout)),
-              stratification_(LabelWiseStratification<LabelMatrix, IndexIterator>(
-                labelMatrix, IndexIterator(), IndexIterator(labelMatrix.getNumRows()))) {}
+            : partition_(numTraining, numHoldout),
+              stratification_(labelMatrix, IndexIterator(), IndexIterator(labelMatrix.getNumRows())) {}
 
         IPartition& partition(RNG& rng) override {
             stratification_.sampleBiPartition(partition_, rng);

--- a/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_no.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/partition_sampling_no.cpp
@@ -16,7 +16,7 @@ class NoPartitionSampling final : public IPartitionSampling {
         /**
          * @param numExamples The total number of available training examples
          */
-        NoPartitionSampling(uint32 numExamples) : partition_(SinglePartition(numExamples)) {}
+        NoPartitionSampling(uint32 numExamples) : partition_(numExamples) {}
 
         IPartition& partition(RNG& rng) override {
             return partition_;

--- a/cpp/subprojects/common/src/mlrl/common/sampling/weight_vector_bit.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/weight_vector_bit.cpp
@@ -5,8 +5,7 @@
 
 BitWeightVector::BitWeightVector(uint32 numElements) : BitWeightVector(numElements, false) {}
 
-BitWeightVector::BitWeightVector(uint32 numElements, bool init)
-    : vector_(BitVector(numElements, init)), numNonZeroWeights_(0) {}
+BitWeightVector::BitWeightVector(uint32 numElements, bool init) : vector_(numElements, init), numNonZeroWeights_(0) {}
 
 uint32 BitWeightVector::getNumElements() const {
     return vector_.getNumElements();

--- a/cpp/subprojects/common/src/mlrl/common/sampling/weight_vector_dense.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/weight_vector_dense.cpp
@@ -8,7 +8,7 @@ DenseWeightVector<T>::DenseWeightVector(uint32 numElements) : DenseWeightVector<
 
 template<typename T>
 DenseWeightVector<T>::DenseWeightVector(uint32 numElements, bool init)
-    : vector_(DenseVector<T>(numElements, init)), numNonZeroWeights_(0) {}
+    : vector_(numElements, init), numNonZeroWeights_(0) {}
 
 template<typename T>
 typename DenseWeightVector<T>::iterator DenseWeightVector<T>::begin() {

--- a/cpp/subprojects/common/src/mlrl/common/stopping/global_pruning_pre.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/stopping/global_pruning_pre.cpp
@@ -73,9 +73,8 @@ class PrePruning final : public IStoppingCriterion {
                    uint32 stopInterval, uint32 numPast, uint32 numCurrent, float64 minImprovement)
             : partition_(partition), aggregationFunctionPtr_(std::move(aggregationFunctionPtr)),
               useHoldoutSet_(useHoldoutSet), removeUnusedRules_(removeUnusedRules), updateInterval_(updateInterval),
-              stopInterval_(stopInterval), minImprovement_(minImprovement), pastBuffer_(RingBuffer<float64>(numPast)),
-              recentBuffer_(RingBuffer<float64>(numCurrent)), bestScore_(std::numeric_limits<float64>::infinity()),
-              stopped_(false) {
+              stopInterval_(stopInterval), minImprovement_(minImprovement), pastBuffer_(numPast),
+              recentBuffer_(numCurrent), bestScore_(std::numeric_limits<float64>::infinity()), stopped_(false) {
             uint32 bufferInterval = (numPast * updateInterval) + (numCurrent * updateInterval);
             offset_ = bufferInterval < minRules ? minRules - bufferInterval : 0;
         }

--- a/cpp/subprojects/common/src/mlrl/common/thresholds/thresholds_approximate.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/thresholds/thresholds_approximate.cpp
@@ -224,7 +224,7 @@ class ApproximateThresholds final : public AbstractThresholds {
                                  std::unique_ptr<IWeightedStatistics> weightedStatisticsPtr,
                                  const WeightVector& weights)
                     : thresholds_(thresholds), weightedStatisticsPtr_(std::move(weightedStatisticsPtr)),
-                      weights_(weights), coverageSet_(CoverageSet(thresholds.featureMatrix_.getNumRows())) {}
+                      weights_(weights), coverageSet_(thresholds.featureMatrix_.getNumRows()) {}
 
                 /**
                  * @param thresholdsSubset A reference to an object of type `ThresholdsSubset` to be copied
@@ -232,7 +232,7 @@ class ApproximateThresholds final : public AbstractThresholds {
                 ThresholdsSubset(const ThresholdsSubset& thresholdsSubset)
                     : thresholds_(thresholdsSubset.thresholds_),
                       weightedStatisticsPtr_(thresholdsSubset.weightedStatisticsPtr_->copy()),
-                      weights_(thresholdsSubset.weights_), coverageSet_(CoverageSet(thresholdsSubset.coverageSet_)) {}
+                      weights_(thresholdsSubset.weights_), coverageSet_(thresholdsSubset.coverageSet_) {}
 
                 std::unique_ptr<IThresholdsSubset> copy() const override {
                     return std::make_unique<ThresholdsSubset<WeightVector>>(*this);

--- a/cpp/subprojects/common/src/mlrl/common/thresholds/thresholds_exact.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/thresholds/thresholds_exact.cpp
@@ -339,7 +339,7 @@ class ExactThresholds final : public AbstractThresholds {
                                  const WeightVector& weights)
                     : thresholds_(thresholds), weightedStatisticsPtr_(std::move(weightedStatisticsPtr)),
                       weights_(weights), numCoveredExamples_(weights.getNumNonZeroWeights()),
-                      coverageMask_(CoverageMask(thresholds.featureMatrix_.getNumRows())), numModifications_(0) {}
+                      coverageMask_(thresholds.featureMatrix_.getNumRows()), numModifications_(0) {}
 
                 /**
                  * @param thresholdsSubset A reference to an object of type `ThresholdsSubset` to be copied
@@ -348,7 +348,7 @@ class ExactThresholds final : public AbstractThresholds {
                     : thresholds_(thresholdsSubset.thresholds_),
                       weightedStatisticsPtr_(thresholdsSubset.weightedStatisticsPtr_->copy()),
                       weights_(thresholdsSubset.weights_), numCoveredExamples_(thresholdsSubset.numCoveredExamples_),
-                      coverageMask_(CoverageMask(thresholdsSubset.coverageMask_)),
+                      coverageMask_(thresholdsSubset.coverageMask_),
                       numModifications_(thresholdsSubset.numModifications_) {}
 
                 std::unique_ptr<IThresholdsSubset> copy() const override {

--- a/cpp/subprojects/seco/src/mlrl/seco/rule_evaluation/rule_evaluation_label_wise_majority.hpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/rule_evaluation/rule_evaluation_label_wise_majority.hpp
@@ -28,8 +28,7 @@ namespace seco {
              * @param labelIndices A reference to an object of template type `T` that provides access to the indices of
              *                     the labels for which the rules may predict
              */
-            LabelWiseMajorityRuleEvaluation(const T& labelIndices)
-                : scoreVector_(DenseScoreVector<T>(labelIndices, true)) {
+            LabelWiseMajorityRuleEvaluation(const T& labelIndices) : scoreVector_(labelIndices, true) {
                 scoreVector_.quality = 0;
             }
 

--- a/cpp/subprojects/seco/src/mlrl/seco/rule_evaluation/rule_evaluation_label_wise_partial.cpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/rule_evaluation/rule_evaluation_label_wise_partial.cpp
@@ -43,8 +43,8 @@ namespace seco {
             LabelWiseCompleteRuleEvaluation(const PartialIndexVector& labelIndices,
                                             std::unique_ptr<IHeuristic> heuristicPtr,
                                             std::unique_ptr<ILiftFunction> liftFunctionPtr)
-                : scoreVector_(DenseScoreVector<PartialIndexVector>(labelIndices, true)),
-                  heuristicPtr_(std::move(heuristicPtr)), liftFunctionPtr_(std::move(liftFunctionPtr)) {}
+                : scoreVector_(labelIndices, true), heuristicPtr_(std::move(heuristicPtr)),
+                  liftFunctionPtr_(std::move(liftFunctionPtr)) {}
 
             const IScoreVector& calculateScores(const VectorConstView<uint32>& majorityLabelIndices,
                                                 const DenseConfusionMatrixVector& confusionMatricesTotal,
@@ -109,9 +109,8 @@ namespace seco {
              */
             LabelWisePartialRuleEvaluation(const T& labelIndices, std::unique_ptr<IHeuristic> heuristicPtr,
                                            std::unique_ptr<ILiftFunction> liftFunctionPtr)
-                : labelIndices_(labelIndices), indexVector_(PartialIndexVector(labelIndices.getNumElements())),
-                  scoreVector_(DenseScoreVector<PartialIndexVector>(indexVector_, false)),
-                  sortedVector_(SparseArrayVector<Tuple<float64>>(labelIndices.getNumElements())),
+                : labelIndices_(labelIndices), indexVector_(labelIndices.getNumElements()),
+                  scoreVector_(indexVector_, false), sortedVector_(labelIndices.getNumElements()),
                   heuristicPtr_(std::move(heuristicPtr)), liftFunctionPtr_(std::move(liftFunctionPtr)) {}
 
             const IScoreVector& calculateScores(const VectorConstView<uint32>& majorityLabelIndices,

--- a/cpp/subprojects/seco/src/mlrl/seco/rule_evaluation/rule_evaluation_label_wise_single.cpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/rule_evaluation/rule_evaluation_label_wise_single.cpp
@@ -34,8 +34,7 @@ namespace seco {
              *                      be optimized
              */
             LabelWiseSingleLabelRuleEvaluation(const T& labelIndices, std::unique_ptr<IHeuristic> heuristicPtr)
-                : labelIndices_(labelIndices), indexVector_(PartialIndexVector(1)),
-                  scoreVector_(DenseScoreVector<PartialIndexVector>(indexVector_, true)),
+                : labelIndices_(labelIndices), indexVector_(1), scoreVector_(indexVector_, true),
                   heuristicPtr_(std::move(heuristicPtr)) {}
 
             const IScoreVector& calculateScores(const VectorConstView<uint32>& majorityLabelIndices,

--- a/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_label_wise_common.hpp
@@ -130,7 +130,7 @@ namespace seco {
                                               const ConfusionMatrixVector& totalSumVector,
                                               const RuleEvaluationFactory& ruleEvaluationFactory,
                                               const WeightVector& weights, const IndexVector& labelIndices)
-                : sumVector_(ConfusionMatrixVector(labelIndices.getNumElements(), true)), labelMatrix_(labelMatrix),
+                : sumVector_(labelIndices.getNumElements(), true), labelMatrix_(labelMatrix),
                   coverageMatrix_(coverageMatrix), majorityLabelVector_(majorityLabelVector),
                   totalSumVector_(totalSumVector), weights_(weights), labelIndices_(labelIndices),
                   ruleEvaluationPtr_(ruleEvaluationFactory.create(labelIndices)) {}
@@ -336,8 +336,7 @@ namespace seco {
                           statistics.labelMatrix_, statistics.coverageMatrix_, statistics.majorityLabelVector_,
                           statistics.totalSumVector_, statistics.ruleEvaluationFactory_, statistics.weights_,
                           labelIndices),
-                          subsetSumVector_(&statistics.subsetSumVector_),
-                          tmpVector_(ConfusionMatrixVector(labelIndices.getNumElements())) {}
+                          subsetSumVector_(&statistics.subsetSumVector_), tmpVector_(labelIndices.getNumElements()) {}
 
                     /**
                      * @see `IWeightedStatisticsSubset::addToMissing`
@@ -440,10 +439,8 @@ namespace seco {
                                         const BinarySparseArrayVector& majorityLabelVector,
                                         const RuleEvaluationFactory& ruleEvaluationFactory, const WeightVector& weights)
                 : weights_(weights), ruleEvaluationFactory_(ruleEvaluationFactory), labelMatrix_(labelMatrix),
-                  majorityLabelVector_(majorityLabelVector),
-                  totalSumVector_(ConfusionMatrixVector(labelMatrix.getNumCols(), true)),
-                  subsetSumVector_(ConfusionMatrixVector(labelMatrix.getNumCols(), true)),
-                  coverageMatrix_(coverageMatrix) {
+                  majorityLabelVector_(majorityLabelVector), totalSumVector_(labelMatrix.getNumCols(), true),
+                  subsetSumVector_(labelMatrix.getNumCols(), true), coverageMatrix_(coverageMatrix) {
                 initializeLabelWiseStatisticVector(weights, labelMatrix, majorityLabelVector, coverageMatrix,
                                                    totalSumVector_);
                 initializeLabelWiseStatisticVector(weights, labelMatrix, majorityLabelVector, coverageMatrix,
@@ -456,8 +453,7 @@ namespace seco {
             LabelWiseWeightedStatistics(const LabelWiseWeightedStatistics& statistics)
                 : weights_(statistics.weights_), ruleEvaluationFactory_(statistics.ruleEvaluationFactory_),
                   labelMatrix_(statistics.labelMatrix_), majorityLabelVector_(statistics.majorityLabelVector_),
-                  totalSumVector_(ConfusionMatrixVector(statistics.totalSumVector_)),
-                  subsetSumVector_(ConfusionMatrixVector(statistics.subsetSumVector_)),
+                  totalSumVector_(statistics.totalSumVector_), subsetSumVector_(statistics.subsetSumVector_),
                   coverageMatrix_(statistics.coverageMatrix_) {}
 
             /**


### PR DESCRIPTION
Statt nicht primitive Klassenvariablen per Copy-Konstruktor zu initialisieren, wird nun "direct initialization" verwendet, d.h., statt einem Objekt der zu initialisierenden Klasse, werden die Konstruktorargumente direkt an die an die Member-Initialization-List übergeben.