### PR TITLE
Update build-time dependencies

### DIFF
--- a/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_binary_common.hpp
+++ b/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_binary_common.hpp
@@ -85,7 +85,7 @@ namespace boosting {
                     IncrementalPredictor(const BinaryPredictor& predictor, uint32 maxRules,
                                          std::shared_ptr<IBinaryTransformation> binaryTransformationPtr)
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, DensePredictionMatrix<uint8>>(
-                          predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
+                            predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
                           binaryTransformationPtr_(binaryTransformationPtr),
                           realMatrix_(predictor.featureMatrix_.numRows, predictor.numLabels_,
                                       binaryTransformationPtr_ != nullptr),
@@ -274,7 +274,7 @@ namespace boosting {
                     IncrementalPredictor(const SparseBinaryPredictor& predictor, uint32 maxRules,
                                          std::shared_ptr<IBinaryTransformation> binaryTransformationPtr)
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, BinarySparsePredictionMatrix>(
-                          predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
+                            predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
                           binaryTransformationPtr_(binaryTransformationPtr),
                           realMatrix_(predictor.featureMatrix_.numRows, predictor.numLabels_,
                                       binaryTransformationPtr_ != nullptr),

--- a/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_probability_common.hpp
+++ b/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_probability_common.hpp
@@ -85,7 +85,7 @@ namespace boosting {
                     IncrementalPredictor(const ProbabilityPredictor& predictor, uint32 maxRules,
                                          std::shared_ptr<IProbabilityTransformation> probabilityTransformationPtr)
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, DensePredictionMatrix<float64>>(
-                          predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
+                            predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
                           probabilityTransformationPtr_(probabilityTransformationPtr),
                           scoreMatrix_(predictor.featureMatrix_.numRows, predictor.numLabels_,
                                        probabilityTransformationPtr_ != nullptr),

--- a/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_score_common.hpp
+++ b/cpp/subprojects/boosting/include/mlrl/boosting/prediction/predictor_score_common.hpp
@@ -182,7 +182,7 @@ namespace boosting {
 
                     IncrementalPredictor(const ScorePredictor& predictor, uint32 maxRules)
                         : AbstractIncrementalPredictor<FeatureMatrix, Model, DensePredictionMatrix<float64>>(
-                          predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
+                            predictor.featureMatrix_, predictor.model_, predictor.numThreads_, maxRules),
                           predictionMatrix_(predictor.featureMatrix_.numRows, predictor.numLabels_, true) {}
             };
 

--- a/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_example_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_example_wise_dense.cpp
@@ -6,9 +6,9 @@ namespace boosting {
 
     DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(uint32 numGradients, bool init)
         : ClearableViewDecorator<ViewDecorator<CompositeVector<AllocatedVector<float64>, AllocatedVector<float64>>>>(
-          CompositeVector<AllocatedVector<float64>, AllocatedVector<float64>>(
-            AllocatedVector<float64>(numGradients, init),
-            AllocatedVector<float64>(triangularNumber(numGradients), init))) {}
+            CompositeVector<AllocatedVector<float64>, AllocatedVector<float64>>(
+              AllocatedVector<float64>(numGradients, init),
+              AllocatedVector<float64>(triangularNumber(numGradients), init))) {}
 
     DenseExampleWiseStatisticVector::DenseExampleWiseStatisticVector(const DenseExampleWiseStatisticVector& other)
         : DenseExampleWiseStatisticVector(other.getNumGradients()) {

--- a/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_label_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_label_wise_dense.cpp
@@ -4,7 +4,7 @@ namespace boosting {
 
     DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(uint32 numElements, bool init)
         : ClearableViewDecorator<DenseVectorDecorator<AllocatedVector<Tuple<float64>>>>(
-          AllocatedVector<Tuple<float64>>(numElements, init)) {}
+            AllocatedVector<Tuple<float64>>(numElements, init)) {}
 
     DenseLabelWiseStatisticVector::DenseLabelWiseStatisticVector(const DenseLabelWiseStatisticVector& other)
         : DenseLabelWiseStatisticVector(other.getNumElements()) {

--- a/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_label_wise_sparse.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_label_wise_sparse.cpp
@@ -57,7 +57,7 @@ namespace boosting {
 
     SparseLabelWiseStatisticVector::SparseLabelWiseStatisticVector(uint32 numElements, bool init)
         : ClearableViewDecorator<VectorDecorator<AllocatedVector<Triple<float64>>>>(
-          AllocatedVector<Triple<float64>>(numElements, init)),
+            AllocatedVector<Triple<float64>>(numElements, init)),
           sumOfWeights_(0) {}
 
     SparseLabelWiseStatisticVector::SparseLabelWiseStatisticVector(const SparseLabelWiseStatisticVector& other)

--- a/cpp/subprojects/boosting/src/mlrl/boosting/data/view_statistic_example_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/data/view_statistic_example_wise_dense.cpp
@@ -6,8 +6,8 @@ namespace boosting {
 
     DenseExampleWiseStatisticView::DenseExampleWiseStatisticView(uint32 numRows, uint32 numCols)
         : CompositeMatrix<AllocatedCContiguousView<float64>, AllocatedCContiguousView<float64>>(
-          AllocatedCContiguousView<float64>(numRows, numCols),
-          AllocatedCContiguousView<float64>(numRows, triangularNumber(numCols)), numRows, numCols) {}
+            AllocatedCContiguousView<float64>(numRows, numCols),
+            AllocatedCContiguousView<float64>(numRows, triangularNumber(numCols)), numRows, numCols) {}
 
     DenseExampleWiseStatisticView::DenseExampleWiseStatisticView(DenseExampleWiseStatisticView&& other)
         : CompositeMatrix<AllocatedCContiguousView<float64>, AllocatedCContiguousView<float64>>(std::move(other)) {}

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_binned_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_binned_common.hpp
@@ -380,8 +380,8 @@ namespace boosting {
                                                          std::unique_ptr<ILabelBinning> binningPtr, const Blas& blas,
                                                          const Lapack& lapack)
                 : AbstractExampleWiseBinnedRuleEvaluation<DenseExampleWiseStatisticVector, IndexVector>(
-                  labelIndices, true, maxBins, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr),
-                  blas, lapack) {}
+                    labelIndices, true, maxBins, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr),
+                    blas, lapack) {}
     };
 
 }

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_complete_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_complete_common.hpp
@@ -168,7 +168,7 @@ namespace boosting {
                                                    float64 l2RegularizationWeight, const Blas& blas,
                                                    const Lapack& lapack)
                 : AbstractExampleWiseRuleEvaluation<DenseExampleWiseStatisticVector, IndexVector>(
-                  labelIndices.getNumElements(), lapack),
+                    labelIndices.getNumElements(), lapack),
                   scoreVector_(labelIndices, true), l1RegularizationWeight_(l1RegularizationWeight),
                   l2RegularizationWeight_(l2RegularizationWeight), blas_(blas), lapack_(lapack) {}
 

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_dynamic.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_dynamic.cpp
@@ -60,7 +60,7 @@ namespace boosting {
                                                          float64 l2RegularizationWeight, const Blas& blas,
                                                          const Lapack& lapack)
                 : AbstractExampleWiseRuleEvaluation<DenseExampleWiseStatisticVector, IndexVector>(
-                  labelIndices.getNumElements(), lapack),
+                    labelIndices.getNumElements(), lapack),
                   labelIndices_(labelIndices), indexVector_(labelIndices.getNumElements()),
                   scoreVector_(indexVector_, true), threshold_(1.0 - threshold), exponent_(exponent),
                   l1RegularizationWeight_(l1RegularizationWeight), l2RegularizationWeight_(l2RegularizationWeight),

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_dynamic_binned.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_dynamic_binned.cpp
@@ -89,8 +89,8 @@ namespace boosting {
               float32 threshold, float32 exponent, float64 l1RegularizationWeight, float64 l2RegularizationWeight,
               std::unique_ptr<ILabelBinning> binningPtr, const Blas& blas, const Lapack& lapack)
                 : AbstractExampleWiseBinnedRuleEvaluation<DenseExampleWiseStatisticVector, PartialIndexVector>(
-                  *indexVectorPtr, true, maxBins, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr),
-                  blas, lapack),
+                    *indexVectorPtr, true, maxBins, l1RegularizationWeight, l2RegularizationWeight,
+                    std::move(binningPtr), blas, lapack),
                   labelIndices_(labelIndices), indexVectorPtr_(std::move(indexVectorPtr)), threshold_(1.0 - threshold),
                   exponent_(exponent) {}
     };

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_fixed_binned.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_example_wise_partial_fixed_binned.cpp
@@ -76,8 +76,8 @@ namespace boosting {
                                                              std::unique_ptr<ILabelBinning> binningPtr,
                                                              const Blas& blas, const Lapack& lapack)
                 : AbstractExampleWiseBinnedRuleEvaluation<DenseExampleWiseStatisticVector, PartialIndexVector>(
-                  *indexVectorPtr, false, maxBins, l1RegularizationWeight, l2RegularizationWeight,
-                  std::move(binningPtr), blas, lapack),
+                    *indexVectorPtr, false, maxBins, l1RegularizationWeight, l2RegularizationWeight,
+                    std::move(binningPtr), blas, lapack),
                   labelIndices_(labelIndices), indexVectorPtr_(std::move(indexVectorPtr)),
                   tmpVector_(labelIndices.getNumElements()) {}
     };

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_binned_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_binned_common.hpp
@@ -203,7 +203,7 @@ namespace boosting {
                                                   float64 l2RegularizationWeight,
                                                   std::unique_ptr<ILabelBinning> binningPtr)
                 : AbstractLabelWiseBinnedRuleEvaluation<StatisticVector, IndexVector>(
-                  labelIndices, true, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr)) {}
+                    labelIndices, true, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr)) {}
     };
 
 }

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_dynamic_binned.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_dynamic_binned.cpp
@@ -82,7 +82,7 @@ namespace boosting {
                                                         float64 l1RegularizationWeight, float64 l2RegularizationWeight,
                                                         std::unique_ptr<ILabelBinning> binningPtr)
                 : AbstractLabelWiseBinnedRuleEvaluation<StatisticVector, PartialIndexVector>(
-                  *indexVectorPtr, true, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr)),
+                    *indexVectorPtr, true, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr)),
                   labelIndices_(labelIndices), indexVectorPtr_(std::move(indexVectorPtr)), threshold_(1.0 - threshold),
                   exponent_(exponent) {}
     };

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_fixed_binned.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/rule_evaluation_label_wise_partial_fixed_binned.cpp
@@ -66,7 +66,7 @@ namespace boosting {
                                                       float64 l1RegularizationWeight, float64 l2RegularizationWeight,
                                                       std::unique_ptr<ILabelBinning> binningPtr)
                 : AbstractLabelWiseBinnedRuleEvaluation<StatisticVector, PartialIndexVector>(
-                  *indexVectorPtr, false, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr)),
+                    *indexVectorPtr, false, l1RegularizationWeight, l2RegularizationWeight, std::move(binningPtr)),
                   labelIndices_(labelIndices), indexVectorPtr_(std::move(indexVectorPtr)),
                   tmpVector_(labelIndices.getNumElements()) {}
     };

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_example_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_example_wise_common.hpp
@@ -372,10 +372,10 @@ namespace boosting {
                     WeightedStatisticsSubset(const ExampleWiseWeightedStatistics& statistics,
                                              const StatisticVector& totalSumVector, const IndexVector& labelIndices)
                         : AbstractExampleWiseImmutableWeightedStatistics<
-                          StatisticVector, StatisticView, RuleEvaluationFactory,
-                          WeightVector>::template AbstractWeightedStatisticsSubset<IndexVector>(statistics,
-                                                                                                totalSumVector,
-                                                                                                labelIndices) {}
+                            StatisticVector, StatisticView, RuleEvaluationFactory,
+                            WeightVector>::template AbstractWeightedStatisticsSubset<IndexVector>(statistics,
+                                                                                                  totalSumVector,
+                                                                                                  labelIndices) {}
 
                     /**
                      * @see `IWeightedStatisticsSubset::addToMissing`
@@ -427,7 +427,7 @@ namespace boosting {
             ExampleWiseWeightedStatistics(const ExampleWiseWeightedStatistics& statistics)
                 : AbstractExampleWiseImmutableWeightedStatistics<StatisticVector, StatisticView, RuleEvaluationFactory,
                                                                  WeightVector>(
-                  statistics.statisticView_, statistics.ruleEvaluationFactory_, statistics.weights_),
+                    statistics.statisticView_, statistics.ruleEvaluationFactory_, statistics.weights_),
                   totalSumVectorPtr_(std::make_unique<StatisticVector>(*statistics.totalSumVectorPtr_)) {}
 
             /**

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_common.hpp
@@ -350,10 +350,10 @@ namespace boosting {
                     WeightedStatisticsSubset(const LabelWiseWeightedStatistics& statistics,
                                              const StatisticVector& totalSumVector, const IndexVector& labelIndices)
                         : AbstractLabelWiseImmutableWeightedStatistics<
-                          StatisticVector, StatisticView, RuleEvaluationFactory,
-                          WeightVector>::template AbstractWeightedStatisticsSubset<IndexVector>(statistics,
-                                                                                                totalSumVector,
-                                                                                                labelIndices) {}
+                            StatisticVector, StatisticView, RuleEvaluationFactory,
+                            WeightVector>::template AbstractWeightedStatisticsSubset<IndexVector>(statistics,
+                                                                                                  totalSumVector,
+                                                                                                  labelIndices) {}
 
                     /**
                      * @see `IWeightedStatisticsSubset::addToMissing`
@@ -404,7 +404,7 @@ namespace boosting {
             LabelWiseWeightedStatistics(const LabelWiseWeightedStatistics& statistics)
                 : AbstractLabelWiseImmutableWeightedStatistics<StatisticVector, StatisticView, RuleEvaluationFactory,
                                                                WeightVector>(
-                  statistics.statisticView_, statistics.ruleEvaluationFactory_, statistics.weights_),
+                    statistics.statisticView_, statistics.ruleEvaluationFactory_, statistics.weights_),
                   totalSumVectorPtr_(std::make_unique<StatisticVector>(*statistics.totalSumVectorPtr_)) {}
 
             /**

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_dense.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_dense.hpp
@@ -25,7 +25,7 @@ namespace boosting {
              */
             DenseLabelWiseStatisticMatrix(uint32 numRows, uint32 numCols)
                 : ClearableViewDecorator<MatrixDecorator<AllocatedCContiguousView<Tuple<float64>>>>(
-                  AllocatedCContiguousView<Tuple<float64>>(numRows, numCols)) {}
+                    AllocatedCContiguousView<Tuple<float64>>(numRows, numCols)) {}
 
             /**
              * Adds all gradients and Hessians in a vector to a specific row of this matrix. The gradients and Hessians
@@ -80,8 +80,8 @@ namespace boosting {
                 : AbstractLabelWiseStatistics<LabelMatrix, DenseLabelWiseStatisticVector, DenseLabelWiseStatisticMatrix,
                                               NumericCContiguousMatrix<float64>, ILabelWiseLoss, IEvaluationMeasure,
                                               ILabelWiseRuleEvaluationFactory>(
-                  std::move(lossPtr), std::move(evaluationMeasurePtr), ruleEvaluationFactory, labelMatrix,
-                  std::move(statisticMatrixPtr), std::move(scoreMatrixPtr)) {}
+                    std::move(lossPtr), std::move(evaluationMeasurePtr), ruleEvaluationFactory, labelMatrix,
+                    std::move(statisticMatrixPtr), std::move(scoreMatrixPtr)) {}
 
             /**
              * @see `IBoostingStatistics::visitScoreMatrix`

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_provider_example_wise_dense.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_provider_example_wise_dense.cpp
@@ -29,7 +29,7 @@ namespace boosting {
              */
             DenseExampleWiseStatisticMatrix(uint32 numRows, uint32 numCols)
                 : ClearableViewDecorator<MatrixDecorator<DenseExampleWiseStatisticView>>(
-                  DenseExampleWiseStatisticView(numRows, numCols)) {}
+                    DenseExampleWiseStatisticView(numRows, numCols)) {}
 
             /**
              * Adds all gradients and Hessians in a vector to a specific row of this matrix. The gradients and Hessians
@@ -91,8 +91,8 @@ namespace boosting {
                                                 DenseExampleWiseStatisticMatrix, NumericCContiguousMatrix<float64>,
                                                 IExampleWiseLoss, IEvaluationMeasure, IExampleWiseRuleEvaluationFactory,
                                                 ILabelWiseRuleEvaluationFactory>(
-                  std::move(lossPtr), std::move(evaluationMeasurePtr), ruleEvaluationFactory, labelMatrix,
-                  std::move(statisticMatrixPtr), std::move(scoreMatrixPtr)) {}
+                    std::move(lossPtr), std::move(evaluationMeasurePtr), ruleEvaluationFactory, labelMatrix,
+                    std::move(statisticMatrixPtr), std::move(scoreMatrixPtr)) {}
 
             /**
              * @see `IBoostingStatistics::visitScoreMatrix`

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_provider_label_wise_sparse.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_provider_label_wise_sparse.cpp
@@ -69,8 +69,8 @@ namespace boosting {
                                               SparseLabelWiseStatisticMatrix, NumericSparseSetMatrix<float64>,
                                               ISparseLabelWiseLoss, ISparseEvaluationMeasure,
                                               ISparseLabelWiseRuleEvaluationFactory>(
-                  std::move(lossPtr), std::move(evaluationMeasurePtr), ruleEvaluationFactory, labelMatrix,
-                  std::move(statisticViewPtr), std::move(scoreMatrixPtr)) {}
+                    std::move(lossPtr), std::move(evaluationMeasurePtr), ruleEvaluationFactory, labelMatrix,
+                    std::move(statisticViewPtr), std::move(scoreMatrixPtr)) {}
 
             /**
              * @see `IBoostingStatistics::visitScoreMatrix`

--- a/cpp/subprojects/common/include/mlrl/common/data/matrix_lil.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/data/matrix_lil.hpp
@@ -29,5 +29,5 @@ class LilMatrix final : public LilMatrixDecorator<AllocatedListOfLists<IndexedVa
          */
         LilMatrix(uint32 numRows, uint32 numCols)
             : LilMatrixDecorator<AllocatedListOfLists<IndexedValue<T>>>(
-              AllocatedListOfLists<IndexedValue<T>>(numRows, numCols)) {}
+                AllocatedListOfLists<IndexedValue<T>>(numRows, numCols)) {}
 };

