### PR TITLE
Safe floating point comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release comes with several API changes. For an updated overview of the avai
 - **The implementation of feature binning has been reworked** in a way that avoids redundant code and results in a reduction of training times due to the use of the data structures mentioned above.
 - **The value to be used for sparse elements of a feature matrix** can now be specified via the C++ or Python API.
 - **Nominal and ordinal feature values are now represented as integers** to avoid issues due to limited floating point precision.
+- **Safe comparisons of floating point values** are now used to avoid issues due to limited floating point precision.
 
 ### Additions to the Command Line API
 

--- a/cpp/subprojects/boosting/include/mlrl/boosting/util/math.hpp
+++ b/cpp/subprojects/boosting/include/mlrl/boosting/util/math.hpp
@@ -124,12 +124,12 @@ namespace boosting {
      * @return  The value that has been calculated
      */
     static inline constexpr float64 logisticFunction(float64 x) {
-        if (x >= 0) {
-            float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
-            return 1 / (1 + exponential);
-        } else {
+        if (x < 0) {
             float64 exponential = std::exp(x);  // Evaluates to 0 for large x, resulting in 0 ultimately
             return exponential / (1 + exponential);
+        } else {
+            float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
+            return 1 / (1 + exponential);
         }
     }
 

--- a/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_label_wise_sparse.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/data/vector_statistic_label_wise_sparse.cpp
@@ -85,7 +85,7 @@ namespace boosting {
     }
 
     void SparseLabelWiseStatisticVector::add(const SparseSetView<Tuple<float64>>& view, uint32 row, float64 weight) {
-        if (weight != 0) {
+        if (weight > 0) {
             sumOfWeights_ += weight;
             addToSparseLabelWiseStatisticVector(this->view.begin(), view.values_cbegin(row), view.values_cend(row),
                                                 weight);
@@ -98,7 +98,7 @@ namespace boosting {
     }
 
     void SparseLabelWiseStatisticVector::remove(const SparseSetView<Tuple<float64>>& view, uint32 row, float64 weight) {
-        if (weight != 0) {
+        if (weight > 0) {
             sumOfWeights_ -= weight;
             removeFromSparseLabelWiseStatisticVector(this->view.begin(), view.values_cbegin(row), view.values_cend(row),
                                                      weight);
@@ -134,7 +134,7 @@ namespace boosting {
 
     void SparseLabelWiseStatisticVector::addToSubset(const SparseSetView<Tuple<float64>>& view, uint32 row,
                                                      const CompleteIndexVector& indices, float64 weight) {
-        if (weight != 0) {
+        if (weight > 0) {
             sumOfWeights_ += weight;
             addToSparseLabelWiseStatisticVector(this->view.begin(), view.values_cbegin(row), view.values_cend(row),
                                                 weight);
@@ -143,7 +143,7 @@ namespace boosting {
 
     void SparseLabelWiseStatisticVector::addToSubset(const SparseSetView<Tuple<float64>>& view, uint32 row,
                                                      const PartialIndexVector& indices, float64 weight) {
-        if (weight != 0) {
+        if (weight > 0) {
             sumOfWeights_ += weight;
             SparseSetView<Tuple<float64>>::const_row viewRow = view[row];
             PartialIndexVector::const_iterator indexIterator = indices.cbegin();

--- a/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_example_wise_squared_hinge.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_example_wise_squared_hinge.cpp
@@ -154,7 +154,7 @@ namespace boosting {
             for (uint32 j = 0; j < i; j++) {
                 float64 hessianTriangle;
 
-                if (!isEqual(gradient, 0.0)) {
+                if (!isEqualToZero(gradient)) {
                     bool trueLabel2 = *labelIterator4;
                     float64 predictedScore2 = scoreIterator[j];
                     float64 numerator;

--- a/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_example_wise_squared_hinge.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_example_wise_squared_hinge.cpp
@@ -154,7 +154,7 @@ namespace boosting {
             for (uint32 j = 0; j < i; j++) {
                 float64 hessianTriangle;
 
-                if (gradient != 0) {
+                if (!isEqual(gradient, 0.0)) {
                     bool trueLabel2 = *labelIterator4;
                     float64 predictedScore2 = scoreIterator[j];
                     float64 numerator;

--- a/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_label_wise_logistic.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_label_wise_logistic.cpp
@@ -19,12 +19,12 @@ namespace boosting {
      * @return  The value that has been calculated
      */
     static inline constexpr float64 squaredLogisticFunction(float64 x) {
-        if (x >= 0) {
-            float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
-            return 1 / ((exponential + 1) * (exponential + 1));
-        } else {
+        if (x < 0) {
             float64 exponential = std::exp(x);  // Evaluates to 0 for large x, resulting in 0 ultimately
             return (exponential * exponential) / ((exponential + 1) * (exponential + 1));
+        } else {
+            float64 exponential = std::exp(-x);  // Evaluates to 0 for large x, resulting in 1 ultimately
+            return 1 / ((exponential + 1) * (exponential + 1));
         }
     }
 

--- a/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_label_wise_sparse_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_label_wise_sparse_common.hpp
@@ -52,7 +52,7 @@ namespace boosting {
                                                    LabelWiseLoss::UpdateFunction updateFunction) {
         uint32 index = fetchNextStatistic(indexIterator, indicesEnd, scoreIterator, scoresEnd, tuple, updateFunction);
 
-        while (tuple.first == 0 && index < LIMIT) {
+        while (index < LIMIT && isEqual(tuple.first, 0.0)) {
             index = fetchNextStatistic(indexIterator, indicesEnd, scoreIterator, scoresEnd, tuple, updateFunction);
         }
 
@@ -111,7 +111,7 @@ namespace boosting {
         uint32 index =
           fetchNextEvaluation(indexIterator, indicesEnd, scoreIterator, scoresEnd, score, evaluateFunction);
 
-        while (score == 0 && index < LIMIT) {
+        while (index < LIMIT && isEqual(score, 0.0)) {
             index = fetchNextEvaluation(indexIterator, indicesEnd, scoreIterator, scoresEnd, score, evaluateFunction);
         }
 
@@ -189,7 +189,7 @@ namespace boosting {
                     bool trueLabel = labelIterator[index];
                     (*LabelWiseLoss::updateFunction_)(trueLabel, predictedScore, tuple.first, tuple.second);
 
-                    if (tuple.first != 0) {
+                    if (!isEqual(tuple.first, 0.0)) {
                         IndexedValue<Tuple<float64>>& statisticViewEntry = statisticViewRow.emplace(index);
                         statisticViewEntry.value = tuple;
                     } else {
@@ -229,7 +229,7 @@ namespace boosting {
                     float64 predictedScore = scoreMatrixEntry ? scoreMatrixEntry->value : 0;
                     (*LabelWiseLoss::updateFunction_)(trueLabel, predictedScore, tuple.first, tuple.second);
 
-                    if (tuple.first != 0) {
+                    if (!isEqual(tuple.first, 0.0)) {
                         IndexedValue<Tuple<float64>>& statisticViewEntry = statisticViewRow.emplace(index);
                         statisticViewEntry.value = tuple;
                     } else {

--- a/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_label_wise_sparse_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/losses/loss_label_wise_sparse_common.hpp
@@ -52,7 +52,7 @@ namespace boosting {
                                                    LabelWiseLoss::UpdateFunction updateFunction) {
         uint32 index = fetchNextStatistic(indexIterator, indicesEnd, scoreIterator, scoresEnd, tuple, updateFunction);
 
-        while (index < LIMIT && isEqual(tuple.first, 0.0)) {
+        while (index < LIMIT && isEqualToZero(tuple.first)) {
             index = fetchNextStatistic(indexIterator, indicesEnd, scoreIterator, scoresEnd, tuple, updateFunction);
         }
 
@@ -111,7 +111,7 @@ namespace boosting {
         uint32 index =
           fetchNextEvaluation(indexIterator, indicesEnd, scoreIterator, scoresEnd, score, evaluateFunction);
 
-        while (index < LIMIT && isEqual(score, 0.0)) {
+        while (index < LIMIT && isEqualToZero(score)) {
             index = fetchNextEvaluation(indexIterator, indicesEnd, scoreIterator, scoresEnd, score, evaluateFunction);
         }
 
@@ -189,7 +189,7 @@ namespace boosting {
                     bool trueLabel = labelIterator[index];
                     (*LabelWiseLoss::updateFunction_)(trueLabel, predictedScore, tuple.first, tuple.second);
 
-                    if (!isEqual(tuple.first, 0.0)) {
+                    if (!isEqualToZero(tuple.first)) {
                         IndexedValue<Tuple<float64>>& statisticViewEntry = statisticViewRow.emplace(index);
                         statisticViewEntry.value = tuple;
                     } else {
@@ -229,7 +229,7 @@ namespace boosting {
                     float64 predictedScore = scoreMatrixEntry ? scoreMatrixEntry->value : 0;
                     (*LabelWiseLoss::updateFunction_)(trueLabel, predictedScore, tuple.first, tuple.second);
 
-                    if (!isEqual(tuple.first, 0.0)) {
+                    if (!isEqualToZero(tuple.first)) {
                         IndexedValue<Tuple<float64>>& statisticViewEntry = statisticViewRow.emplace(index);
                         statisticViewEntry.value = tuple;
                     } else {

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/head_type_partial_fixed.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/head_type_partial_fixed.cpp
@@ -26,7 +26,7 @@ namespace boosting {
     }
 
     IFixedPartialHeadConfig& FixedPartialHeadConfig::setLabelRatio(float32 labelRatio) {
-        if (!isEqual(labelRatio, 0.0f)) {
+        if (!isEqualToZero(labelRatio)) {
             assertGreater<float32>("labelRatio", labelRatio, 0);
             assertLess<float32>("labelRatio", labelRatio, 1);
         }

--- a/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/head_type_partial_fixed.cpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/rule_evaluation/head_type_partial_fixed.cpp
@@ -26,10 +26,11 @@ namespace boosting {
     }
 
     IFixedPartialHeadConfig& FixedPartialHeadConfig::setLabelRatio(float32 labelRatio) {
-        if (labelRatio != 0) {
+        if (!isEqual(labelRatio, 0.0f)) {
             assertGreater<float32>("labelRatio", labelRatio, 0);
             assertLess<float32>("labelRatio", labelRatio, 1);
         }
+
         labelRatio_ = labelRatio;
         return *this;
     }

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_example_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_example_wise_common.hpp
@@ -13,7 +13,7 @@ namespace boosting {
 
     template<typename WeightVector>
     static inline bool hasNonZeroWeightExampleWise(const WeightVector& weights, uint32 statisticIndex) {
-        return weights[statisticIndex] != 0;
+        return !isEqualToZero(weights[statisticIndex]);
     }
 
     template<typename StatisticView, typename StatisticVector, typename IndexVector>

--- a/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/boosting/src/mlrl/boosting/statistics/statistics_label_wise_common.hpp
@@ -13,7 +13,7 @@ namespace boosting {
 
     template<typename WeightVector>
     static inline bool hasNonZeroWeightLabelWise(const WeightVector& weights, uint32 statisticIndex) {
-        return weights[statisticIndex] != 0;
+        return !isEqualToZero(weights[statisticIndex]);
     }
 
     template<typename StatisticView, typename StatisticVector, typename IndexVector>

--- a/cpp/subprojects/common/include/mlrl/common/data/types.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/data/types.hpp
@@ -14,14 +14,40 @@ typedef float float32;
 typedef double float64;
 
 /**
- * Returns whether two floating point values `a` and `b` are (approximately) equal.
+ * Returns whether two values `a` and `b` are equal or not.
  *
- * @tparam T    The type of the floating point values to be compared
- * @param a     The first floating point value
- * @param b     The second floating point value
- * @return      True if the given floating point values are equal, false otherwise
+ * @tparam T    The type of the values to be compared
+ * @param a     The first value
+ * @param b     The second value
+ * @return      True if the given values are equal, false otherwise
  */
 template<typename T>
-static inline constexpr bool isEqual(T a, T b) {
-    return std::fabs(a - b) <= std::numeric_limits<T>::epsilon() * std::fmax(1, std::fmax(std::fabs(a), std::fabs(b)));
+inline constexpr bool isEqual(T a, T b) {
+    return a == b;
+}
+
+/**
+ * Returns whether two values `a` and `b` of type `float32` are (approximately) equal or not.
+ *
+ * @param a The first value
+ * @param b The second value
+ * @return  True if the given values are equal, false otherwise
+ */
+template<>
+inline constexpr bool isEqual(float32 a, float32 b) {
+    return std::fabs(a - b)
+           <= std::numeric_limits<float32>::epsilon() * std::fmax(1, std::fmax(std::fabs(a), std::fabs(b)));
+}
+
+/**
+ * Returns whether two values `a` and `b` of type `float64` are (approximately) equal or not.
+ *
+ * @param a The first value
+ * @param b The second value
+ * @return  True if the given values are equal, false otherwise
+ */
+template<>
+inline constexpr bool isEqual(float64 a, float64 b) {
+    return std::fabs(a - b)
+           <= std::numeric_limits<float64>::epsilon() * std::fmax(1, std::fmax(std::fabs(a), std::fabs(b)));
 }

--- a/cpp/subprojects/common/include/mlrl/common/data/types.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/data/types.hpp
@@ -51,3 +51,14 @@ inline constexpr bool isEqual(float64 a, float64 b) {
     return std::fabs(a - b)
            <= std::numeric_limits<float64>::epsilon() * std::fmax(1, std::fmax(std::fabs(a), std::fabs(b)));
 }
+
+/**
+ * Returns whether a specific value is equal to zero or not.
+ *
+ * @param a The value
+ * @return  True, if the given value is equal to zero, false otherwise
+ */
+template<typename T>
+inline constexpr bool isEqualToZero(T a) {
+    return isEqual(a, (T) 0);
+}

--- a/cpp/subprojects/common/include/mlrl/common/data/types.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/data/types.hpp
@@ -22,7 +22,7 @@ typedef double float64;
  * @return      True if the given values are equal, false otherwise
  */
 template<typename T>
-inline constexpr bool isEqual(T a, T b) {
+inline bool isEqual(T a, T b) {
     return a == b;
 }
 
@@ -34,7 +34,7 @@ inline constexpr bool isEqual(T a, T b) {
  * @return  True if the given values are equal, false otherwise
  */
 template<>
-inline constexpr bool isEqual(float32 a, float32 b) {
+inline bool isEqual(float32 a, float32 b) {
     return std::fabs(a - b)
            <= std::numeric_limits<float32>::epsilon() * std::fmax(1, std::fmax(std::fabs(a), std::fabs(b)));
 }
@@ -47,7 +47,7 @@ inline constexpr bool isEqual(float32 a, float32 b) {
  * @return  True if the given values are equal, false otherwise
  */
 template<>
-inline constexpr bool isEqual(float64 a, float64 b) {
+inline bool isEqual(float64 a, float64 b) {
     return std::fabs(a - b)
            <= std::numeric_limits<float64>::epsilon() * std::fmax(1, std::fmax(std::fabs(a), std::fabs(b)));
 }
@@ -59,6 +59,6 @@ inline constexpr bool isEqual(float64 a, float64 b) {
  * @return  True, if the given value is equal to zero, false otherwise
  */
 template<typename T>
-inline constexpr bool isEqualToZero(T a) {
+inline bool isEqualToZero(T a) {
     return isEqual(a, (T) 0);
 }

--- a/cpp/subprojects/common/include/mlrl/common/iterator/non_zero_index_forward_iterator.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/iterator/non_zero_index_forward_iterator.hpp
@@ -34,7 +34,7 @@ class NonZeroIndexForwardIterator {
             for (; iterator_ != end_; iterator_++) {
                 auto value = *iterator_;
 
-                if (value != 0) {
+                if (!isEqualToZero(value)) {
                     break;
                 }
 
@@ -88,7 +88,7 @@ class NonZeroIndexForwardIterator {
             for (; iterator_ != end_; iterator_++) {
                 auto value = *iterator_;
 
-                if (value != 0) {
+                if (!isEqualToZero(value)) {
                     break;
                 }
 
@@ -110,7 +110,7 @@ class NonZeroIndexForwardIterator {
             for (; iterator_ != end_; iterator_++) {
                 auto value = *iterator_;
 
-                if (value != 0) {
+                if (!isEqualToZero(value)) {
                     break;
                 }
 

--- a/cpp/subprojects/common/include/mlrl/common/model/body_conjunctive.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/model/body_conjunctive.hpp
@@ -64,7 +64,7 @@ class MLRLCOMMON_API ConjunctiveBody final : public IBody {
                  * @return              True, if the feature value satisfies the threshold, false otherwise
                  */
                 inline bool operator()(const float32& featureValue, const float32& threshold) const {
-                    return featureValue <= threshold;
+                    return !(featureValue > threshold);
                 }
         };
 

--- a/cpp/subprojects/common/include/mlrl/common/util/validation.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/util/validation.hpp
@@ -80,7 +80,7 @@ static inline constexpr void assertLessOrEqual(const std::string& name, const T 
  */
 template<typename T>
 static inline constexpr void assertMultiple(const std::string& name, const T value, const T other) {
-    if (value % other != 0) {
+    if (!isEqualToZero(value % other)) {
         throw std::invalid_argument("Invalid value given for parameter \"" + name + "\": Must be a multiple of "
                                     + std::to_string(other) + ", but is " + std::to_string(value));
     }

--- a/cpp/subprojects/common/include/mlrl/common/util/validation.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/util/validation.hpp
@@ -16,7 +16,7 @@
  */
 template<typename T>
 static inline constexpr void assertGreater(const std::string& name, const T value, const T threshold) {
-    if (value <= threshold) {
+    if (!(value > threshold)) {
         throw std::invalid_argument("Invalid value given for parameter \"" + name + "\": Must be greater than "
                                     + std::to_string(threshold) + ", but is " + std::to_string(value));
     }
@@ -48,7 +48,7 @@ static inline constexpr void assertGreaterOrEqual(const std::string& name, const
  */
 template<typename T>
 static inline constexpr void assertLess(const std::string& name, const T value, const T threshold) {
-    if (value >= threshold) {
+    if (!(value < threshold)) {
         throw std::invalid_argument("Invalid value given for parameter \"" + name + "\": Must be less than "
                                     + std::to_string(threshold) + ", but is " + std::to_string(value));
     }

--- a/cpp/subprojects/common/include/mlrl/common/util/view_functions.hpp
+++ b/cpp/subprojects/common/include/mlrl/common/util/view_functions.hpp
@@ -267,7 +267,7 @@ static inline constexpr bool compareViews(FirstIterator first, uint32 numFirst, 
     }
 
     for (uint32 i = 0; i < numFirst; i++) {
-        if (first[i] != second[i]) {
+        if (!isEqual(first[i], second[i])) {
             return false;
         }
     }

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_binning_equal_frequency.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_binning_equal_frequency.cpp
@@ -30,7 +30,7 @@ static inline std::unique_ptr<IFeatureVector> createFeatureVectorInternally(
             const IndexedValue<float32>& entry = numericalFeatureVector[i];
             float32 currentValue = entry.value;
 
-            if (currentValue >= sparseValue) {
+            if (!(currentValue < sparseValue)) {
                 break;
             }
 

--- a/cpp/subprojects/common/src/mlrl/common/input/feature_binning_equal_frequency.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/input/feature_binning_equal_frequency.cpp
@@ -73,7 +73,7 @@ static inline std::unique_ptr<IFeatureVector> createFeatureVectorInternally(
 
             // Skip feature values that are equal to the previous one...
             for (; i < numElements; i++) {
-                if (numericalFeatureVector[i].value != previousValue) {
+                if (!isEqual(numericalFeatureVector[i].value, previousValue)) {
                     break;
                 }
 

--- a/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_beam_search.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_beam_search.cpp
@@ -457,7 +457,7 @@ float32 BeamSearchTopDownRuleInductionConfig::getMinSupport() const {
 }
 
 IBeamSearchTopDownRuleInductionConfig& BeamSearchTopDownRuleInductionConfig::setMinSupport(float32 minSupport) {
-    if (!isEqual(minSupport, 0.0f)) {
+    if (!isEqualToZero(minSupport)) {
         assertGreater<float32>("minSupport", minSupport, 0);
         assertLess<float32>("minSupport", minSupport, 1);
     }

--- a/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_beam_search.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_beam_search.cpp
@@ -457,8 +457,11 @@ float32 BeamSearchTopDownRuleInductionConfig::getMinSupport() const {
 }
 
 IBeamSearchTopDownRuleInductionConfig& BeamSearchTopDownRuleInductionConfig::setMinSupport(float32 minSupport) {
-    if (minSupport != 0) assertGreater<float32>("minSupport", minSupport, 0);
-    if (minSupport != 0) assertLess<float32>("minSupport", minSupport, 1);
+    if (!isEqual(minSupport, 0.0f)) {
+        assertGreater<float32>("minSupport", minSupport, 0);
+        assertLess<float32>("minSupport", minSupport, 1);
+    }
+
     minSupport_ = minSupport;
     return *this;
 }

--- a/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_greedy.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_greedy.cpp
@@ -175,7 +175,7 @@ float32 GreedyTopDownRuleInductionConfig::getMinSupport() const {
 }
 
 IGreedyTopDownRuleInductionConfig& GreedyTopDownRuleInductionConfig::setMinSupport(float32 minSupport) {
-    if (!isEqual(minSupport, 0.0f)) {
+    if (!isEqualToZero(minSupport)) {
         assertGreater<float32>("minSupport", minSupport, 0);
         assertLess<float32>("minSupport", minSupport, 1);
     }

--- a/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_greedy.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_induction/rule_induction_top_down_greedy.cpp
@@ -175,8 +175,11 @@ float32 GreedyTopDownRuleInductionConfig::getMinSupport() const {
 }
 
 IGreedyTopDownRuleInductionConfig& GreedyTopDownRuleInductionConfig::setMinSupport(float32 minSupport) {
-    if (minSupport != 0) assertGreater<float32>("minSupport", minSupport, 0);
-    if (minSupport != 0) assertLess<float32>("minSupport", minSupport, 1);
+    if (!isEqual(minSupport, 0.0f)) {
+        assertGreater<float32>("minSupport", minSupport, 0);
+        assertLess<float32>("minSupport", minSupport, 1);
+    }
+
     minSupport_ = minSupport;
     return *this;
 }

--- a/cpp/subprojects/common/src/mlrl/common/rule_refinement/feature_based_search_numerical.hpp
+++ b/cpp/subprojects/common/src/mlrl/common/rule_refinement/feature_based_search_numerical.hpp
@@ -25,7 +25,7 @@ static inline void searchForNumericalRefinementInternally(const NumericalFeature
         const IndexedValue<float32>& entry = featureVector[i];
         float32 currentValue = entry.value;
 
-        if (currentValue >= sparseValue) {
+        if (!(currentValue < sparseValue)) {
             break;
         }
 
@@ -46,7 +46,7 @@ static inline void searchForNumericalRefinementInternally(const NumericalFeature
             const IndexedValue<float32>& entry = featureVector[i];
             float32 currentValue = entry.value;
 
-            if (currentValue >= sparseValue) {
+            if (!(currentValue < sparseValue)) {
                 break;
             }
 

--- a/cpp/subprojects/common/src/mlrl/common/sampling/weight_vector_out_of_sample.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/sampling/weight_vector_out_of_sample.cpp
@@ -14,7 +14,7 @@ uint32 OutOfSampleWeightVector<WeightVector>::getNumElements() const {
 
 template<typename WeightVector>
 bool OutOfSampleWeightVector<WeightVector>::operator[](uint32 pos) const {
-    return vector_[pos] == 0;
+    return isEqualToZero(vector_[pos]);
 }
 
 template class OutOfSampleWeightVector<EqualWeightVector>;

--- a/cpp/subprojects/common/src/mlrl/common/stopping/global_pruning_pre.cpp
+++ b/cpp/subprojects/common/src/mlrl/common/stopping/global_pruning_pre.cpp
@@ -99,7 +99,7 @@ class PrePruning final : public IStoppingCriterion {
                         float64 percentageImprovement =
                           (aggregatedScorePast - aggregatedScoreRecent) / aggregatedScoreRecent;
 
-                        if (percentageImprovement <= minImprovement_) {
+                        if (percentageImprovement < minImprovement_) {
                             result.stop = removeUnusedRules_;
                             result.numUsedRules = bestNumRules_;
                             stopped_ = true;

--- a/cpp/subprojects/seco/src/mlrl/seco/heuristics/heuristic_common.hpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/heuristics/heuristic_common.hpp
@@ -29,11 +29,11 @@ namespace seco {
         float64 numUncovered = numUncoveredEqual + uip + urn;
         float64 numTotal = numCovered + numUncovered;
 
-        if (numCovered == 0 || numTotal == 0) {
-            return 0;
+        if (numCovered > 0 && numTotal > 0) {
+            return (numCovered / numTotal) * ((numCoveredEqual / numCovered) - (numEqual / numTotal));
         }
 
-        return (numCovered / numTotal) * ((numCoveredEqual / numCovered) - (numEqual / numTotal));
+        return 0;
     }
 
 }

--- a/cpp/subprojects/seco/src/mlrl/seco/heuristics/heuristic_m_estimate.cpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/heuristics/heuristic_m_estimate.cpp
@@ -34,11 +34,11 @@ namespace seco {
                     float64 numEqual = numCoveredEqual + numUncoveredEqual;
                     float64 numTotal = numCovered + numUncoveredEqual + uip + urn;
 
-                    if (numTotal == 0) {
-                        return 0;
+                    if (numTotal > 0) {
+                        return (numCoveredEqual + (m_ * (numEqual / numTotal))) / (numCovered + m_);
                     }
 
-                    return (numCoveredEqual + (m_ * (numEqual / numTotal))) / (numCovered + m_);
+                    return 0;
                 } else {
                     // Equivalent to precision
                     return precision(cin, cip, crn, crp);

--- a/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_label_wise_common.hpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/statistics/statistics_label_wise_common.hpp
@@ -14,7 +14,7 @@ namespace seco {
 
     template<typename WeightVector>
     static inline bool hasNonZeroWeightLabelWise(const WeightVector& weights, uint32 statisticIndex) {
-        return weights[statisticIndex] != 0;
+        return !isEqualToZero(weights[statisticIndex]);
     }
 
     template<typename LabelMatrix, typename CoverageMatrix, typename ConfusionMatrixVector, typename IndexVector>

--- a/cpp/subprojects/seco/src/mlrl/seco/stopping/stopping_criterion_coverage.cpp
+++ b/cpp/subprojects/seco/src/mlrl/seco/stopping/stopping_criterion_coverage.cpp
@@ -26,7 +26,7 @@ namespace seco {
                 Result result;
                 const ICoverageStatistics& coverageStatistics = static_cast<const ICoverageStatistics&>(statistics);
 
-                if (coverageStatistics.getSumOfUncoveredWeights() <= threshold_) {
+                if (!(coverageStatistics.getSumOfUncoveredWeights() > threshold_)) {
                     result.stop = true;
                 }
 


### PR DESCRIPTION
Ensures that safe comparisons of floating point values are used throughout the entire C++ code as suggested in #741.