### PR TITLE
Link statically against library "mlrlcommon"

### DIFF
--- a/cpp/subprojects/common/meson.build
+++ b/cpp/subprojects/common/meson.build
@@ -178,15 +178,9 @@ endif
 # Library declaration
 common_lib = library(lib_name, source_files, include_directories : include_dir, cpp_args : cpp_args,
                      link_args : link_args, version : version, install : true, install_dir : install_dir)
-
-if host_machine.system() == 'windows'
-    # On Windows, we must additionally built a static library to link against, as we cannot add DLL exports for all
-    # classes that can potentially be used by dependant libraries
-    common_lib = static_library(lib_name, source_files, include_directories : include_dir, cpp_args : cpp_args,
-                                link_args : link_args)
-endif
-
-common_dep = declare_dependency(include_directories : include_dir, link_with : common_lib)
+common_static_lib = static_library(lib_name, source_files, include_directories : include_dir, cpp_args : cpp_args,
+                                   link_args : link_args)
+common_dep = declare_dependency(include_directories : include_dir, link_with : common_static_lib)
 
 # Test declaration
 test_support_option = get_option('test_support')


### PR DESCRIPTION
Reverts the changes in #785, such that the library "mlrlcommon" is again compiled as both, a shared library and a static library. Currently, compiling the library only as a shared library, breaks the creation of pre-built PyPi packages via cibuildwheel.