### PR TITLE
Add missing sections to documentation

### DIFF
--- a/doc/developer_guide/compilation.md
+++ b/doc/developer_guide/compilation.md
@@ -59,7 +59,7 @@ This project uses [Meson](https://mesonbuild.com/) as a build system for compili
    ```
 ````
 
-Additional build- or run-time dependencies will automatically be installed when following the instructions below and must not be installed manually.
+Additional build- or run-time dependencies are automatically installed when following the instructions below and must not be installed manually.
 
 `````{tip}
 Instead of following the instructions below step by step, the following command, which automatically executes all necessary steps, can be used for simplicity.
@@ -82,7 +82,7 @@ Instead of following the instructions below step by step, the following command,
    ```
 ````
 
-Whenever any C++, Cython or Python source files have been modified, the above command must be run again in order to rebuild modified files and install updated wheel packages into the virtual environment. If any compilation files do already exist, this will only result in the affected parts of the code to be rebuilt.
+Whenever any C++, Cython or Python source files have been modified, the above command must be run again in order to rebuild modified files and install updated wheel packages into the virtual environment. If any compilation files already exist, this does only result in the affected parts of the code to be rebuilt.
 `````
 
 `````{note}
@@ -340,7 +340,7 @@ Certain functionalities of the project can be enabled or disabled at compile-tim
 
 ### Testing Support
 
-This project comes with unit tests for the C++ code it contains (see {ref}`testing`). They are based on the [GoogleTest](https://github.com/google/googletest) framework. When building the project on a system where this dependency is available, the testing code is compiled and linked against the shared libraries it is supposed to test. By default, the build option `test_support` is set to `auto`, i.e., the testing code is only compiled if GoogleTest is available and no error will be raised otherwise. To enforce the compilation of the testing code, the build option can be set to `enabled`. Setting it to `disabled` will prevent the code from being compiled even if GoogleTest is available. Alternatively, the desired value can be specified via the environment variable `TEST_SUPPORT`.
+This project comes with unit tests for the C++ code it contains (see {ref}`testing`). They are based on the [GoogleTest](https://github.com/google/googletest) framework. When building the project on a system where this dependency is available, the testing code is compiled and linked against the shared libraries it is supposed to test. By default, the build option `test_support` is set to `auto`, i.e., the testing code is only compiled if GoogleTest is available and no error is raised otherwise. To enforce the compilation of the testing code, the build option can be set to `enabled`. Setting it to `disabled` prevents the code from being compiled even if GoogleTest is available. Alternatively, the desired value can be specified via the environment variable `TEST_SUPPORT`.
 
 (multi-threading-support)=
 
@@ -348,7 +348,7 @@ This project comes with unit tests for the C++ code it contains (see {ref}`testi
 
 By default, the project is built with multi-threading support enabled. This requires [OpenMP](https://www.openmp.org/) to be available on the host system. In order to compile the project without multi-threading support, e.g., because OpenMP is not available, the build option `multi_threading_support` can be set to `disabled` instead of `enabled`. Alternatively, the desired value can be specified via the environment variable `MULTI_THREADING_SUPPORT`.
 
-When using the {ref}`testbed`, the command `boomer --version` or `boomer -v` can be executed to check whether the program was built with multi-threading support enabled or not. It will print the build options used for compilation, as well as information about the CPU cores available on the system for multi-threading.
+When using the {ref}`testbed`, the command `boomer --version` or `boomer -v` can be executed to check whether the program was built with multi-threading support enabled or not. It prints the build options used for compilation, as well as information about the CPU cores available on the system for multi-threading.
 
 If you need to access this information programmatically in your own Python or C++ code, the following code snippets can be used (see {ref}`python-apidoc` and {ref}`cpp-apidoc`):
 
@@ -380,7 +380,7 @@ So far, GPU support is still at an early stage of development. No algorithm prov
 
 GPU support via [OpenCL](https://www.khronos.org/opencl/) is enabled by default when building the project. However, it can be disabled at compile-time by setting the build option `gpu_support` to `disabled` instead of `enabled`. Alternatively, the desired value can be specified via the environment variable `GPU_SUPPORT`.
 
-An easy way to check whether the program was built with GPU support enabled or not, is to run the `boomer --version` or `boomer -v` command that is provided by the {ref}`testbed`. It will print the build options used for compiling the program, together with a list of supported GPUs available on your machine.
+An easy way to check whether the program was built with GPU support enabled or not, is to run the `boomer --version` or `boomer -v` command that is provided by the {ref}`testbed`. It prints the build options used for compiling the program, together with a list of supported GPUs available on your machine.
 
 Alternatively, this information can be retrieved programmatically via the Python or C++ API as shown below (see {ref}`python-apidoc` and {ref}`cpp-apidoc`):
 

--- a/doc/developer_guide/documentation.md
+++ b/doc/developer_guide/documentation.md
@@ -10,7 +10,7 @@ The documentation is regularly built by our {ref}`ci` jobs. The documentation ge
 
 ## Prerequisites
 
-In order to generate the documentation, [Doxygen](https://sourceforge.net/projects/doxygen/) must be installed on the host system beforehand. It is used to generate an API documentation from the C++ source files. In addition, the [Roboto](https://fonts.google.com/specimen/Roboto) font should be available on your system. If this is not the case, another font will be used as a fallback.
+In order to generate the documentation, [Doxygen](https://sourceforge.net/projects/doxygen/) must be installed on the host system beforehand. It is used to generate an API documentation from the C++ source files. In addition, the [Roboto](https://fonts.google.com/specimen/Roboto) font should be available on your system. If this is not the case, another font is used as a fallback.
 
 `````{tip}
 It is not necessary to execute the steps below one after the other. Instead, running the following command should suffice to create the entire documentation, including files that describe the C++ and Python API.

--- a/doc/user_guide/boosting/parameters.md
+++ b/doc/user_guide/boosting/parameters.md
@@ -317,7 +317,7 @@ To be able to use the algorithm's multi-threading capabilities, it must have bee
 
   - `'true'` Multi-threading is used to search for potential refinements of rules in parallel. The following options may be provided using the {ref}`bracket-notation`:
 
-    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible will be used.
+    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible are used.
 
 - `parallel_statistic_update` (Default value = `'auto'`)
 
@@ -327,7 +327,7 @@ To be able to use the algorithm's multi-threading capabilities, it must have bee
 
   - `'true'` Multi-threading is used to calculate the gradients and Hessians of different examples in parallel. The following options may be provided using the {ref}`bracket-notation`:
 
-    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible will be used.
+    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible are used.
 
 - `parallel_prediction` (Default value = `'true'`)
 
@@ -335,4 +335,4 @@ To be able to use the algorithm's multi-threading capabilities, it must have bee
 
   - `'true'` Multi-threading is used to obtain predictions for different examples in parallel. The following options may be provided using the {ref}`bracket-notation`:
 
-    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible will be used.
+    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible are used.

--- a/doc/user_guide/seco/parameters.md
+++ b/doc/user_guide/seco/parameters.md
@@ -222,7 +222,7 @@ To be able to use the algorithm's multi-threading capabilities, it must have bee
 
   - `'true'` Multi-threading is used to search for potential refinements of rules in parallel. The following options may be provided using the {ref}`bracket-notation`:
 
-    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible will be used.
+    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible are used.
 
 - `parallel_statistic_update` (Default value = `'false'`)
 
@@ -230,7 +230,7 @@ To be able to use the algorithm's multi-threading capabilities, it must have bee
 
   - `'true'` Multi-threading is used to assess the correctness of predictions for different examples in parallel. The following options may be provided using the {ref}`bracket-notation`:
 
-    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible will be used.
+    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible are used.
 
 - `parallel_prediction` (Default value = `'true'`)
 
@@ -238,4 +238,4 @@ To be able to use the algorithm's multi-threading capabilities, it must have bee
 
   - `'true'` Multi-threading is used to obtain predictions for different examples in parallel. The following options may be provided using the {ref}`bracket-notation`:
 
-    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible will be used.
+    - `num_preferred_threads` (Default value = `0`) The number of preferred threads. Must be at least 1 or 0, if the number of cores available on the machine should be used. If not enough CPU cores are available or if multi-threading support is disabled, as many threads as possible are used.

--- a/doc/user_guide/testbed/arguments.md
+++ b/doc/user_guide/testbed/arguments.md
@@ -111,8 +111,8 @@ As an alternative to storing the models learned by an algorithm, the algorithmic
 
 - `--store-parameters` (Default value = `false`)
 
-  - `true` Algorithmic parameters that have been set by the user are written into .csv files. Does only have an effect if the parameter `--output-dir` is specified.
-  - `false` Algorithmic parameters that have been set by the user are not written into .csv files.
+  - `true` Algorithmic parameters that have been set by the user are written into [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) files. Does only have an effect if the parameter `--output-dir` is specified.
+  - `false` Algorithmic parameters that have been set by the user are not written into [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) files.
 
 ## Output of Experimental Results
 
@@ -169,7 +169,7 @@ To provide valuable insights into the models learned by an algorithm, the predic
 
 - `--store-evaluation` (Default value = `true`)
 
-  - `true` The evaluation results in terms of common metrics are written into .csv files. Does only have an effect if the parameter `--output-dir` is specified.
+  - `true` The evaluation results in terms of common metrics are written into [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) files. Does only have an effect if the parameter `--output-dir` is specified.
 
     - `decimals` (Default value = `0`) The number of decimals to be used for evaluation scores or 0, if the number of decimals should not be restricted.
     - `percentage` (Default value = `true`) `true`, if evaluation scores should be given as a percentage, if possible, `false` otherwise.
@@ -208,7 +208,7 @@ To provide valuable insights into the models learned by an algorithm, the predic
     - `training_time` (Default value = `true`) `true`, if the time that was needed for training should be stored, `false` otherwise.
     - `prediction_time` (Default value = `true`) `true`, if the time that was needed for prediction should be stored, `false` otherwise.
 
-  - `false` The evaluation results are not written into .csv files.
+  - `false` The evaluation results are not written into [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) files.
 
 (arguments-predictions)=
 
@@ -251,7 +251,7 @@ To provide valuable insights into the models learned by an algorithm, the predic
 
 - `--store-prediction-characteristics` (Default value = `false`)
 
-  - `true` The characteristics of binary predictions are written into .csv files. Does only have an effect if the parameter `--predict-probabilities` is set to `false`.
+  - `true` The characteristics of binary predictions are written into [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) files. Does only have an effect if the parameter `--predict-probabilities` is set to `false`.
 
     - `decimals` (Default value = `0`) The number of decimals to be used for characteristics or 0, if the number of decimals should not be restricted.
     - `percentage` (Default value = `true`) `true`, if the characteristics should be given as a percentage, if possible, `false` otherwise.
@@ -262,7 +262,7 @@ To provide valuable insights into the models learned by an algorithm, the predic
     - `label_cardinality` (Default value = `true`) `true`, if the average label cardinality should be stored, `false` otherwise.
     - `distinct_label_vectors` (Default value = `true`) `true`, if the number of distinct label vectors should be stored, `false` otherwise.
 
-  - `false` The characteristics of predictions are not written into .csv files.
+  - `false` The characteristics of predictions are not written into [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) files.
 
 (arguments-data-characteristics)=
 
@@ -291,7 +291,7 @@ To provide valuable insights into the models learned by an algorithm, the predic
 
 - `--store-data-characteristics` (Default value = `false`)
 
-  - `true` The characteristics of the training data set are written into a .csv file. Does only have an effect if the parameter `--output-dir` is specified.
+  - `true` The characteristics of the training data set are written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file. Does only have an effect if the parameter `--output-dir` is specified.
 
     - `decimals` (Default value = `0`) The number of decimals to be used for characteristics or 0, if the number of decimals should not be restricted.
     - `percentage` (Default value = `true`) `true`, if the characteristics should be given as a percentage, if possible, `false` otherwise.
@@ -308,7 +308,7 @@ To provide valuable insights into the models learned by an algorithm, the predic
     - `feature_density` (Default value = `true`) `true`, if the feature density should be stored, `false` otherwise.
     - `feature_sparsity` (Default value = `true`) `true`, if the feature sparsity should be stored, `false` otherwise.
 
-  - `false` The characteristics of the training data set are not written into a .csv file.
+  - `false` The characteristics of the training data set are not written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file.
 
 (arguments-label-vectors)=
 
@@ -324,11 +324,11 @@ To provide valuable insights into the models learned by an algorithm, the predic
 
 - `--store-label-vectors` (Default value = `false`)
 
-  - `true` The unique label vectors contained in the training data are written into a .csv file. Does only have an effect if the parameter `` `--output-dir `` is specified. The following options may be specified using the {ref}`bracket-notation`:
+  - `true` The unique label vectors contained in the training data are written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file. Does only have an effect if the parameter `` `--output-dir `` is specified. The following options may be specified using the {ref}`bracket-notation`:
 
     - `sparse` (Default value = `false`) `true`, if a sparse representation of label vectors should be used, `false` otherwise.
 
-  - `false` The unique label vectors contained in the training data are not written into a .csv file.
+  - `false` The unique label vectors contained in the training data are not written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file.
 
 (arguments-model-characteristics)=
 
@@ -341,8 +341,8 @@ To provide valuable insights into the models learned by an algorithm, the predic
 
 - `--store-model-characteristics` (Default value = `false`)
 
-  - `true` The characteristics of rule models are written into a .csv file. Does only have an effect if the parameter `--output-dir` is specified.
-  - `false` The characteristics of rule models are not written into a .csv file.
+  - `true` The characteristics of rule models are written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file. Does only have an effect if the parameter `--output-dir` is specified.
+  - `false` The characteristics of rule models are not written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file.
 
 (arguments-output-rules)=
 
@@ -390,11 +390,11 @@ To provide valuable insights into the models learned by an algorithm, the predic
 
 - `--store-marginal-probability-calibration-model` (Default value = `false`)
 
-  - `true` The model for the calibration of marginal probabilities is written into a .csv file. Does only have an effect if the parameter `--output-dir` is specified. The following options may be specified using the {ref}`bracket-notation`:
+  - `true` The model for the calibration of marginal probabilities is written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file. Does only have an effect if the parameter `--output-dir` is specified. The following options may be specified using the {ref}`bracket-notation`:
 
     - `decimals` (Default value = `0`) The number of decimals to be used for thresholds and probabilities or 0, if the number of decimals should not be restricted.
 
-  - `false` The model for the calibration of marginal probabilities is not written into a .csv file.
+  - `false` The model for the calibration of marginal probabilities is not written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file.
 
 - `--print-joint-probability-calibration-model` (Default value = `false`)
 
@@ -406,11 +406,11 @@ To provide valuable insights into the models learned by an algorithm, the predic
 
 - `--store-joint-probability-calibration-model` (Default value = `false`)
 
-  - `true` The model for the calibration of joint probabilities is written into a .csv file. Does only have an effect if the parameter `--output-dir` is specified. The following options may be specified using the {ref}`bracket-notation`:
+  - `true` The model for the calibration of joint probabilities is written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file. Does only have an effect if the parameter `--output-dir` is specified. The following options may be specified using the {ref}`bracket-notation`:
 
     - `decimals` (Default value = `2`) The number of decimals to be used for thresholds and probabilities or 0, if the number of decimals should not be restricted.
 
-  - `false` The model for the calibration of joint probabilities is not written into a .csv file.
+  - `false` The model for the calibration of joint probabilities is not written into a [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) file.
 
 (setting-algorithmic-parameters)=
 

--- a/doc/user_guide/testbed/arguments.md
+++ b/doc/user_guide/testbed/arguments.md
@@ -35,11 +35,11 @@ One of the most important capabilities of the command line API is to train machi
 
 - `--data-split` (Default value = `train-test`)
 
-  - `train-test` The available data is split into a single training and test set. Given that `dataset-name` is provided as the value of the argument `--dataset`, the training data must be stored in a file named `dataset-name_training.arff`, whereas the test data must be stored in a file named `dataset-name_test.arff`. If no such files are available, the program will look for a file with the name `dataset-name.arff` and split it into training and test data automatically. The following options may be specified using the {ref}`bracket-notation`:
+  - `train-test` The available data is split into a single training and test set. Given that `dataset-name` is provided as the value of the argument `--dataset`, the training data must be stored in a file named `dataset-name_training.arff`, whereas the test data must be stored in a file named `dataset-name_test.arff`. If no such files are available, the program searches for a file with the name `dataset-name.arff` and splits it into training and test data automatically. The following options may be specified using the {ref}`bracket-notation`:
 
     - `test_size` (Default value = `0.33`) The fraction of the available data to be included in the test set, if the training and test set are not provided as separate files. Must be in (0, 1).
 
-  - `cross-validation` A cross validation is performed. Given that `dataset-name` is provided as the value of the argument `--dataset`, the data for individual folds must be stored in files named `dataset-name_fold-1`, `dataset-name_fold-2`, etc.. If no such files are available, the program will look for a file with the name `dataset-name.arff` and split it into training and test data for the individual folds automatically. The following options may be specified using the {ref}`bracket-notation`:
+  - `cross-validation` A cross validation is performed. Given that `dataset-name` is provided as the value of the argument `--dataset`, the data for individual folds must be stored in files named `dataset-name_fold-1`, `dataset-name_fold-2`, etc.. If no such files are available, the program searches for a file with the name `dataset-name.arff` and splits it into training and test data for the individual folds automatically. The following options may be specified using the {ref}`bracket-notation`:
 
     - `num_folds` (Default value = `10`) The total number of cross validation folds to be performed. Must be at least 2.
     - `current_fold` (Default value = `0`) The cross validation fold to be performed. Must be in \[1, `num_folds`\] or 0, if all folds should be performed.
@@ -92,7 +92,7 @@ Because the training of models can be time-consuming, it might be desirable to s
 
 - `--model-dir` (Default value = `None`)
 
-  - An absolute or relative path to the directory where models should be stored. If such models are found in the specified directory, they will be used instead of learning a new model from scratch. If no models are available, the trained models will be saved in the specified directory once training has completed.
+  - An absolute or relative path to the directory where models should be stored. If such models are found in the specified directory, they are used instead of learning a new model from scratch. If no models are available, the trained models are saved in the specified directory once training has completed.
 
 ## Saving and Loading Parameters
 

--- a/doc/user_guide/testbed/evaluation.md
+++ b/doc/user_guide/testbed/evaluation.md
@@ -18,34 +18,34 @@ The simplest and computationally least demanding strategy for obtaining training
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --data-split train-test
 ```
 
-Following the argument `--dataset`, the program will load the training data from a file named `dataset-name_training.arff`. Similarly, it will expect the test data to be stored in a file named `dataset-name_test.arff`. If these files are not available, the program will look for a file with the name `dataset-name.arff` and split it into training and test data automatically.
+Following the argument `--dataset`, the program loads the training data from a file named `dataset-name_training.arff`. Similarly, it expects the test data to be stored in a file named `dataset-name_test.arff`. If these files are not available, the program searches for a file with the name `dataset-name.arff` and splits it into training and test data automatically.
 
-When it is the responsibility of the command line API to split a given dataset into training and test tests, 66% of the data will be included in the training set, whereas the remaining 33% will be part of the test set. Although this ratio is frequently used in machine learning, you can easily adjust it by providing the option `test_size`:
+When it is the responsibility of the command line API to split a given dataset into training and test tests, 66% of the data are included in the training set, whereas the remaining 33% are part of the test set. Although this ratio is frequently used in machine learning, you can easily adjust it by providing the option `test_size`:
 
 ```text
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --data-split 'train-test{test_size=0.25}'
 ```
 
-This command will tell the command line API to include 75% of the available data in the training set and use the remaining 25% for the test set.
+This command instructs the command line API to include 75% of the available data in the training set and use the remaining 25% for the test set.
 
 (cross-validation)=
 
 ### Cross Validation
 
-A more elaborate strategy for splitting data into training and test sets, which results in more realistic performance estimates, but also entails greater computational costs, is referred to as [cross validation](<https://en.wikipedia.org/wiki/Cross-validation_(statistics)>) (CV). The basic idea is to split the available data into several, equally-sized, parts. Afterwards, several machine learning models are trained and evaluated on different portions of the data using the same learning method. Each of these parts will be used for testing exactly once, whereas the remaining ones make up the training set. The performance estimates that are obtained for each of these subsequent runs, referred to as *folds*, are finally averaged to obtain a single score and corresponding [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation). The command line API can be instructed to perform a cross validation using the argument `--data-split cv`:
+A more elaborate strategy for splitting data into training and test sets, which results in more realistic performance estimates, but also entails greater computational costs, is referred to as [cross validation](<https://en.wikipedia.org/wiki/Cross-validation_(statistics)>) (CV). The basic idea is to split the available data into several, equally-sized, parts. Afterwards, several machine learning models are trained and evaluated on different portions of the data using the same learning method. Each of these parts are used for testing exactly once, whereas the remaining ones make up the training set. The performance estimates that are obtained for each of these subsequent runs, referred to as *folds*, are finally averaged to obtain a single score and corresponding [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation). The command line API can be instructed to perform a cross validation using the argument `--data-split cv`:
 
 ```text
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --data-split cv
 ```
 
-By default, a 10-fold cross validation, where ten models are trained and evaluated, will be performed. The number of folds can easily be adjusted via the option `num_folds`. For example, the following command results in a 5-fold CV being used:
+By default, a 10-fold cross validation, where ten models are trained and evaluated, is performed. The number of folds can easily be adjusted via the option `num_folds`. For example, the following command results in a 5-fold CV being used:
 
 ```text
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --data-split 'cv{num_folds=5}'
 ```
 
 ```{tip}
-When providing the option `current_fold`, only a single fold, instead of the entire procedure, will be performed. This is particularly useful, if one intends to train and evaluate the models for each individual fold in parallel on different machines. For example, the following command does only execute the second fold of a 5-fold CV:
+When providing the option `current_fold`, only a single fold, instead of the entire procedure, is performed. This is particularly useful, if one intends to train and evaluate the models for each individual fold in parallel on different machines. For example, the following command does only execute the second fold of a 5-fold CV:
 
     boomer --data-dir /path/to/datasets/ --dataset dataset-name --data-split 'cv{num_folds=5,current_fold=2}'
 ```
@@ -58,7 +58,7 @@ When providing the option `current_fold`, only a single fold, instead of the ent
 The configuraton described in this section should only be used for testing purposes, as the evaluation results will be highly biased and overly optimistic.
 ```
 
-Sometimes, evaluating the performance of a model on the data it has been trained on can be helpful for analyzing the behavior of a machine learning algorithm, e.g., if one needs to check if the approach is able to fit the data accurately. For this purpose, the command line API allows to use the argument `--data-split none`, which will not result in the given data to be split at all. Instead, the learning algorithm will be applied to the entire dataset and predictions will be obtained from the resulting model for the exact same data points. The argument can be specified as follows:
+Sometimes, evaluating the performance of a model on the data it has been trained on can be helpful for analyzing the behavior of a machine learning algorithm, e.g., if one needs to check if the approach is able to fit the data accurately. For this purpose, the command line API allows to use the argument `--data-split none`, which results in the given data not being split at all. Instead, the learning algorithm is applied to the entire dataset and predictions are be obtained from the resulting model for the exact same data points. The argument can be specified as follows:
 
 ```text
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --data-split none
@@ -108,7 +108,7 @@ The most common type of prediction used for multi-label classification are binar
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --prediction-type binary
 ```
 
-In a multi-label setting, the quality of binary predictions is assessed in terms of commonly used [multi-label classification metrics](https://scikit-learn.org/stable/modules/model_evaluation.html#classification-metrics) implemented by the [scikit-learn](https://scikit-learn.org) framework. If a dataset contains only a single label, the evaluation will be restricted to classification metrics that are suited for single-label classification problems.
+In a multi-label setting, the quality of binary predictions is assessed in terms of commonly used [multi-label classification metrics](https://scikit-learn.org/stable/modules/model_evaluation.html#classification-metrics) implemented by the [scikit-learn](https://scikit-learn.org) framework. If a dataset contains only a single label, the evaluation is restricted to classification metrics that are suited for single-label classification problems.
 
 ## Incremental Evaluation
 
@@ -118,13 +118,13 @@ When evaluating the predictive performance of an [ensemble method](https://en.wi
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --incremental-evaluation true
 ```
 
-When using the above command, the rule-based model that is learned by the BOOMER algorithm will be evaluated repeatedly as more rules are added to it. Evaluation results will be obtained for a model consisting of a single rule, two rules, three rules, and so on. Of course, because the evaluation is performed multiple times, this evaluation strategy comes with a large computational overhead. Therefore, depending on the size of the final model, it might be necessary to limit the number of evaluations via the following options:
+When using the above command, the rule-based model that is learned by the BOOMER algorithm is evaluated repeatedly as more rules are added to it. Evaluation results are obtained for a model consisting of a single rule, two rules, three rules, and so on. Of course, because the evaluation is performed multiple times, this evaluation strategy comes with a large computational overhead. Therefore, depending on the size of the final model, it might be necessary to limit the number of evaluations via the following options:
 
 - `min_size` specifies the minimum number of ensemble members that must be included in a model for the first evaluation to be performed.
 - `max_size` specifies the maximum number of ensemble members to be evaluated.
 - `step_size` allows to to specify after how many additional ensemble members the evaluation should be repeated.
 
-For example, the following command may be used for the incremental evaluation of a BOOMER model that consists of up to 1000 rules. The model will be evaluated for the first time after 200 rules have been added. Subsequent evaluations will be perfomed when the model comprises 400, 600, 800, and 1000 rules.
+For example, the following command may be used for the incremental evaluation of a BOOMER model that consists of up to 1000 rules. The model is evaluated for the first time after 200 rules have been added. Subsequent evaluations are perfomed when the model comprises 400, 600, 800, and 1000 rules.
 
 ```text
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --incremental-evaluation 'true{min_size=200,max_size=1000,step_size=200}'

--- a/doc/user_guide/testbed/experimental_results.md
+++ b/doc/user_guide/testbed/experimental_results.md
@@ -144,7 +144,41 @@ In addition, the following statistics regarding the labels in a dataset are prov
 
 ## Label Vectors
 
-TODO
+We refer to the unique labels combinations present for different examples in a dataset as label vectors. They can be printed by using the command line argument ``--print-label-vectors``: 
+
+```text
+boomer --data-dir /path/to/datasets/ --dataset dataset-name --print-label-vectors true
+```
+
+If you prefer writing the label vectors into an output file, the argument ``--store-label-vectors`` can be used:
+
+```text
+boomer --data-dir /path/to/datasets/ --dataset dataset-name --store-label-vectors true
+```
+
+When using {ref}`train-test-split` for splitting the available data into distinct training and test sets, a single output file is created. It stores the label vectors present in the training data:
+
+- `label_vectors_overall.csv`
+
+When using a {ref}`cross-validation`, several models are trained on different parts of the dataset. The label vectors present in each of these training sets are written into separate output files. For example, the following files result from a 5-fold cross validation:
+
+- `label_vectors_fold-1.csv`
+- `label_vectors_fold-2.csv`
+- `label_vectors_fold-3.csv`
+- `label_vectors_fold-4.csv`
+- `label_vectors_fold-5.csv`
+
+The above commands output each label vector present in a dataset, as well as their frequency, i.e., the number of examples they are associated with. Moreover, each label vector is assigned an unique index. By default, feature vectors are given in the following format, where the n-th element indicates whether the n-th label is relevant (1) or not (0):
+
+```text
+[0 0 1 1 1 0]
+```
+
+By setting the option ``sparse`` to the value ``true``, an alternative representation can be used (see {ref}`here<arguments-label-vectors>`). It consists of the indices of all relevant labels in a label vector (counting from zero and sorted in increasing order), while all irrelevant ones are omitted. Due to its compactness, this representation is particularly well-suited when dealing with a large number of labels:
+
+```text
+[2 3 4]
+```
 
 (output-model-characteristics)=
 

--- a/doc/user_guide/testbed/experimental_results.md
+++ b/doc/user_guide/testbed/experimental_results.md
@@ -89,11 +89,11 @@ When using a {ref}`cross-validation`, the data is split into several parts of wh
 
 The statistics obtained via the previous commands include the following:
 
-- The number of labels for which predictions have been obtained.
-- The percentage of labels predicted as irrelevant for all examples, indicating the sparsity of the prediction matrix.
-- The average label cardinality, i.e., the average number of labels predicted as relevant for each example.
-- The number of distinct label vectors, i.e., the number of unique label combinations, predicted for different examples.
-- The *label imbalance ratio* [^charte2013] that measures the imbalance between labels predicted as relevant and irrelevant, respectively.
+- **The number of labels:** Indicates for how many lables predictions have been obtained.
+- **The sparsity of the prediction matrix:** The percentage of labels predicted as irrelevant for all examples.
+- **The average label cardinality:** The average number of labels predicted as relevant for each example.
+- **The number of distinct label vectors:** The number of unique label combinations predicted for different examples.
+- **The label imbalance ratio:** A measure for the imbalance between labels predicted as relevant and irrelevant, respectively. [^charte2013]
 
 (output-data-characteristics)=
 
@@ -129,16 +129,16 @@ In contrast, when using a {ref}`cross-validation`, the data is split into severa
 
 The output produced by the previous commands includes the following information regarding a dataset's features:
 
-- The total number of examples contained in a dataset, as well as the number of examples per type of feature (numerical, ordinal, or nominal).
-- The sparsity among the feature values of all examples, calculated as the percentage of elements in the feature matrix that are equal to zero.
+- **The number of examples contained in a dataset:** Besides the total number, the number of examples per type of feature (numerical, ordinal, or nominal) is also given.
+- **The sparsity of the feature matrix:** This statistic calculates as the percentage of elements in the feature matrix that are equal to zero.
 
 In addition, the following statistics regarding the labels in a dataset are provided:
 
-- The total number of available labels.
-- The percentage of irrelevant labels among all examples, corresponding to the sparsity of the label matrix.
-- The average label cardinality, i.e., the average number of relevant labels per example.
-- The number of distinct label vectors, i.e., the number of unique label combinations that are present in a dataset.
-- The *label imbalance ratio* [^charte2013], which is an important metric in multi-label classification. It measures to which degree the distribution of relevant and irrelevant labels is unbalanced.
+- **The total number of available labels**
+- **The sparsity of the label matrix:** This statistic calculates as the percentage of irrelevant labels among all examples.
+- **The average label cardinality:** The average number of relevant labels per example.
+- **The number of distinct label vectors:** The number of unique label combinations present in a dataset.
+- **The label imbalance ratio:** An important metric in multi-label classification measuring to which degree the distribution of relevant and irrelevant labels is unbalanced. [^charte2013]
 
 (output-label-vectors)=
 

--- a/doc/user_guide/testbed/experimental_results.md
+++ b/doc/user_guide/testbed/experimental_results.md
@@ -268,6 +268,38 @@ Examples that satisfy all conditions in a rule's body are said to be "covered" b
 
 ## Probability Calibration Models
 
-TODO
+Some machine learning algorithms provided by this project allow to obtain probabilistic predictions. These predictions can optionally be fine-tuned via calibration models to improve the reliability of the probability estimates. We support two types of calibration models for tuning marginal and joint probabilities, respectively. If one needs to inspect these calibration models, the command line arguments ``--print-marginal-probability-calibration-model`` and ``--print-joint-probability-calibration-model`` may be helpful:
+
+```text
+boomer --data-dir /path/to/datasets/ --dataset dataset-name --print-marginal-probability-calibration-model true --print-joint-probabiliy-calibration-model true
+```
+
+Alternatively, a representations of the calibration models can be written into [.csv](https://en.wikipedia.org/wiki/Comma-separated_values) files by using the arguments ``--store-marginal-probability-calibration-model`` and ``--store-joint-probability-calibration-model``
+
+```text
+boomer --data-dir /path/to/datasets/ --dataset dataset-name --store-marginal-probability-calibration-model true --store-joint-probabiliy-calibration-model true
+```
+
+```{tip}
+All of the above commands come with options for customizing the textual representation of models. A more detailed description of these options is available {ref}`here<arguments-probability-calibration-models>`.
+```
+
+Calibration models are learned during training and depend on the training data. {ref}`train-test-split`, where only a single model is trained, result in a single file being created for each type of calibration model:
+
+- `marginal_probability_calibration_model_overall.csv`
+- `joint_probability_calibration_model_overall.csv`
+
+In contrast, a {ref}`cross-validation` produces multiple output files. Each one corresponds to a calibration model learned on the training data for an individual fold. For example, the following files are created when using a 5-fold cross validation:
+
+- `marginal_probability_calibration_model_fold-1.csv`
+- `marginal_probability_calibration_model_fold-2.csv`
+- `marginal_probability_calibration_model_fold-3.csv`
+- `marginal_probability_calibration_model_fold-4.csv`
+- `marginal_probability_calibration_model_fold-5.csv`
+- `joint_probability_calibration_model_fold-1.csv`
+- `joint_probability_calibration_model_fold-2.csv`
+- `joint_probability_calibration_model_fold-3.csv`
+- `joint_probability_calibration_model_fold-4.csv`
+- `joint_probability_calibration_model_fold-5.csv`
 
 [^charte2013]: Charte, Francisco, Antonio J. Rivera, María José del Jesus, and Francisco Herrera (2019). ‘REMEDIAL-HwR: Tackling multilabel imbalance through label decoupling and data resampling hybridization’. In: *Neurocomputing* 326-327, pp. 110–122.

--- a/doc/user_guide/testbed/experimental_results.md
+++ b/doc/user_guide/testbed/experimental_results.md
@@ -36,7 +36,7 @@ boomer --data-dir /path/to/datasets/ --dataset dataset-name --output-dir /path/t
 Depending on the {ref}`prediction-types`, the machine learning models used in an experiment are supposed to provide, the predictions stored in the resulting output files are either binary values (if binary predictions are provided), or real values (if regression scores or proability estimates are provided). When working with real-valued predictions, the option ``decimals`` may be supplied to the arguments ``--print-predictions`` and ``--store-predictions`` to specify the number of decimals that should be included in the output (see {ref}`here<arguments-predictions>` for more information).
 ```
 
-When using {ref}`train-test-split`, a single model is trained and queried for predictions for the test set. These predictions will be written into a single output file. When using an {ref}`evaluating-training-data`, predictions are also obtained for the training set and written into an additional output file. The names of the output files indicate whether the predictions have been obtained for the training or test set, respectively:
+When using {ref}`train-test-split`, a single model is trained and queried for predictions for the test set. These predictions are written into a single output file. When using an {ref}`evaluating-training-data`, predictions are also obtained for the training set and written into an additional output file. The names of the output files indicate whether the predictions have been obtained for the training or test set, respectively:
 
 - `predictions_train_overall.arff`
 - `predictions_test_overall.arff`
@@ -115,11 +115,11 @@ boomer --data-dir /path/to/datasets/ --dataset dataset-name --output-dir /path/t
 As shown {ref}`here<arguments-data-characteristics>`, the arguments ``--print-data-characteristics`` and ``--store-data-characteristics`` come with several options that allow to exclude specific statistics from the respective output. It is also possible to specify whether percentages should be prefered for presenting the statistics. Additionally, the number of decimals to be included in the output can be limited.
 ```
 
-The statistics provided by the previous commands are obtained on the training data and therefore depend on the strategy used for splitting a dataset into training and test sets. If {ref}`train-test-split` are used, a single training set is used and its characteristics will be saved to a file:
+The statistics provided by the previous commands are obtained on the training data and therefore depend on the strategy used for splitting a dataset into training and test sets. If {ref}`train-test-split` are used, a single training set is used and its characteristics are saved to a file:
 
 - `data_characteristics_overall.csv`
 
-In contrast, when using a {ref}`cross-validation`, the data is split into several parts of which each one is used once for training. As a result, multiple output files will be created in a such a scenario. For example, a 5-fold cross validation will result in the following files:
+In contrast, when using a {ref}`cross-validation`, the data is split into several parts of which each one is used once for training. As a result, multiple output files are created in a such a scenario. For example, a 5-fold cross validation results in the following files:
 
 - `data_characteristics_fold-1.csv`
 - `data_characteristics_fold-2.csv`
@@ -162,11 +162,11 @@ The above command results in a tabular representation of the characteristics bei
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --output-dir /path/to/results/ --store-model-characteristics true
 ```
 
-Model characteristics are obtained for each model training during an experiment. This means that a single output file will be created when using on {ref}`train-test-split`:
+Model characteristics are obtained for each model training during an experiment. This means that a single output file is created when using on {ref}`train-test-split`:
 
 - `model_characteristics_overall.csv`
 
-When using a {ref}`cross-validation`, several models are trained on different parts of the available data, resulting in multiple output files being saved to the output directory. For example, the following files will be created when conducting a 5-fold cross validation:
+When using a {ref}`cross-validation`, several models are trained on different parts of the available data, resulting in multiple output files being saved to the output directory. For example, the following files are created when conducting a 5-fold cross validation:
 
 - `model_characteristics_fold-1.csv`
 - `model_characteristics_fold-2.csv`
@@ -200,7 +200,7 @@ boomer --data-dir /path/to/datasets/ --dataset dataset-name --output-dir /path/t
 Both, the ``--print-rules`` and ``--store-rules`` arguments, come with several options that allow to customize the textual representation of models. An overview of these options is provided {ref}`here<arguments-output-rules>`.
 ```
 
-When using {ref}`train-test-split`, only a single model is trained. Consequently, the above command will result in a single output file being created:
+When using {ref}`train-test-split`, only a single model is trained. Consequently, the above command results in a single output file being created:
 
 - `rules_overall.csv`
 

--- a/doc/user_guide/testbed/model_persistence.md
+++ b/doc/user_guide/testbed/model_persistence.md
@@ -12,11 +12,11 @@ boomer --data-dir /path/to/datasets/ --dataset dataset-name --model-dir /path/to
 The path of the directory, where models should be saved, can be either absolute or relative to the working directory.
 ```
 
-If {ref}`train-test-split` are used for evaluating the predictive performance of models, a single model will be fit to the training data and stored in a file:
+If {ref}`train-test-split` are used for evaluating the predictive performance of models, a single model is fit to the training data and stored in a file:
 
 - `boomer.model`
 
-If a {ref}`cross-validation` is performed instead, one model is trained per cross validation fold and all of these models are stored in the specified directory. For example, a 5-fold cross validation will result in the following files:
+If a {ref}`cross-validation` is performed instead, one model is trained per cross validation fold and all of these models are stored in the specified directory. For example, a 5-fold cross validation results in the following files:
 
 - `boomer_fold-1.model`
 - `boomer_fold-2.model`
@@ -24,4 +24,4 @@ If a {ref}`cross-validation` is performed instead, one model is trained per cros
 - `boomer_fold-4.model`
 - `boomer_fold-5.model`
 
-When executing the aforementioned command again, the program will recognize the previously stored models in the specified directory. Instead of training them from scratch, the models will then be loaded from the respective files, which should be much faster than training them again.
+When executing the aforementioned command again, the program recognizes the previously stored models in the specified directory. Instead of training them from scratch, the models are then loaded from the respective files, which should be much faster than training them again.

--- a/doc/user_guide/testbed/parameter_persistence.md
+++ b/doc/user_guide/testbed/parameter_persistence.md
@@ -4,7 +4,7 @@
 
 To remember the parameters that have been used for training a model, it might be useful to save them to disk. Similar to {ref}`model-persistence`, keeping the resulting files allows to load a previously used configuration and reuse it at a later point in time.
 
-On the one hand, this requires to specify a directory where parameter settings should be saved via the command line argument `--parameter-dir`. On the other hand, the argument `--store-parameters true` instructs the program to save custom parameters that are set via command line argments (see {ref}`setting-algorithmic-parameters`). For example, the following command sets a custom value for the parameter `shrinkage`, which will be stored in an output file:
+On the one hand, this requires to specify a directory where parameter settings should be saved via the command line argument `--parameter-dir`. On the other hand, the argument `--store-parameters true` instructs the program to save custom parameters that are set via command line argments (see {ref}`setting-algorithmic-parameters`). For example, the following command sets a custom value for the parameter `shrinkage`, which is stored in an output file:
 
 ```text
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --parameter-dir /path/to/parameters --store-parameters true --shrinkage 0.5
@@ -14,11 +14,11 @@ boomer --data-dir /path/to/datasets/ --dataset dataset-name --parameter-dir /pat
 The path of the directory, where parameter settings should be saved, can be either absolute or relative to the working directory.
 ```
 
-If {ref}`train-test-split` are used for splitting the available data into training and test sets, a single model will be trained and its configuration will be saved to a file:
+If {ref}`train-test-split` are used for splitting the available data into training and test sets, a single model is trained and its configuration is saved to a file:
 
 - `parameters_overall.csv`
 
-If a {ref}`cross-validation` is performed instead, one model is trained per cross validation fold and the configurations of all of these models are stored in the specified directory. For example, a 5-fold cross validation will result in the following files:
+If a {ref}`cross-validation` is performed instead, one model is trained per cross validation fold and the configurations of all of these models are stored in the specified directory. For example, a 5-fold cross validation results in the following files:
 
 - `parameters_fold-1.csv`
 - `parameters_fold-2.csv`
@@ -30,7 +30,7 @@ If a {ref}`cross-validation` is performed instead, one model is trained per cros
 Only parameters with custom values are included in the output files. Parameters for which the default value is used are not included.
 ```
 
-When executing the previously mentioned command again, the program will restore the parameter settings from the files that are found in the specified directory. This allows to omit the respective parameters from the command line. If a parameter is included in both, the loaded file and the command line arguments, the latter takes precedence.
+When executing the previously mentioned command again, the program restores the parameter settings from the files that are found in the specified directory. This allows to omit the respective parameters from the command line. If a parameter is included in both, the loaded file and the command line arguments, the latter takes precedence.
 
 If you want to print all custom parameters that are used by a learning algorithm on the console, you can specify the argument `--print-parameters true`:
 

--- a/doc/user_guide/testbed/pre_processing.md
+++ b/doc/user_guide/testbed/pre_processing.md
@@ -2,7 +2,7 @@
 
 # Data Pre-Processing
 
-Depending on the dataset at hand, it might be desirable to apply pre-processing techniques to the data before training a machine learning model. The pre-processing techniques that are supported are discussed in the following. When using such a technique, it will be applied to the training and test sets (see {ref}`evaluation`), before training a model and querying it for predictions, respectively.
+Depending on the dataset at hand, it might be desirable to apply pre-processing techniques to the data before training a machine learning model. The pre-processing techniques that are supported are discussed in the following. When using such a technique, it is applied to the training and test sets (see {ref}`evaluation`), before training a model and querying it for predictions, respectively.
 
 ## One-Hot-Encoding
 
@@ -10,7 +10,7 @@ Depending on the dataset at hand, it might be desirable to apply pre-processing 
 When using the algorithms provided by this project, the use of one-hot-encoding is typically not adviced, as they can deal with nominal and binary features in a more efficient way. However, as argued below, it might still be useful for a fair comparison with machine learning approaches that cannot deal with such features.
 ```
 
-Not all machine learning methods can deal with nominal or binary features out-of-the-box. In such cases, it is necessary to pre-process the available data in order to convert these features into numerical ones. The most commonly used technique for this purpose is referred to as [one-hot-encoding](https://en.wikipedia.org/wiki/One-hot). It will replace each feature that comes with a predefined set of discrete values, with several numerical features corresponding to each of the potential values. The values for these newly added features will be set to `1`, if an original data point was associated with the corresponding nominal value, or `0` otherwise. Because the resulting dataset will typically entail more features than the original one, the use of one-hot-encoding often increases the computational costs and time needed for training a machine learning model.
+Not all machine learning methods can deal with nominal or binary features out-of-the-box. In such cases, it is necessary to pre-process the available data in order to convert these features into numerical ones. The most commonly used technique for this purpose is referred to as [one-hot-encoding](https://en.wikipedia.org/wiki/One-hot). It replaces each feature that comes with a predefined set of discrete values, with several numerical features corresponding to each of the potential values. The values for these newly added features are set to `1`, if an original data point was associated with the corresponding nominal value, or `0` otherwise. Because the resulting dataset typically entails more features than the original one, the use of one-hot-encoding often increases the computational costs and time needed for training a machine learning model.
 
 Even though nominal and binary features are natively supported in an efficient way by all algorithms provided by this project, it might still be useful to use one-hot-encoding if one seeks for a fair comparison with machine learning approaches that cannot deal with such features. In such cases, you can provide the argument `--one-hot-encoding true` to the command line API:
 
@@ -18,4 +18,4 @@ Even though nominal and binary features are natively supported in an efficient w
 boomer --data-dir /path/to/datasets/ --dataset dataset-name --one-hot-encoding true
 ```
 
-Under the hood, the program will make use of scikit-learn's [OneHotEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html) for pre-processing the data.
+Under the hood, the program makes use of scikit-learn's [OneHotEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html) for pre-processing the data.


### PR DESCRIPTION
Adds the sections "Label Vectors" and "Probability Calibration Models" to the documentation of the command line API.