--- a/cpp/subprojects/common/include/mlrl/common/data/vector_dense.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/data/vector_dense.hpp
@@ -54,5 +54,5 @@ class ResizableDenseVector final : public ResizableVectorDecorator<DenseVectorDe
          */
         ResizableDenseVector(uint32 numElements, bool init = false)
             : ResizableVectorDecorator<DenseVectorDecorator<ResizableVector<T>>>(
-              ResizableVector<T>(numElements, init)) {}
+                ResizableVector<T>(numElements, init)) {}
 };

--- a/cpp/subprojects/common/include/mlrl/common/data/view_matrix_lil.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/data/view_matrix_lil.hpp
@@ -156,10 +156,8 @@ class MLRLCOMMON_API ListOfListsAllocator : public Matrix {
          * @param numCols   The number of columns in the view
          */
         ListOfListsAllocator(uint32 numRows, uint32 numCols)
-            : Matrix(
-              new std::vector<typename Matrix::value_type>[numRows] {
-        },
-              numRows, numCols) {}
+            : Matrix(new std::vector<typename Matrix::value_type>[numRows] {
+              }, numRows, numCols) {}
 
         /**
          * @param other A reference to an object of type `ListOfListsAllocator` that should be copied

--- a/cpp/subprojects/common/include/mlrl/common/data/view_matrix_sparse_set.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/data/view_matrix_sparse_set.hpp
@@ -265,8 +265,8 @@ class MLRLCOMMON_API SparseSetView
          */
         SparseSetView(uint32 numRows, uint32 numCols)
             : CompositeMatrix<AllocatedListOfLists<IndexedValue<T>>, AllocatedCContiguousView<uint32>>(
-              AllocatedListOfLists<IndexedValue<T>>(numRows, numCols),
-              AllocatedCContiguousView<uint32>(numRows, numCols), numRows, numCols) {
+                AllocatedListOfLists<IndexedValue<T>>(numRows, numCols),
+                AllocatedCContiguousView<uint32>(numRows, numCols), numRows, numCols) {
             setViewToValue(this->secondView.array, this->secondView.numRows * this->secondView.numCols, MAX_INDEX);
         }
 
@@ -275,7 +275,7 @@ class MLRLCOMMON_API SparseSetView
          */
         SparseSetView(SparseSetView&& other)
             : CompositeMatrix<AllocatedListOfLists<IndexedValue<T>>, AllocatedCContiguousView<uint32>>(
-              std::move(other)) {}
+                std::move(other)) {}
 
         virtual ~SparseSetView() override {}
 

