### PR TITLE
Readthedocs Integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+build:
+  os: "ubuntu-lts-latest"
+  tools:
+    python: "latest"
+  apt_packages:
+    - doxygen
+  commands:
+    - export READTHEDOCS_OUTPUT="doc/_build"
+    - ./build doc

--- a/doc/developer_guide/documentation.md
+++ b/doc/developer_guide/documentation.md
@@ -108,7 +108,7 @@ To generate the final documentation's HTML files via [sphinx](https://www.sphinx
    ```
 ````
 
-Afterwards, the generated files can be found in the directory `doc/build_/`.
+Afterwards, the generated files can be found in the directory `doc/_build/html/`.
 
 ## Cleaning up Build Files
 

--- a/scons/modules.py
+++ b/scons/modules.py
@@ -393,7 +393,7 @@ class DocumentationModule(Module):
         """
         The directory, where the documentation should be stored.
         """
-        return path.join(self.root_dir, '_build')
+        return path.join(self.root_dir, '_build', 'html')
 
     def find_build_files(self) -> List[str]:
         """


### PR DESCRIPTION
Adds support for building the documentation published on [readthedocs.org](https://readthedocs.org) directly from this repository.  