### PR TITLE
Allow to restrict build to individual subprojects

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -1,3 +1,9 @@
 project('mlrl', default_options : ['cpp_std=c++17', 'buildtype=release', 'werror=true'])
-subproject('boosting')
-subproject('seco')
+
+subprojects = get_option('subprojects')
+
+foreach subproject_name : ['common', 'boosting', 'seco']
+    if subprojects.length() == 0 or subprojects.contains(subproject_name)
+        subproject(subproject_name)
+    endif
+endforeach

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -1,0 +1,1 @@
+option('subprojects', type : 'array', value : [])

--- a/doc/developer_guide/compilation.md
+++ b/doc/developer_guide/compilation.md
@@ -61,9 +61,8 @@ This project uses [Meson](https://mesonbuild.com/) as a build system for compili
 
 Additional build- or run-time dependencies will automatically be installed when following the instructions below and must not be installed manually.
 
-```{tip}
+`````{tip}
 Instead of following the instructions below step by step, the following command, which automatically executes all necessary steps, can be used for simplicity.
-```
 
 ````{tab} Linux
    ```text
@@ -84,6 +83,30 @@ Instead of following the instructions below step by step, the following command,
 ````
 
 Whenever any C++, Cython or Python source files have been modified, the above command must be run again in order to rebuild modified files and install updated wheel packages into the virtual environment. If any compilation files do already exist, this will only result in the affected parts of the code to be rebuilt.
+`````
+
+`````{note}
+As shown in {ref}`project-structure`, this project is organized in terms of several subprojects. By default, all of these subprojects are built when following the instructions below. However, the environment variable `SUBPROJECTS` may be used to restrict individual steps of the build process, such as the compilation of C++ and Cython code, the assemblage of Python packages, and the generation of apidocs, to a subset of the available subprojects. As shown below, multiple subprojects can be specified as a comma-separated list:
+
+````{tab} Linux
+   ```text
+   SUBPROJECTS=common,boosting ./build
+   ```
+````
+
+````{tab} MacOS
+   ```text
+   SUBPROJECTS=common,boosting ./build
+   ```
+````
+
+````{tab} Windows
+   ```text
+   $env:SUBPROJECTS = "common,boosting"
+   build.bat
+   ```
+````
+`````
 
 ## Creating a Virtual Environment
 

--- a/doc/developer_guide/compilation.md
+++ b/doc/developer_guide/compilation.md
@@ -317,7 +317,7 @@ Certain functionalities of the project can be enabled or disabled at compile-tim
 
 ### Testing Support
 
-This project comes with unit tests for the C++ code it contains (see {ref}`testing`). They are based on the [GoogleTest](https://github.com/google/googletest) framework. When building the project on a system where this dependency is available, the testing code is compiled and linked against the shared libraries it is supposed to test. By default, the build option `test_support` is set to `auto`, i.e., the testing code is only compiled if GoogleTest is available and no error will be raised otherwise. To enforce the compilation of the testing code, the build option can be set to `enabled`. Setting it to `disabled` will prevent the code from being compiled even if GoogleTest is available. Alternatively, the desired value can be specified via the environment variable `TEST_SUPPORT`.enabled
+This project comes with unit tests for the C++ code it contains (see {ref}`testing`). They are based on the [GoogleTest](https://github.com/google/googletest) framework. When building the project on a system where this dependency is available, the testing code is compiled and linked against the shared libraries it is supposed to test. By default, the build option `test_support` is set to `auto`, i.e., the testing code is only compiled if GoogleTest is available and no error will be raised otherwise. To enforce the compilation of the testing code, the build option can be set to `enabled`. Setting it to `disabled` will prevent the code from being compiled even if GoogleTest is available. Alternatively, the desired value can be specified via the environment variable `TEST_SUPPORT`.
 
 (multi-threading-support)=
 

--- a/python/meson.build
+++ b/python/meson.build
@@ -1,3 +1,9 @@
 project('mlrl-python', default_options : ['cpp_std=c++17', 'buildtype=release'])
-subproject('boosting')
-subproject('seco')
+
+subprojects = get_option('subprojects')
+
+foreach subproject_name : ['common', 'boosting', 'seco']
+    if subprojects.length() == 0 or subprojects.contains(subproject_name)
+        subproject(subproject_name)
+    endif
+endforeach

--- a/python/meson.options
+++ b/python/meson.options
@@ -1,0 +1,1 @@
+option('subprojects', type : 'array', value : [])

--- a/scons/documentation.py
+++ b/scons/documentation.py
@@ -107,12 +107,14 @@ def apidoc_cpp(env, target, source):
     """
     if target:
         apidoc_subproject = DOC_MODULE.find_cpp_apidoc_subproject(target[0].path)
-        subproject_name = apidoc_subproject.name
-        print('Generating C++ API documentation for subproject "' + subproject_name + '"...')
-        include_dir = path.join(apidoc_subproject.source_subproject.root_dir, 'include')
-        build_dir = apidoc_subproject.build_dir
-        __doxygen(project_name=subproject_name, input_dir=include_dir, output_dir=build_dir)
-        __breathe_apidoc(source_dir=path.join(build_dir, 'xml'), output_dir=build_dir, project=subproject_name)
+
+        if apidoc_subproject:
+            subproject_name = apidoc_subproject.name
+            print('Generating C++ API documentation for subproject "' + subproject_name + '"...')
+            include_dir = path.join(apidoc_subproject.source_subproject.root_dir, 'include')
+            build_dir = apidoc_subproject.build_dir
+            __doxygen(project_name=subproject_name, input_dir=include_dir, output_dir=build_dir)
+            __breathe_apidoc(source_dir=path.join(build_dir, 'xml'), output_dir=build_dir, project=subproject_name)
 
 
 def apidoc_cpp_tocfile(**_):
@@ -145,10 +147,12 @@ def apidoc_python(env, target, source):
     """
     if target:
         apidoc_subproject = DOC_MODULE.find_python_apidoc_subproject(target[0].path)
-        print('Generating Python API documentation for subproject "' + apidoc_subproject.name + '"...')
-        build_dir = apidoc_subproject.build_dir
-        makedirs(build_dir, exist_ok=True)
-        __sphinx_apidoc(source_dir=apidoc_subproject.source_subproject.source_dir, output_dir=build_dir)
+
+        if apidoc_subproject:
+            print('Generating Python API documentation for subproject "' + apidoc_subproject.name + '"...')
+            build_dir = apidoc_subproject.build_dir
+            makedirs(build_dir, exist_ok=True)
+            __sphinx_apidoc(source_dir=apidoc_subproject.source_subproject.source_dir, output_dir=build_dir)
 
 
 def apidoc_python_tocfile(**_):

--- a/scons/environment.py
+++ b/scons/environment.py
@@ -3,10 +3,10 @@ Author: Michael Rapp (michael.rapp.ml@gmail.com)
 
 Provides utility functions for accessing environment variables.
 """
-from typing import Optional
+from typing import List, Optional
 
 
-def get_env(env, name: str, default: bool = None) -> Optional[str]:
+def get_env(env, name: str, default: Optional[bool] = None) -> Optional[str]:
     """
     Returns the value of the environment variable with a given name.
 
@@ -16,6 +16,23 @@ def get_env(env, name: str, default: bool = None) -> Optional[str]:
     :return:        The value of the environment variable
     """
     return env.get(name, default)
+
+
+def get_env_array(env, name: str, default: Optional[List[str]] = None) -> List[str]:
+    """
+    Returns the value of the environment variable with a given name as a comma-separated list.
+
+    :param env:     The environment to be accessed
+    :param name:    The name of the environment variable
+    :param default: The default value to be returned if the environment variable is not set
+    :return:        The value of the environment variable
+    """
+    value = get_env(env, name)
+
+    if value:
+        return value.split(',')
+
+    return default if default else []
 
 
 def set_env(env, name: str, value: str):

--- a/scons/modules.py
+++ b/scons/modules.py
@@ -196,18 +196,18 @@ class PythonModule(SourceModule):
             if path.isdir(file)
         ]
 
-    def find_subproject(self, file: str) -> Subproject:
+    def find_subproject(self, file: str) -> Optional[Subproject]:
         """
         Finds and returns the subproject to which a given file belongs.
 
         :param file:    The path of the file
-        :return:        The subproject to which the given file belongs
+        :return:        The subproject to which the given file belongs or None, if no such subproject is available
         """
         for subproject in self.find_subprojects():
             if file.startswith(subproject.root_dir):
                 return subproject
 
-        raise ValueError('File "' + file + '" does not belong to a Python subproject')
+        return None
 
 
 class CppModule(SourceModule):
@@ -436,12 +436,13 @@ class DocumentationModule(Module):
         """
         return DocumentationModule.PythonApidocSubproject(self, python_subproject)
 
-    def find_cpp_apidoc_subproject(self, file: str) -> CppApidocSubproject:
+    def find_cpp_apidoc_subproject(self, file: str) -> Optional[CppApidocSubproject]:
         """
         Finds and returns the `CppApidocSubproject` to which a given file belongs.
 
         :param file:    The path of the file
-        :return:        The `CppApiSubproject` to which the given file belongs
+        :return:        The `CppApiSubproject` to which the given file belongs or None, if no such subproject is
+                        available
         """
         for subproject in CPP_MODULE.find_subprojects():
             apidoc_subproject = self.get_cpp_apidoc_subproject(subproject)
@@ -449,14 +450,15 @@ class DocumentationModule(Module):
             if file.startswith(apidoc_subproject.build_dir):
                 return apidoc_subproject
 
-        raise ValueError('File "' + file + '" does not belong to a C++ API documentation subproject')
+        return None
 
-    def find_python_apidoc_subproject(self, file: str) -> PythonApidocSubproject:
+    def find_python_apidoc_subproject(self, file: str) -> Optional[PythonApidocSubproject]:
         """
         Finds and returns the `PythonApidocSubproject` to which a given file belongs.
 
         :param file:    The path of the file
-        :return:        The `PythonApidocSubproject` to which the given file belongs
+        :return:        The `PythonApidocSubproject` to which the given file belongs or None, if no such subproject is
+                        available
         """
         for subproject in PYTHON_MODULE.find_subprojects():
             apidoc_subproject = self.get_python_apidoc_subproject(subproject)
@@ -464,7 +466,7 @@ class DocumentationModule(Module):
             if file.startswith(apidoc_subproject.build_dir):
                 return apidoc_subproject
 
-        raise ValueError('File "' + file + '" does not belong to a Python API documentation subproject')
+        return None
 
 
 BUILD_MODULE = BuildModule()

--- a/scons/packaging.py
+++ b/scons/packaging.py
@@ -41,8 +41,10 @@ def build_python_wheel(env, target, source):
     """
     if target:
         subproject = PYTHON_MODULE.find_subproject(target[0].path)
-        print('Building Python wheels for subproject "' + subproject.name + '"...')
-        __build_python_wheel(subproject.root_dir)
+
+        if subproject:
+            print('Building Python wheels for subproject "' + subproject.name + '"...')
+            __build_python_wheel(subproject.root_dir)
 
 
 # pylint: disable=unused-argument
@@ -56,5 +58,7 @@ def install_python_wheels(env, target, source):
     """
     if source:
         subproject = PYTHON_MODULE.find_subproject(source[0].path)
-        print('Installing Python wheels for subproject "' + subproject.name + '"...')
-        __install_python_wheels(subproject.find_wheels())
+
+        if subproject:
+            print('Installing Python wheels for subproject "' + subproject.name + '"...')
+            __install_python_wheels(subproject.find_wheels())

--- a/scons/sconstruct.py
+++ b/scons/sconstruct.py
@@ -141,7 +141,7 @@ if not COMMAND_LINE_TARGETS \
         or TARGET_NAME_INSTALL in COMMAND_LINE_TARGETS:
     __print_if_clean(env, 'Removing shared libraries from source tree...')
 
-    for subproject in PYTHON_MODULE.find_subprojects():
+    for subproject in PYTHON_MODULE.find_subprojects(return_all=True):
         env.Clean([target_install_cpp, DEFAULT_TARGET], subproject.find_shared_libraries())
 
 if not COMMAND_LINE_TARGETS \
@@ -149,7 +149,7 @@ if not COMMAND_LINE_TARGETS \
         or TARGET_NAME_INSTALL in COMMAND_LINE_TARGETS:
     __print_if_clean(env, 'Removing extension modules from source tree...')
 
-    for subproject in PYTHON_MODULE.find_subprojects():
+    for subproject in PYTHON_MODULE.find_subprojects(return_all=True):
         env.Clean([target_install_cython, DEFAULT_TARGET], subproject.find_extension_modules())
 
 # Define targets for building and installing Python wheels...
@@ -177,7 +177,7 @@ env.Depends(target_install_wheels, [target_install] + commands_install_wheels)
 if not COMMAND_LINE_TARGETS or TARGET_NAME_BUILD_WHEELS in COMMAND_LINE_TARGETS:
     __print_if_clean(env, 'Removing Python wheels...')
 
-    for subproject in PYTHON_MODULE.find_subprojects():
+    for subproject in PYTHON_MODULE.find_subprojects(return_all=True):
         env.Clean([target_build_wheels, DEFAULT_TARGET], subproject.build_dirs)
 
 # Define targets for running automated tests...
@@ -242,7 +242,7 @@ if not COMMAND_LINE_TARGETS \
     __print_if_clean(env, 'Removing C++ API documentation...')
     env.Clean([target_apidoc_cpp, DEFAULT_TARGET], DOC_MODULE.apidoc_tocfile_cpp)
 
-    for subproject in CPP_MODULE.find_subprojects():
+    for subproject in CPP_MODULE.find_subprojects(return_all=True):
         apidoc_subproject = DOC_MODULE.get_cpp_apidoc_subproject(subproject)
         env.Clean([target_apidoc_cpp, DEFAULT_TARGET], apidoc_subproject.build_dir)
 
@@ -252,7 +252,7 @@ if not COMMAND_LINE_TARGETS \
     __print_if_clean(env, 'Removing Python API documentation...')
     env.Clean([target_apidoc_python, DEFAULT_TARGET], DOC_MODULE.apidoc_tocfile_python)
 
-    for subproject in PYTHON_MODULE.find_subprojects():
+    for subproject in PYTHON_MODULE.find_subprojects(return_all=True):
         apidoc_subproject = DOC_MODULE.get_python_apidoc_subproject(subproject)
         env.Clean([target_apidoc_python, DEFAULT_TARGET], apidoc_subproject.build_dir)
 


### PR DESCRIPTION
The environment variable `SUBPROJECTS` can now be used to restrict the entire build process to a subset of the available subprojects:
```
SUBPROJECTS=common,boosting ./build
```