--- a/cpp/subprojects/common/src/mlrl/common/data/vector_bit.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/data/vector_bit.cpp
@@ -18,7 +18,7 @@ static inline constexpr uint32 mask(uint32 pos) {
 
 BitVector::BitVector(uint32 numElements, bool init)
     : ClearableViewDecorator<VectorDecorator<AllocatedVector<uint32>>>(
-      AllocatedVector<uint32>(size(numElements), init)),
+        AllocatedVector<uint32>(size(numElements), init)),
       numElements_(numElements) {}
 
 bool BitVector::operator[](uint32 pos) const {

--- a/cpp/subprojects/common/src/mlrl/common/indices/index_vector_partial.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/indices/index_vector_partial.cpp
@@ -4,7 +4,7 @@
 
 PartialIndexVector::PartialIndexVector(uint32 numElements, bool init)
     : ResizableVectorDecorator<DenseVectorDecorator<ResizableVector<uint32>>>(
-      ResizableVector<uint32>(numElements, init)) {}
+        ResizableVector<uint32>(numElements, init)) {}
 
 uint32 PartialIndexVector::getNumElements() const {
     return VectorDecorator<ResizableVector<uint32>>::getNumElements();

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_matrix_csc.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_matrix_csc.cpp
@@ -30,7 +30,7 @@ class CscFeatureMatrix final : public IterableSparseMatrixDecorator<MatrixDecora
         CscFeatureMatrix(const float32* values, uint32* indices, uint32* indptr, uint32 numRows, uint32 numCols,
                          float32 sparseValue)
             : IterableSparseMatrixDecorator<MatrixDecorator<CscView<const float32>>>(
-              CscView<const float32>(values, indices, indptr, numRows, numCols, sparseValue)) {}
+                CscView<const float32>(values, indices, indptr, numRows, numCols, sparseValue)) {}
 
         bool isSparse() const override {
             return true;

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_matrix_csr.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_matrix_csr.cpp
@@ -27,7 +27,7 @@ class CsrFeatureMatrix final : public MatrixDecorator<CsrView<const float32>>,
         CsrFeatureMatrix(const float32* values, uint32* indices, uint32* indptr, uint32 numRows, uint32 numCols,
                          float32 sparseValue)
             : MatrixDecorator<CsrView<const float32>>(
-              CsrView<const float32>(values, indices, indptr, numRows, numCols, sparseValue)) {}
+                CsrView<const float32>(values, indices, indptr, numRows, numCols, sparseValue)) {}
 
         bool isSparse() const override {
             return true;

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_matrix_fortran_contiguous.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_matrix_fortran_contiguous.cpp
@@ -23,7 +23,7 @@ class FortranContiguousFeatureMatrix final : public DenseMatrixDecorator<Fortran
          */
         FortranContiguousFeatureMatrix(const float32* array, uint32 numRows, uint32 numCols)
             : DenseMatrixDecorator<FortranContiguousView<const float32>>(
-              FortranContiguousView<const float32>(array, numRows, numCols)) {}
+                FortranContiguousView<const float32>(array, numRows, numCols)) {}
 
         bool isSparse() const override {
             return false;

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator.hpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator.hpp
@@ -83,6 +83,6 @@ class AbstractFeatureVectorDecorator
          */
         AbstractFeatureVectorDecorator(FeatureVector&& firstView, AllocatedMissingFeatureVector&& secondView)
             : ViewDecorator<CompositeView<FeatureVector, AllocatedMissingFeatureVector>>(
-              CompositeView<FeatureVector, AllocatedMissingFeatureVector>(std::move(firstView),
-                                                                          std::move(secondView))) {}
+                CompositeView<FeatureVector, AllocatedMissingFeatureVector>(std::move(firstView),
+                                                                            std::move(secondView))) {}
 };

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_binned.hpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_binned.hpp
@@ -234,30 +234,30 @@ class BinnedFeatureVectorDecorator final : public AbstractBinnedFeatureVectorDec
          */
         BinnedFeatureVectorDecorator(const BinnedFeatureVectorDecorator& other)
             : BinnedFeatureVectorDecorator(
-              AllocatedBinnedFeatureVector(other.view.firstView.numBins,
-                                           other.view.firstView.indptr[other.view.firstView.numBins],
-                                           other.view.firstView.sparseBinIndex),
-              AllocatedMissingFeatureVector()) {}
+                AllocatedBinnedFeatureVector(other.view.firstView.numBins,
+                                             other.view.firstView.indptr[other.view.firstView.numBins],
+                                             other.view.firstView.sparseBinIndex),
+                AllocatedMissingFeatureVector()) {}
 
         /**
          * @param other A reference to an object of type `BinnedFeatureVectorView` that should be copied
          */
         BinnedFeatureVectorDecorator(const BinnedFeatureVectorView& other)
             : BinnedFeatureVectorDecorator(
-              AllocatedBinnedFeatureVector(other.getView().firstView.numBins,
-                                           other.getView().firstView.indptr[other.getView().firstView.numBins],
-                                           other.getView().firstView.sparseBinIndex),
-              AllocatedMissingFeatureVector()) {}
+                AllocatedBinnedFeatureVector(other.getView().firstView.numBins,
+                                             other.getView().firstView.indptr[other.getView().firstView.numBins],
+                                             other.getView().firstView.sparseBinIndex),
+                AllocatedMissingFeatureVector()) {}
 
         /**
          * @param other A reference to an object of type `AllocatedBinnedFeatureVectorView` that should be copied
          */
         BinnedFeatureVectorDecorator(const AllocatedBinnedFeatureVectorView& other)
             : BinnedFeatureVectorDecorator(
-              AllocatedBinnedFeatureVector(other.getView().firstView.numBins,
-                                           other.getView().firstView.indptr[other.getView().firstView.numBins],
-                                           other.getView().firstView.sparseBinIndex),
-              AllocatedMissingFeatureVector()) {}
+                AllocatedBinnedFeatureVector(other.getView().firstView.numBins,
+                                             other.getView().firstView.indptr[other.getView().firstView.numBins],
+                                             other.getView().firstView.sparseBinIndex),
+                AllocatedMissingFeatureVector()) {}
 
         void searchForRefinement(FeatureBasedSearch& featureBasedSearch, IWeightedStatisticsSubset& statisticsSubset,
                                  SingleRefinementComparator& comparator, uint32 numExamplesWithNonZeroWeights,

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_binned_common.hpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_binned_common.hpp
@@ -74,10 +74,10 @@ class AbstractBinnedFeatureVectorDecorator : public AbstractFeatureVectorDecorat
          */
         AbstractBinnedFeatureVectorDecorator(const AbstractBinnedFeatureVectorDecorator& other)
             : AbstractBinnedFeatureVectorDecorator<AllocatedFeatureVector>(
-              AllocatedFeatureVector(other.view.firstView.numValues,
-                                     other.view.firstView.indptr[other.view.firstView.numValues],
-                                     other.view.firstView.majorityValue),
-              AllocatedMissingFeatureVector()) {}
+                AllocatedFeatureVector(other.view.firstView.numValues,
+                                       other.view.firstView.indptr[other.view.firstView.numValues],
+                                       other.view.firstView.majorityValue),
+                AllocatedMissingFeatureVector()) {}
 
         virtual ~AbstractBinnedFeatureVectorDecorator() override {}
 

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_numerical.hpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_numerical.hpp
@@ -230,27 +230,27 @@ class NumericalFeatureVectorDecorator final
          */
         NumericalFeatureVectorDecorator(const NumericalFeatureVectorDecorator& other)
             : NumericalFeatureVectorDecorator(
-              AllocatedNumericalFeatureVector(other.view.firstView.numElements, other.view.firstView.sparseValue,
-                                              other.view.firstView.sparse),
-              AllocatedMissingFeatureVector()) {}
+                AllocatedNumericalFeatureVector(other.view.firstView.numElements, other.view.firstView.sparseValue,
+                                                other.view.firstView.sparse),
+                AllocatedMissingFeatureVector()) {}
 
         /**
          * @param other A reference to an object of type `NumericalFeatureVectorView` that should be copied
          */
         NumericalFeatureVectorDecorator(const NumericalFeatureVectorView& other)
-            : NumericalFeatureVectorDecorator(
-              AllocatedNumericalFeatureVector(other.getView().firstView.numElements,
-                                              other.getView().firstView.sparseValue, other.getView().firstView.sparse),
-              AllocatedMissingFeatureVector()) {}
+            : NumericalFeatureVectorDecorator(AllocatedNumericalFeatureVector(other.getView().firstView.numElements,
+                                                                              other.getView().firstView.sparseValue,
+                                                                              other.getView().firstView.sparse),
+                                              AllocatedMissingFeatureVector()) {}
 
         /**
          * @param other A reference to an object of type `AllocatedNumericalFeatureVectorView` that should be copied
          */
         NumericalFeatureVectorDecorator(const AllocatedNumericalFeatureVectorView& other)
-            : NumericalFeatureVectorDecorator(
-              AllocatedNumericalFeatureVector(other.getView().firstView.numElements,
-                                              other.getView().firstView.sparseValue, other.getView().firstView.sparse),
-              AllocatedMissingFeatureVector()) {}
+            : NumericalFeatureVectorDecorator(AllocatedNumericalFeatureVector(other.getView().firstView.numElements,
+                                                                              other.getView().firstView.sparseValue,
+                                                                              other.getView().firstView.sparse),
+                                              AllocatedMissingFeatureVector()) {}
 
         std::unique_ptr<IFeatureVector> createFilteredFeatureVector(std::unique_ptr<IFeatureVector>& existing,
                                                                     const Interval& interval) const override {

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_ordinal.hpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_vector_decorator_ordinal.hpp
@@ -185,20 +185,20 @@ class OrdinalFeatureVectorDecorator final : public AbstractBinnedFeatureVectorDe
          */
         OrdinalFeatureVectorDecorator(const OrdinalFeatureVectorView& other)
             : OrdinalFeatureVectorDecorator(
-              AllocatedNominalFeatureVector(other.getView().firstView.numValues,
-                                            other.getView().firstView.indptr[other.getView().firstView.numValues],
-                                            other.getView().firstView.majorityValue),
-              AllocatedMissingFeatureVector()) {}
+                AllocatedNominalFeatureVector(other.getView().firstView.numValues,
+                                              other.getView().firstView.indptr[other.getView().firstView.numValues],
+                                              other.getView().firstView.majorityValue),
+                AllocatedMissingFeatureVector()) {}
 
         /**
          * @param other A reference to an object of type `AllocatedOrdinalFeatureVectorView` that should be copied
          */
         OrdinalFeatureVectorDecorator(const AllocatedOrdinalFeatureVectorView& other)
             : OrdinalFeatureVectorDecorator(
-              AllocatedNominalFeatureVector(other.getView().firstView.numValues,
-                                            other.getView().firstView.indptr[other.getView().firstView.numValues],
-                                            other.getView().firstView.majorityValue),
-              AllocatedMissingFeatureVector()) {}
+                AllocatedNominalFeatureVector(other.getView().firstView.numValues,
+                                              other.getView().firstView.indptr[other.getView().firstView.numValues],
+                                              other.getView().firstView.majorityValue),
+                AllocatedMissingFeatureVector()) {}
 
         void searchForRefinement(FeatureBasedSearch& featureBasedSearch, IWeightedStatisticsSubset& statisticsSubset,
                                  SingleRefinementComparator& comparator, uint32 numExamplesWithNonZeroWeights,

--- a/cpp/subprojects/common/src/mlrl/common/input/label_matrix_c_contiguous.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/label_matrix_c_contiguous.cpp
@@ -23,7 +23,7 @@ class CContiguousLabelMatrix final : public DenseMatrixDecorator<CContiguousView
          */
         CContiguousLabelMatrix(const uint8* array, uint32 numRows, uint32 numCols)
             : DenseMatrixDecorator<CContiguousView<const uint8>>(
-              CContiguousView<const uint8>(array, numRows, numCols)) {}
+                CContiguousView<const uint8>(array, numRows, numCols)) {}
 
         bool isSparse() const override {
             return false;

--- a/cpp/subprojects/common/src/mlrl/common/input/label_matrix_csr.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/label_matrix_csr.cpp
@@ -26,7 +26,7 @@ class CsrLabelMatrix final : public IterableBinarySparseMatrixDecorator<MatrixDe
          */
         CsrLabelMatrix(uint32* indices, uint32* indptr, uint32 numRows, uint32 numCols)
             : IterableBinarySparseMatrixDecorator<MatrixDecorator<BinaryCsrView>>(
-              BinaryCsrView(indices, indptr, numRows, numCols)) {}
+                BinaryCsrView(indices, indptr, numRows, numCols)) {}
 
         bool isSparse() const override {
             return true;

--- a/cpp/subprojects/common/src/mlrl/common/model/body_conjunctive.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/model/body_conjunctive.cpp
@@ -3,8 +3,8 @@
 template<typename Threshold, typename Compare>
 ConjunctiveBody::ConditionVector<Threshold, Compare>::ConditionVector(uint32 numConditions)
     : IterableIndexedVectorDecorator<IndexedVectorDecorator<AllocatedVector<uint32>, AllocatedVector<Threshold>>>(
-      CompositeVector<AllocatedVector<uint32>, AllocatedVector<Threshold>>(
-        AllocatedVector<uint32>(numConditions), AllocatedVector<Threshold>(numConditions))) {}
+        CompositeVector<AllocatedVector<uint32>, AllocatedVector<Threshold>>(
+          AllocatedVector<uint32>(numConditions), AllocatedVector<Threshold>(numConditions))) {}
 
 template<typename Threshold, typename Compare>
 bool ConjunctiveBody::ConditionVector<Threshold, Compare>::covers(View<const float32>::const_iterator begin,

--- a/cpp/subprojects/common/src/mlrl/common/model/head_partial.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/model/head_partial.cpp
@@ -2,8 +2,8 @@
 
 PartialHead::PartialHead(uint32 numElements)
     : IterableIndexedVectorDecorator<IndexedVectorDecorator<AllocatedVector<uint32>, AllocatedVector<float64>>>(
-      CompositeVector<AllocatedVector<uint32>, AllocatedVector<float64>>(AllocatedVector<uint32>(numElements),
-                                                                         AllocatedVector<float64>(numElements))) {}
+        CompositeVector<AllocatedVector<uint32>, AllocatedVector<float64>>(AllocatedVector<uint32>(numElements),
+                                                                           AllocatedVector<float64>(numElements))) {}
 
 void PartialHead::visit(CompleteHeadVisitor completeHeadVisitor, PartialHeadVisitor partialHeadVisitor) const {
     partialHeadVisitor(*this);

--- a/cpp/subprojects/common/src/mlrl/common/prediction/prediction_matrix_sparse_binary.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/prediction/prediction_matrix_sparse_binary.cpp
@@ -21,7 +21,7 @@ BinarySparsePredictionView::BinarySparsePredictionView(BinarySparsePredictionVie
 BinarySparsePredictionMatrix::BinarySparsePredictionMatrix(const BinaryLilMatrix& lilMatrix, uint32 numCols,
                                                            uint32 numNonZeroElements)
     : IterableBinarySparseMatrixDecorator<MatrixDecorator<BinarySparsePredictionView>>(
-      BinarySparsePredictionView(lilMatrix, numCols, numNonZeroElements)) {}
+        BinarySparsePredictionView(lilMatrix, numCols, numNonZeroElements)) {}
 
 uint32* BinarySparsePredictionMatrix::getIndices() {
     return this->view.indices;

--- a/cpp/subprojects/common/src/mlrl/common/prediction/probability_calibration_isotonic.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/prediction/probability_calibration_isotonic.cpp
@@ -132,7 +132,7 @@ static inline float64 calibrateProbability(ListOfLists<Tuple<float64>>::const_ro
 
 IsotonicProbabilityCalibrationModel::IsotonicProbabilityCalibrationModel(uint32 numLists)
     : IterableListOfListsDecorator<ViewDecorator<AllocatedListOfLists<Tuple<float64>>>>(
-      AllocatedListOfLists<Tuple<float64>>(numLists, 0)) {}
+        AllocatedListOfLists<Tuple<float64>>(numLists, 0)) {}
 
 void IsotonicProbabilityCalibrationModel::fit() {
     uint32 numLists = this->getNumBinLists();

--- a/cpp/subprojects/common/src/mlrl/common/rule_evaluation/score_vector_binned_dense.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_evaluation/score_vector_binned_dense.cpp
@@ -9,8 +9,8 @@ template<typename IndexVector>
 DenseBinnedScoreVector<IndexVector>::DenseBinnedScoreVector(const IndexVector& labelIndices, uint32 numBins,
                                                             bool sorted)
     : BinnedVectorDecorator<ViewDecorator<CompositeVector<AllocatedVector<uint32>, ResizableVector<float64>>>>(
-      CompositeVector<AllocatedVector<uint32>, ResizableVector<float64>>(
-        AllocatedVector<uint32>(labelIndices.getNumElements()), ResizableVector<float64>(numBins))),
+        CompositeVector<AllocatedVector<uint32>, ResizableVector<float64>>(
+          AllocatedVector<uint32>(labelIndices.getNumElements()), ResizableVector<float64>(numBins))),
       labelIndices_(labelIndices), sorted_(sorted), maxCapacity_(numBins) {}
 
 template<typename IndexVector>

--- a/cpp/subprojects/common/src/mlrl/common/sampling/stratified_sampling_label_wise.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/stratified_sampling_label_wise.cpp
@@ -370,7 +370,7 @@ LabelWiseStratification<LabelMatrix, IndexIterator>::LabelWiseStratification(con
                                                                              IndexIterator indicesBegin,
                                                                              IndexIterator indicesEnd)
     : stratificationMatrix_(StratificationMatrix<LabelMatrix, IndexIterator>(
-      labelMatrix, CscLabelMatrix(labelMatrix, indicesBegin, indicesEnd), indicesBegin, indicesEnd)) {}
+        labelMatrix, CscLabelMatrix(labelMatrix, indicesBegin, indicesEnd), indicesBegin, indicesEnd)) {}
 
 template<typename LabelMatrix, typename IndexIterator>
 void LabelWiseStratification<LabelMatrix, IndexIterator>::sampleWeights(BitWeightVector& weightVector,

--- a/cpp/subprojects/seco/src/mlrl/seco/data/matrix_coverage_dense.cpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/data/matrix_coverage_dense.cpp
@@ -6,7 +6,7 @@ namespace seco {
 
     DenseCoverageMatrix::DenseCoverageMatrix(uint32 numRows, uint32 numCols, float64 sumOfUncoveredWeights)
         : DenseMatrixDecorator<AllocatedCContiguousView<uint32>>(
-          AllocatedCContiguousView<uint32>(numRows, numCols, true)),
+            AllocatedCContiguousView<uint32>(numRows, numCols, true)),
           sumOfUncoveredWeights_(sumOfUncoveredWeights) {}
 
     float64 DenseCoverageMatrix::getSumOfUncoveredWeights() const {

--- a/cpp/subprojects/seco/src/mlrl/seco/data/vector_confusion_matrix_dense.cpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/data/vector_confusion_matrix_dense.cpp
@@ -32,7 +32,7 @@ namespace seco {
 
     DenseConfusionMatrixVector::DenseConfusionMatrixVector(uint32 numElements, bool init)
         : ClearableViewDecorator<DenseVectorDecorator<AllocatedVector<ConfusionMatrix>>>(
-          AllocatedVector<ConfusionMatrix>(numElements, init)) {}
+            AllocatedVector<ConfusionMatrix>(numElements, init)) {}
 
     DenseConfusionMatrixVector::DenseConfusionMatrixVector(const DenseConfusionMatrixVector& other)
         : DenseConfusionMatrixVector(other.getNumElements()) {

--- a/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_label_wise_common.hpp
@@ -241,8 +241,8 @@ namespace seco {
                                       const IndexVector& labelIndices)
                 : AbstractLabelWiseStatisticsSubset<LabelMatrix, CoverageMatrix, ConfusionMatrixVector,
                                                     RuleEvaluationFactory, WeightVector, IndexVector>(
-                  labelMatrix, coverageMatrix, majorityLabelVector, *totalSumVectorPtr, ruleEvaluationFactory, weights,
-                  labelIndices),
+                    labelMatrix, coverageMatrix, majorityLabelVector, *totalSumVectorPtr, ruleEvaluationFactory,
+                    weights, labelIndices),
                   totalSumVectorPtr_(std::move(totalSumVectorPtr)) {
                 initializeLabelWiseStatisticVector(weights, labelMatrix, majorityLabelVector, coverageMatrix,
                                                    *totalSumVectorPtr_);
@@ -342,9 +342,9 @@ namespace seco {
                                              const IndexVector& labelIndices)
                         : AbstractLabelWiseStatisticsSubset<LabelMatrix, CoverageMatrix, ConfusionMatrixVector,
                                                             RuleEvaluationFactory, WeightVector, IndexVector>(
-                          statistics.labelMatrix_, statistics.coverageMatrix_, statistics.majorityLabelVector_,
-                          statistics.totalSumVector_, statistics.ruleEvaluationFactory_, statistics.weights_,
-                          labelIndices),
+                            statistics.labelMatrix_, statistics.coverageMatrix_, statistics.majorityLabelVector_,
+                            statistics.totalSumVector_, statistics.ruleEvaluationFactory_, statistics.weights_,
+                            labelIndices),
                           subsetSumVector_(&statistics.subsetSumVector_), tmpVector_(labelIndices.getNumElements()) {}
 
                     /**

--- a/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_provider_label_wise_dense.cpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_provider_label_wise_dense.cpp
@@ -38,8 +38,8 @@ namespace seco {
                                      const ILabelWiseRuleEvaluationFactory& ruleEvaluationFactory)
                 : AbstractLabelWiseStatistics<LabelMatrix, DenseCoverageMatrix, DenseConfusionMatrixVector,
                                               ILabelWiseRuleEvaluationFactory>(
-                  labelMatrix, std::move(coverageMatrixPtr), std::move(majorityLabelVectorPtr), ruleEvaluationFactory) {
-            }
+                    labelMatrix, std::move(coverageMatrixPtr), std::move(majorityLabelVectorPtr),
+                    ruleEvaluationFactory) {}
     };
 
     static inline std::unique_ptr<ILabelWiseStatistics<ILabelWiseRuleEvaluationFactory>> createStatistics(

--- a/scons/requirements.txt
+++ b/scons/requirements.txt
@@ -1,5 +1,5 @@
 build >= 1.1, < 1.2
-clang-format >= 17.0, < 17.1
+clang-format >= 18.1, < 18.2
 cython >= 3.0, < 3.1
 isort >= 5.13, < 5.14
 mdformat >= 0.7, < 0.8


### PR DESCRIPTION
Updates the following build-time dependencies to the most recent versions:

* build
* pylint
* scons
* wheel
* clang-format

Updating "clang-format" results in minor changes in the C++ code style regarding super constructor calls, which are also included in this pull request.