### PR TITLE
Update dependency "scikit-learn" to version 1.4

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 liac-arff >= 2.5, < 2.6
 numpy >= 1.26, < 1.27
-scikit-learn >=1.3, < 1.4
+scikit-learn >=1.4, < 1.5
 scipy >= 1.13, < 1.14
 tabulate >= 0.9, < 0.10

--- a/python/subprojects/testbed/tests/res/out/boomer/binary-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/binary-features-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         62.64
+Example-wise F1         43.07
 Example-wise Jaccard    31.28
 Example-wise Precision  61.51
 Example-wise Recall     36.12
 Hamming Accuracy        94.68
 Hamming Loss             5.32
-Macro F1                14.35
+Macro F1                10.58
 Macro Jaccard            7.81
 Macro Precision         88.88
 Macro Recall             9.27

--- a/python/subprojects/testbed/tests/res/out/boomer/binary-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/binary-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         62.64
+Example-wise F1         43.07
 Example-wise Jaccard    31.28
 Example-wise Precision  61.51
 Example-wise Recall     36.12
 Hamming Accuracy        94.68
 Hamming Loss             5.32
-Macro F1                14.35
+Macro F1                10.58
 Macro Jaccard            7.81
 Macro Precision         88.88
 Macro Recall             9.27

--- a/python/subprojects/testbed/tests/res/out/boomer/evaluation_cross-validation-predefined.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/evaluation_cross-validation-predefined.txt
@@ -22,7 +22,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         68.25
+Example-wise F1         61.47
 Example-wise Jaccard    51.98
 Example-wise Precision  78.53
 Example-wise Recall     62.15
@@ -50,7 +50,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 2):
 
-Example-wise F1         73.95
+Example-wise F1         62.09
 Example-wise Jaccard    54.52
 Example-wise Precision  74.58
 Example-wise Recall     63.56
@@ -78,7 +78,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 3):
 
-Example-wise F1         73.22
+Example-wise F1         59.89
 Example-wise Jaccard    51.39
 Example-wise Precision  74.17
 Example-wise Recall     61.11
@@ -106,7 +106,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 4):
 
-Example-wise F1         75.65
+Example-wise F1         62.09
 Example-wise Jaccard    54.24
 Example-wise Precision  74.01
 Example-wise Recall     62.99
@@ -134,7 +134,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 5):
 
-Example-wise F1         77.29
+Example-wise F1         63.73
 Example-wise Jaccard    57.63
 Example-wise Precision  80.23
 Example-wise Recall     62.15
@@ -162,7 +162,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 6):
 
-Example-wise F1         75.76
+Example-wise F1         58.81
 Example-wise Jaccard    52.4
 Example-wise Precision  71.75
 Example-wise Recall     60.17
@@ -190,7 +190,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 7):
 
-Example-wise F1         72.89
+Example-wise F1         61.22
 Example-wise Jaccard    53.33
 Example-wise Precision  77.78
 Example-wise Recall     59.72
@@ -218,7 +218,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 8):
 
-Example-wise F1         76.72
+Example-wise F1         66.55
 Example-wise Jaccard    58.9
 Example-wise Precision  78.81
 Example-wise Recall     69.21
@@ -246,7 +246,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 9):
 
-Example-wise F1         68.64
+Example-wise F1         58.47
 Example-wise Jaccard    50
 Example-wise Precision  77.12
 Example-wise Recall     60.17
@@ -274,7 +274,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 10):
 
-Example-wise F1         72.22
+Example-wise F1         55.56
 Example-wise Jaccard    48.06
 Example-wise Precision  71.94
 Example-wise Recall     55.28
@@ -293,7 +293,7 @@ Subset Accuracy         25
 
 INFO Evaluation result for test data (Average across 10 folds):
 
-Example-wise F1         73.46  ±2.96
+Example-wise F1         60.99  ±2.88
 Example-wise Jaccard    53.24  ±3.11
 Example-wise Precision  75.89  ±2.83
 Example-wise Recall     61.65  ±3.35

--- a/python/subprojects/testbed/tests/res/out/boomer/evaluation_cross-validation.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/evaluation_cross-validation.txt
@@ -13,7 +13,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.06
+Example-wise F1         61.06
 Example-wise Jaccard    53.19
 Example-wise Precision  83.61
 Example-wise Recall     60.56
@@ -41,7 +41,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 2):
 
-Example-wise F1         72
+Example-wise F1         65.33
 Example-wise Jaccard    55.83
 Example-wise Precision  83.06
 Example-wise Recall     64.44
@@ -69,7 +69,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 3):
 
-Example-wise F1         66
+Example-wise F1         51
 Example-wise Jaccard    43.33
 Example-wise Precision  73.61
 Example-wise Recall     50.83
@@ -97,7 +97,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 4):
 
-Example-wise F1         72.15
+Example-wise F1         55.2
 Example-wise Jaccard    48.59
 Example-wise Precision  73.45
 Example-wise Recall     55.93
@@ -125,7 +125,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 5):
 
-Example-wise F1         70.51
+Example-wise F1         62.03
 Example-wise Jaccard    53.67
 Example-wise Precision  80.51
 Example-wise Recall     61.86
@@ -153,7 +153,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 6):
 
-Example-wise F1         74.12
+Example-wise F1         57.18
 Example-wise Jaccard    50.56
 Example-wise Precision  72.6
 Example-wise Recall     58.19
@@ -181,7 +181,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 7):
 
-Example-wise F1         72.99
+Example-wise F1         62.82
 Example-wise Jaccard    55.23
 Example-wise Precision  76.55
 Example-wise Recall     66.1
@@ -209,7 +209,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 8):
 
-Example-wise F1         74.92
+Example-wise F1         66.44
 Example-wise Jaccard    58.47
 Example-wise Precision  77.4
 Example-wise Recall     69.49
@@ -237,7 +237,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 9):
 
-Example-wise F1         73.79
+Example-wise F1         55.14
 Example-wise Jaccard    46.19
 Example-wise Precision  69.21
 Example-wise Recall     53.67
@@ -265,7 +265,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 10):
 
-Example-wise F1         74.35
+Example-wise F1         55.71
 Example-wise Jaccard    49.29
 Example-wise Precision  75.42
 Example-wise Recall     52.82
@@ -284,7 +284,7 @@ Subset Accuracy         32.2
 
 INFO Evaluation result for test data (Average across 10 folds):
 
-Example-wise F1         71.69  ±3.09
+Example-wise F1         59.19  ±4.80
 Example-wise Jaccard    51.44  ±4.45
 Example-wise Precision  76.54  ±4.45
 Example-wise Recall     59.39  ±5.85

--- a/python/subprojects/testbed/tests/res/out/boomer/evaluation_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/evaluation_incremental.txt
@@ -12,7 +12,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         53.1
+Example-wise F1         41.36
 Example-wise Jaccard    34.78
 Example-wise Precision  83.93
 Example-wise Recall     37.41
@@ -33,7 +33,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         64.2
+Example-wise F1         52.46
 Example-wise Jaccard    45.96
 Example-wise Precision  82.27
 Example-wise Recall     50.17
@@ -54,7 +54,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         66.97
+Example-wise F1         56.76
 Example-wise Jaccard    50
 Example-wise Precision  81.59
 Example-wise Recall     55.87
@@ -75,7 +75,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         67.26
+Example-wise F1         55.53
 Example-wise Jaccard    48.85
 Example-wise Precision  79.76
 Example-wise Recall     54.93
@@ -96,7 +96,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         69.61
+Example-wise F1         57.36
 Example-wise Jaccard    50.43
 Example-wise Precision  78.66
 Example-wise Recall     56.89
@@ -117,7 +117,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         69.95
+Example-wise F1         58.21
 Example-wise Jaccard    51.45
 Example-wise Precision  78.74
 Example-wise Recall     57.74
@@ -138,7 +138,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         69.76
+Example-wise F1         57.52
 Example-wise Jaccard    50.89
 Example-wise Precision  78.32
 Example-wise Recall     57.14
@@ -159,7 +159,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         68.47
+Example-wise F1         57.24
 Example-wise Jaccard    50.77
 Example-wise Precision  79.34
 Example-wise Recall     57.14
@@ -180,7 +180,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         68.59
+Example-wise F1         57.36
 Example-wise Jaccard    50.64
 Example-wise Precision  79
 Example-wise Recall     57.4
@@ -201,7 +201,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         69.15
+Example-wise F1         58.44
 Example-wise Jaccard    51.57
 Example-wise Precision  79.85
 Example-wise Recall     58.5
@@ -222,7 +222,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         69.64
+Example-wise F1         58.93
 Example-wise Jaccard    51.83
 Example-wise Precision  79.59
 Example-wise Recall     58.84
@@ -243,7 +243,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         68.28
+Example-wise F1         58.59
 Example-wise Jaccard    51.57
 Example-wise Precision  80.36
 Example-wise Recall     59.01
@@ -264,7 +264,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         67.74
+Example-wise F1         58.55
 Example-wise Jaccard    51.66
 Example-wise Precision  80.95
 Example-wise Recall     59.01
@@ -285,7 +285,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         67.52
+Example-wise F1         58.33
 Example-wise Jaccard    51.15
 Example-wise Precision  81.04
 Example-wise Recall     58.59
@@ -306,7 +306,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         67.23
+Example-wise F1         58.55
 Example-wise Jaccard    51.49
 Example-wise Precision  81.38
 Example-wise Recall     58.93
@@ -327,7 +327,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         68.06
+Example-wise F1         58.88
 Example-wise Jaccard    51.7
 Example-wise Precision  80.61
 Example-wise Recall     59.44
@@ -348,7 +348,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         67.33
+Example-wise F1         59.17
 Example-wise Jaccard    52
 Example-wise Precision  81.04
 Example-wise Recall     59.95
@@ -369,7 +369,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         68.15
+Example-wise F1         59.47
 Example-wise Jaccard    52.17
 Example-wise Precision  80.44
 Example-wise Recall     60.37
@@ -390,7 +390,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         68.06
+Example-wise F1         59.9
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.88
@@ -411,7 +411,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/evaluation_single-fold.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/evaluation_single-fold.txt
@@ -13,7 +13,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.06
+Example-wise F1         61.06
 Example-wise Jaccard    53.19
 Example-wise Precision  83.61
 Example-wise Recall     60.56

--- a/python/subprojects/testbed/tests/res/out/boomer/evaluation_train-test-predefined.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/evaluation_train-test-predefined.txt
@@ -13,7 +13,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         74.62
+Example-wise F1         59.27
 Example-wise Jaccard    51.53
 Example-wise Precision  73.43
 Example-wise Recall     59.41

--- a/python/subprojects/testbed/tests/res/out/boomer/evaluation_train-test.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/evaluation_train-test.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/evaluation_training-data.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/evaluation_training-data.txt
@@ -35,7 +35,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/example-wise-complete-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/example-wise-complete-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         83.27
+Example-wise F1         65.41
 Example-wise Jaccard    57.65
 Example-wise Precision  72.19
 Example-wise Recall     64.97
@@ -35,7 +35,7 @@ INFO Model characteristics:
 │ Statistics about conditions   │   Total │   Numerical <= operator │   Numerical > operator │   Ordinal <= operator │   Ordinal > operator │   Nominal == operator │   Nominal != operator │
 ├───────────────────────────────┼─────────┼─────────────────────────┼────────────────────────┼───────────────────────┼──────────────────────┼───────────────────────┼───────────────────────┤
 │ Default rule                  │       0 │                   0.00% │                  0.00% │                 0.00% │                0.00% │                 0.00% │                 0.00% │
-│ 999 local rules               │   10661 │                  55.43% │                 44.57% │                 0.00% │                0.00% │                 0.00% │                 0.00% │
+│ 999 local rules               │   10661 │                  55.45% │                 44.55% │                 0.00% │                0.00% │                 0.00% │                 0.00% │
 └───────────────────────────────┴─────────┴─────────────────────────┴────────────────────────┴───────────────────────┴──────────────────────┴───────────────────────┴───────────────────────┘
 
 ┌────────────────────────────────┬─────────┬────────────┬────────────┐

--- a/python/subprojects/testbed/tests/res/out/boomer/example-wise-complete-heads_equal-width-label-binning.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/example-wise-complete-heads_equal-width-label-binning.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         81.8
+Example-wise F1         65.48
 Example-wise Jaccard    56.97
 Example-wise Precision  72.45
 Example-wise Recall     65.39

--- a/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-dynamic-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-dynamic-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.84
+Example-wise F1         60.39
 Example-wise Jaccard    52.51
 Example-wise Precision  67.6
 Example-wise Recall     59.1

--- a/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-dynamic-heads_equal-width-label-binning.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-dynamic-heads_equal-width-label-binning.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.91
+Example-wise F1         65.56
 Example-wise Jaccard    57.53
 Example-wise Precision  72.19
 Example-wise Recall     64.71

--- a/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-fixed-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-fixed-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.47
+Example-wise F1         63.08
 Example-wise Jaccard    54.97
 Example-wise Precision  71
 Example-wise Recall     61.39

--- a/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-fixed-heads_equal-width-label-binning.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/example-wise-partial-fixed-heads_equal-width-label-binning.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.18
+Example-wise F1         63.81
 Example-wise Jaccard    55.53
 Example-wise Precision  71.34
 Example-wise Recall     62.76

--- a/python/subprojects/testbed/tests/res/out/boomer/example-wise-single-label-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/example-wise-single-label-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.01
+Example-wise F1         63.13
 Example-wise Jaccard    54.85
 Example-wise Precision  72.02
 Example-wise Recall     61.14

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_binary-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_binary-features-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         62.64
+Example-wise F1         43.07
 Example-wise Jaccard    31.28
 Example-wise Precision  61.51
 Example-wise Recall     36.12
 Hamming Accuracy        94.68
 Hamming Loss             5.32
-Macro F1                14.35
+Macro F1                10.58
 Macro Jaccard            7.81
 Macro Precision         88.88
 Macro Recall             9.27

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_binary-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_binary-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         62.64
+Example-wise F1         43.07
 Example-wise Jaccard    31.28
 Example-wise Precision  61.51
 Example-wise Recall     36.12
 Hamming Accuracy        94.68
 Hamming Loss             5.32
-Macro F1                14.35
+Macro F1                10.58
 Macro Jaccard            7.81
 Macro Precision         88.88
 Macro Recall             9.27

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_nominal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_nominal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.67
+Example-wise F1         57.38
 Example-wise Jaccard    49.15
 Example-wise Precision  73.64
 Example-wise Recall     56.8

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_nominal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_nominal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.86
+Example-wise F1         54.08
 Example-wise Jaccard    46.6
 Example-wise Precision  76.79
 Example-wise Recall     53.32

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_numerical-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_numerical-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         66.68
+Example-wise F1         57.5
 Example-wise Jaccard    49.57
 Example-wise Precision  80.61
 Example-wise Recall     56.46

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_numerical-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-frequency_numerical-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         66.68
+Example-wise F1         56.48
 Example-wise Jaccard    48.81
 Example-wise Precision  79.42
 Example-wise Recall     55.7

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_binary-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_binary-features-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         62.64
+Example-wise F1         43.07
 Example-wise Jaccard    31.28
 Example-wise Precision  61.51
 Example-wise Recall     36.12
 Hamming Accuracy        94.68
 Hamming Loss             5.32
-Macro F1                14.35
+Macro F1                10.58
 Macro Jaccard            7.81
 Macro Precision         88.88
 Macro Recall             9.27

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_binary-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_binary-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         62.64
+Example-wise F1         43.07
 Example-wise Jaccard    31.28
 Example-wise Precision  61.51
 Example-wise Recall     36.12
 Hamming Accuracy        94.68
 Hamming Loss             5.32
-Macro F1                14.35
+Macro F1                10.58
 Macro Jaccard            7.81
 Macro Precision         88.88
 Macro Recall             9.27

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_nominal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_nominal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.67
+Example-wise F1         57.38
 Example-wise Jaccard    49.15
 Example-wise Precision  73.64
 Example-wise Recall     56.8

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_nominal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_nominal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.86
+Example-wise F1         54.08
 Example-wise Jaccard    46.6
 Example-wise Precision  76.79
 Example-wise Recall     53.32

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_numerical-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_numerical-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         63.64
+Example-wise F1         51.9
 Example-wise Jaccard    44.73
 Example-wise Precision  78.91
 Example-wise Recall     50.85

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_numerical-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-binning-equal-width_numerical-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         63.64
+Example-wise F1         51.9
 Example-wise Jaccard    44.73
 Example-wise Precision  78.91
 Example-wise Recall     50.85

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-sampling-no.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-sampling-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.34
+Example-wise F1         58.61
 Example-wise Jaccard    50.64
 Example-wise Precision  77.81
 Example-wise Recall     57.82

--- a/python/subprojects/testbed/tests/res/out/boomer/feature-sampling-without-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/feature-sampling-without-replacement.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-no.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-stratified-example-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-stratified-example-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         66.99
+Example-wise F1         56.28
 Example-wise Jaccard    48.43
 Example-wise Precision  79
 Example-wise Recall     55.95

--- a/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-stratified-label-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-stratified-label-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.83
+Example-wise F1         58.11
 Example-wise Jaccard    50.81
 Example-wise Precision  79.34
 Example-wise Recall     57.82

--- a/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-with-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-with-replacement.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         66.24
+Example-wise F1         56.04
 Example-wise Jaccard    48.68
 Example-wise Precision  79.17
 Example-wise Recall     56.12

--- a/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-without-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/instance-sampling-without-replacement.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.76
+Example-wise F1         60.09
 Example-wise Jaccard    52.51
 Example-wise Precision  80.1
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/boomer/label-format-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-format-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/label-format-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-format-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/label-sampling-no.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-sampling-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/label-sampling-round-robin.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-sampling-round-robin.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.99
+Example-wise F1         57.79
 Example-wise Jaccard    49.79
 Example-wise Precision  79.25
 Example-wise Recall     56.89

--- a/python/subprojects/testbed/tests/res/out/boomer/label-sampling-without-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-sampling-without-replacement.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.62
+Example-wise F1         59.95
 Example-wise Jaccard    52.59
 Example-wise Precision  80.27
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/label-wise-complete-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-wise-complete-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         74.51
+Example-wise F1         62.77
 Example-wise Jaccard    55.06
 Example-wise Precision  78.06
 Example-wise Recall     62.41

--- a/python/subprojects/testbed/tests/res/out/boomer/label-wise-complete-heads_equal-width-label-binning.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-wise-complete-heads_equal-width-label-binning.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         75.41
+Example-wise F1         63.67
 Example-wise Jaccard    55.91
 Example-wise Precision  77.21
 Example-wise Recall     63.78

--- a/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-dynamic-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-dynamic-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.53
+Example-wise F1         62.33
 Example-wise Jaccard    54.08
 Example-wise Precision  78.32
 Example-wise Recall     62.24

--- a/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-dynamic-heads_equal-width-label-binning.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-dynamic-heads_equal-width-label-binning.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.74
+Example-wise F1         58.55
 Example-wise Jaccard    50.72
 Example-wise Precision  81.63
 Example-wise Recall     56.72

--- a/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-fixed-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-fixed-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.45
+Example-wise F1         60.73
 Example-wise Jaccard    52.34
 Example-wise Precision  77.81
 Example-wise Recall     60.54

--- a/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-fixed-heads_equal-width-label-binning.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-wise-partial-fixed-heads_equal-width-label-binning.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.68
+Example-wise F1         62.51
 Example-wise Jaccard    55.57
 Example-wise Precision  80.48
 Example-wise Recall     63.18

--- a/python/subprojects/testbed/tests/res/out/boomer/label-wise-single-label-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/label-wise-single-label-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/loss-logistic-example-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/loss-logistic-example-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         81.8
+Example-wise F1         65.48
 Example-wise Jaccard    56.97
 Example-wise Precision  72.45
 Example-wise Recall     65.39

--- a/python/subprojects/testbed/tests/res/out/boomer/loss-logistic-label-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/loss-logistic-label-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/loss-squared-error-example-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/loss-squared-error-example-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.09
+Example-wise F1         56.58
 Example-wise Jaccard    49.04
 Example-wise Precision  61.39
 Example-wise Recall     56.89

--- a/python/subprojects/testbed/tests/res/out/boomer/loss-squared-error-label-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/loss-squared-error-label-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.49
+Example-wise F1         58.78
 Example-wise Jaccard    50.98
 Example-wise Precision  78.57
 Example-wise Recall     58.08

--- a/python/subprojects/testbed/tests/res/out/boomer/loss-squared-hinge-example-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/loss-squared-hinge-example-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.23
+Example-wise F1         58.76
 Example-wise Jaccard    51.28
 Example-wise Precision  63.78
 Example-wise Recall     58.76

--- a/python/subprojects/testbed/tests/res/out/boomer/loss-squared-hinge-label-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/loss-squared-hinge-label-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.57
+Example-wise F1         54.8
 Example-wise Jaccard    47.19
 Example-wise Precision  75.85
 Example-wise Recall     54

--- a/python/subprojects/testbed/tests/res/out/boomer/model-persistence_cross-validation.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/model-persistence_cross-validation.txt
@@ -11,7 +11,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.06
+Example-wise F1         61.06
 Example-wise Jaccard    53.19
 Example-wise Precision  83.61
 Example-wise Recall     60.56
@@ -37,7 +37,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 2):
 
-Example-wise F1         72
+Example-wise F1         65.33
 Example-wise Jaccard    55.83
 Example-wise Precision  83.06
 Example-wise Recall     64.44
@@ -63,7 +63,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 3):
 
-Example-wise F1         66
+Example-wise F1         51
 Example-wise Jaccard    43.33
 Example-wise Precision  73.61
 Example-wise Recall     50.83
@@ -89,7 +89,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 4):
 
-Example-wise F1         72.15
+Example-wise F1         55.2
 Example-wise Jaccard    48.59
 Example-wise Precision  73.45
 Example-wise Recall     55.93
@@ -115,7 +115,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 5):
 
-Example-wise F1         70.51
+Example-wise F1         62.03
 Example-wise Jaccard    53.67
 Example-wise Precision  80.51
 Example-wise Recall     61.86
@@ -141,7 +141,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 6):
 
-Example-wise F1         74.12
+Example-wise F1         57.18
 Example-wise Jaccard    50.56
 Example-wise Precision  72.6
 Example-wise Recall     58.19
@@ -167,7 +167,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 7):
 
-Example-wise F1         72.99
+Example-wise F1         62.82
 Example-wise Jaccard    55.23
 Example-wise Precision  76.55
 Example-wise Recall     66.1
@@ -193,7 +193,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 8):
 
-Example-wise F1         74.92
+Example-wise F1         66.44
 Example-wise Jaccard    58.47
 Example-wise Precision  77.4
 Example-wise Recall     69.49
@@ -219,7 +219,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 9):
 
-Example-wise F1         73.79
+Example-wise F1         55.14
 Example-wise Jaccard    46.19
 Example-wise Precision  69.21
 Example-wise Recall     53.67
@@ -245,7 +245,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 10):
 
-Example-wise F1         74.35
+Example-wise F1         55.71
 Example-wise Jaccard    49.29
 Example-wise Precision  75.42
 Example-wise Recall     52.82
@@ -264,7 +264,7 @@ Subset Accuracy         32.2
 
 INFO Evaluation result for test data (Average across 10 folds):
 
-Example-wise F1         71.69  ±3.09
+Example-wise F1         59.19  ±4.80
 Example-wise Jaccard    51.44  ±4.45
 Example-wise Precision  76.54  ±4.45
 Example-wise Recall     59.39  ±5.85

--- a/python/subprojects/testbed/tests/res/out/boomer/model-persistence_single-fold.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/model-persistence_single-fold.txt
@@ -11,7 +11,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.06
+Example-wise F1         61.06
 Example-wise Jaccard    53.19
 Example-wise Precision  83.61
 Example-wise Recall     60.56

--- a/python/subprojects/testbed/tests/res/out/boomer/model-persistence_train-test.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/model-persistence_train-test.txt
@@ -10,7 +10,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/no-default-rule.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/no-default-rule.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.09
+Example-wise F1         58.35
 Example-wise Jaccard    50.3
 Example-wise Precision  78.23
 Example-wise Recall     57.23

--- a/python/subprojects/testbed/tests/res/out/boomer/nominal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/nominal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.67
+Example-wise F1         57.38
 Example-wise Jaccard    49.15
 Example-wise Precision  73.64
 Example-wise Recall     56.8

--- a/python/subprojects/testbed/tests/res/out/boomer/nominal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/nominal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.86
+Example-wise F1         54.08
 Example-wise Jaccard    46.6
 Example-wise Precision  76.79
 Example-wise Recall     53.32

--- a/python/subprojects/testbed/tests/res/out/boomer/numeric-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/numeric-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         21.96
+Example-wise F1         19.47
 Example-wise Jaccard    19.16
 Example-wise Precision  97.51
 Example-wise Recall     19.16

--- a/python/subprojects/testbed/tests/res/out/boomer/numeric-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/numeric-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         19.57
+Example-wise F1         17.91
 Example-wise Jaccard    17.67
 Example-wise Precision  98.34
 Example-wise Recall     17.67
 Hamming Accuracy        98.48
 Hamming Loss             1.52
-Macro F1                10.68
+Macro F1                 9.34
 Macro Jaccard            8.77
 Macro Precision         97.02
 Macro Recall             8.84

--- a/python/subprojects/testbed/tests/res/out/boomer/ordinal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/ordinal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.82
+Example-wise F1         59.59
 Example-wise Jaccard    51.83
 Example-wise Precision  77.47
 Example-wise Recall     59.35

--- a/python/subprojects/testbed/tests/res/out/boomer/ordinal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/ordinal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.33
+Example-wise F1         62.12
 Example-wise Jaccard    54.17
 Example-wise Precision  78.19
 Example-wise Recall     62.5

--- a/python/subprojects/testbed/tests/res/out/boomer/post-pruning_no-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/post-pruning_no-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/post-pruning_random-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/post-pruning_random-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.95
+Example-wise F1         56.68
 Example-wise Jaccard    49.06
 Example-wise Precision  78.32
 Example-wise Recall     55.61

--- a/python/subprojects/testbed/tests/res/out/boomer/post-pruning_stratified-example-wise-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/post-pruning_stratified-example-wise-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.42
+Example-wise F1         54.64
 Example-wise Jaccard    47.07
 Example-wise Precision  75.94
 Example-wise Recall     54.34

--- a/python/subprojects/testbed/tests/res/out/boomer/post-pruning_stratified-label-wise-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/post-pruning_stratified-label-wise-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         66.38
+Example-wise F1         56.17
 Example-wise Jaccard    48.68
 Example-wise Precision  79.68
 Example-wise Recall     55.7

--- a/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_no-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_no-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_random-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_random-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.95
+Example-wise F1         56.68
 Example-wise Jaccard    49.06
 Example-wise Precision  78.32
 Example-wise Recall     55.61

--- a/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_stratified-example-wise-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_stratified-example-wise-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.42
+Example-wise F1         54.64
 Example-wise Jaccard    47.07
 Example-wise Precision  75.94
 Example-wise Recall     54.34

--- a/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_stratified-label-wise-holdout.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/pre-pruning_stratified-label-wise-holdout.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         66.38
+Example-wise F1         56.17
 Example-wise Jaccard    48.68
 Example-wise Precision  79.68
 Example-wise Recall     55.7

--- a/python/subprojects/testbed/tests/res/out/boomer/prediction-format-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/prediction-format-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/prediction-format-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/prediction-format-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.48
+Example-wise F1         65.65
 Example-wise Jaccard    57.65
 Example-wise Precision  72.62
 Example-wise Recall     65.39

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_based-on-probabilities.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_based-on-probabilities.txt
@@ -10,7 +10,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         80.6
+Example-wise F1         45.9
 Example-wise Jaccard    37.77
 Example-wise Precision  56.04
 Example-wise Recall     42.35

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_incremental.txt
@@ -12,7 +12,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         81.16
+Example-wise F1         53.61
 Example-wise Jaccard    44.98
 Example-wise Precision  68.11
 Example-wise Recall     47.62
@@ -33,7 +33,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         82.69
+Example-wise F1         60.24
 Example-wise Jaccard    52.13
 Example-wise Precision  71.77
 Example-wise Recall     56.12
@@ -54,7 +54,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         82.28
+Example-wise F1         64.42
 Example-wise Jaccard    56.25
 Example-wise Precision  74.49
 Example-wise Recall     61.73
@@ -75,7 +75,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         82.14
+Example-wise F1         63.78
 Example-wise Jaccard    55.48
 Example-wise Precision  73.47
 Example-wise Recall     61.31
@@ -96,7 +96,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         81.97
+Example-wise F1         64.63
 Example-wise Jaccard    56.42
 Example-wise Precision  73.38
 Example-wise Recall     63.01
@@ -117,7 +117,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         81.84
+Example-wise F1         65.51
 Example-wise Jaccard    57.4
 Example-wise Precision  73.89
 Example-wise Recall     64.12
@@ -138,7 +138,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         82.24
+Example-wise F1         64.9
 Example-wise Jaccard    56.93
 Example-wise Precision  72.96
 Example-wise Recall     63.61
@@ -159,7 +159,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         82.91
+Example-wise F1         64.03
 Example-wise Jaccard    56.38
 Example-wise Precision  71.43
 Example-wise Recall     63.18
@@ -180,7 +180,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         82.26
+Example-wise F1         64.4
 Example-wise Jaccard    56.42
 Example-wise Precision  72.11
 Example-wise Recall     63.61
@@ -201,7 +201,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         82.24
+Example-wise F1         65.41
 Example-wise Jaccard    57.27
 Example-wise Precision  73.72
 Example-wise Recall     64.2
@@ -222,7 +222,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         81.89
+Example-wise F1         65.05
 Example-wise Jaccard    56.76
 Example-wise Precision  73.47
 Example-wise Recall     63.78
@@ -243,7 +243,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         81.89
+Example-wise F1         65.05
 Example-wise Jaccard    56.76
 Example-wise Precision  73.21
 Example-wise Recall     64.2
@@ -264,7 +264,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         82.53
+Example-wise F1         65.19
 Example-wise Jaccard    57.1
 Example-wise Precision  72.79
 Example-wise Recall     64.46
@@ -285,7 +285,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         81.8
+Example-wise F1         64.97
 Example-wise Jaccard    56.59
 Example-wise Precision  73.38
 Example-wise Recall     64.03
@@ -306,7 +306,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         82.28
+Example-wise F1         64.93
 Example-wise Jaccard    56.76
 Example-wise Precision  72.7
 Example-wise Recall     64.2
@@ -327,7 +327,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         82.35
+Example-wise F1         64.49
 Example-wise Jaccard    56.38
 Example-wise Precision  71.94
 Example-wise Recall     64.12
@@ -348,7 +348,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         82.09
+Example-wise F1         65.26
 Example-wise Jaccard    57.06
 Example-wise Precision  72.7
 Example-wise Recall     64.88
@@ -369,7 +369,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         82.4
+Example-wise F1         64.54
 Example-wise Jaccard    56.46
 Example-wise Precision  71.6
 Example-wise Recall     64.54
@@ -390,7 +390,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         82.57
+Example-wise F1         64.71
 Example-wise Jaccard    56.72
 Example-wise Precision  71.34
 Example-wise Recall     64.88
@@ -411,7 +411,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         82.48
+Example-wise F1         65.65
 Example-wise Jaccard    57.65
 Example-wise Precision  72.62
 Example-wise Recall     65.39

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_incremental_based-on-probabilities.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_incremental_based-on-probabilities.txt
@@ -10,7 +10,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         88.49
+Example-wise F1         27.77
 Example-wise Jaccard    22.36
 Example-wise Precision  37.5
 Example-wise Recall     23.3
@@ -31,7 +31,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         86.05
+Example-wise F1         35.03
 Example-wise Jaccard    28.66
 Example-wise Precision  44.64
 Example-wise Recall     30.61
@@ -52,7 +52,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         83.66
+Example-wise F1         41.31
 Example-wise Jaccard    34.27
 Example-wise Precision  51.45
 Example-wise Recall     36.82
@@ -73,7 +73,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         81.28
+Example-wise F1         43.01
 Example-wise Jaccard    34.99
 Example-wise Precision  53.23
 Example-wise Recall     38.95
@@ -94,7 +94,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         80.24
+Example-wise F1         41.46
 Example-wise Jaccard    33.16
 Example-wise Precision  52.38
 Example-wise Recall     37.41
@@ -115,7 +115,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         79.29
+Example-wise F1         45.1
 Example-wise Jaccard    36.44
 Example-wise Precision  55.95
 Example-wise Recall     41.16
@@ -136,7 +136,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         79.13
+Example-wise F1         44.95
 Example-wise Jaccard    36.14
 Example-wise Precision  55.95
 Example-wise Recall     40.99
@@ -157,7 +157,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         79.05
+Example-wise F1         45.88
 Example-wise Jaccard    37.03
 Example-wise Precision  58.16
 Example-wise Recall     41.24
@@ -178,7 +178,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         79.05
+Example-wise F1         46.39
 Example-wise Jaccard    37.56
 Example-wise Precision  58.33
 Example-wise Recall     42.01
@@ -199,7 +199,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         79.37
+Example-wise F1         46.21
 Example-wise Jaccard    37.47
 Example-wise Precision  57.91
 Example-wise Recall     42.01
@@ -220,7 +220,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         78.27
+Example-wise F1         46.12
 Example-wise Jaccard    36.96
 Example-wise Precision  57.82
 Example-wise Recall     42.09
@@ -241,7 +241,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         79.2
+Example-wise F1         46.55
 Example-wise Jaccard    37.77
 Example-wise Precision  57.74
 Example-wise Recall     42.43
@@ -262,7 +262,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         79.78
+Example-wise F1         46.11
 Example-wise Jaccard    37.52
 Example-wise Precision  56.97
 Example-wise Recall     42.09
@@ -283,7 +283,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         79.51
+Example-wise F1         47.36
 Example-wise Jaccard    38.62
 Example-wise Precision  58.59
 Example-wise Recall     43.11
@@ -304,7 +304,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         79.68
+Example-wise F1         47.53
 Example-wise Jaccard    38.88
 Example-wise Precision  58.84
 Example-wise Recall     43.11
@@ -325,7 +325,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         80.51
+Example-wise F1         47.35
 Example-wise Jaccard    38.96
 Example-wise Precision  58.08
 Example-wise Recall     43.11
@@ -346,7 +346,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         80.51
+Example-wise F1         47.35
 Example-wise Jaccard    38.96
 Example-wise Precision  58.33
 Example-wise Recall     43.03
@@ -367,7 +367,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         80.43
+Example-wise F1         47.26
 Example-wise Jaccard    38.79
 Example-wise Precision  58.25
 Example-wise Recall     43.28
@@ -388,7 +388,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         80.41
+Example-wise F1         45.2
 Example-wise Jaccard    36.96
 Example-wise Precision  55.78
 Example-wise Recall     41.33
@@ -409,7 +409,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         80.6
+Example-wise F1         45.9
 Example-wise Jaccard    37.77
 Example-wise Precision  56.04
 Example-wise Recall     42.35

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_sparse.txt
@@ -12,7 +12,7 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         82.48
+Example-wise F1         65.65
 Example-wise Jaccard    57.65
 Example-wise Precision  72.62
 Example-wise Recall     65.39

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_sparse_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-example-wise_sparse_incremental.txt
@@ -12,7 +12,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         81.16
+Example-wise F1         53.61
 Example-wise Jaccard    44.98
 Example-wise Precision  68.11
 Example-wise Recall     47.62
@@ -33,7 +33,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         82.69
+Example-wise F1         60.24
 Example-wise Jaccard    52.13
 Example-wise Precision  71.77
 Example-wise Recall     56.12
@@ -54,7 +54,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         82.28
+Example-wise F1         64.42
 Example-wise Jaccard    56.25
 Example-wise Precision  74.49
 Example-wise Recall     61.73
@@ -75,7 +75,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         82.14
+Example-wise F1         63.78
 Example-wise Jaccard    55.48
 Example-wise Precision  73.47
 Example-wise Recall     61.31
@@ -96,7 +96,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         81.97
+Example-wise F1         64.63
 Example-wise Jaccard    56.42
 Example-wise Precision  73.38
 Example-wise Recall     63.01
@@ -117,7 +117,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         81.84
+Example-wise F1         65.51
 Example-wise Jaccard    57.4
 Example-wise Precision  73.89
 Example-wise Recall     64.12
@@ -138,7 +138,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         82.24
+Example-wise F1         64.9
 Example-wise Jaccard    56.93
 Example-wise Precision  72.96
 Example-wise Recall     63.61
@@ -159,7 +159,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         82.91
+Example-wise F1         64.03
 Example-wise Jaccard    56.38
 Example-wise Precision  71.43
 Example-wise Recall     63.18
@@ -180,7 +180,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         82.26
+Example-wise F1         64.4
 Example-wise Jaccard    56.42
 Example-wise Precision  72.11
 Example-wise Recall     63.61
@@ -201,7 +201,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         82.24
+Example-wise F1         65.41
 Example-wise Jaccard    57.27
 Example-wise Precision  73.72
 Example-wise Recall     64.2
@@ -222,7 +222,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         81.89
+Example-wise F1         65.05
 Example-wise Jaccard    56.76
 Example-wise Precision  73.47
 Example-wise Recall     63.78
@@ -243,7 +243,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         81.89
+Example-wise F1         65.05
 Example-wise Jaccard    56.76
 Example-wise Precision  73.21
 Example-wise Recall     64.2
@@ -264,7 +264,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         82.53
+Example-wise F1         65.19
 Example-wise Jaccard    57.1
 Example-wise Precision  72.79
 Example-wise Recall     64.46
@@ -285,7 +285,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         81.8
+Example-wise F1         64.97
 Example-wise Jaccard    56.59
 Example-wise Precision  73.38
 Example-wise Recall     64.03
@@ -306,7 +306,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         82.28
+Example-wise F1         64.93
 Example-wise Jaccard    56.76
 Example-wise Precision  72.7
 Example-wise Recall     64.2
@@ -327,7 +327,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         82.35
+Example-wise F1         64.49
 Example-wise Jaccard    56.38
 Example-wise Precision  71.94
 Example-wise Recall     64.12
@@ -348,7 +348,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         82.09
+Example-wise F1         65.26
 Example-wise Jaccard    57.06
 Example-wise Precision  72.7
 Example-wise Recall     64.88
@@ -369,7 +369,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         82.4
+Example-wise F1         64.54
 Example-wise Jaccard    56.46
 Example-wise Precision  71.6
 Example-wise Recall     64.54
@@ -390,7 +390,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         82.57
+Example-wise F1         64.71
 Example-wise Jaccard    56.72
 Example-wise Precision  71.34
 Example-wise Recall     64.88
@@ -411,7 +411,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         82.48
+Example-wise F1         65.65
 Example-wise Jaccard    57.65
 Example-wise Precision  72.62
 Example-wise Recall     65.39

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm.txt
@@ -10,7 +10,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         43.85
+Example-wise F1         39.26
 Example-wise Jaccard    31.25
 Example-wise Precision  69.64
 Example-wise Recall     51.53

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm_incremental.txt
@@ -10,7 +10,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         57.15
+Example-wise F1         56.13
 Example-wise Jaccard    41.11
 Example-wise Precision  43.34
 Example-wise Recall     87.76
@@ -31,7 +31,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         60.83
+Example-wise F1         59.81
 Example-wise Jaccard    45.54
 Example-wise Precision  48.4
 Example-wise Recall     89.88
@@ -52,7 +52,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         62.06
+Example-wise F1         61.04
 Example-wise Jaccard    47.39
 Example-wise Precision  51.47
 Example-wise Recall     88.86
@@ -73,7 +73,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         60.03
+Example-wise F1         59.01
 Example-wise Jaccard    46.05
 Example-wise Precision  54.56
 Example-wise Recall     84.52
@@ -94,7 +94,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         58.03
+Example-wise F1         55.99
 Example-wise Jaccard    43.79
 Example-wise Precision  57.03
 Example-wise Recall     78.83
@@ -115,7 +115,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         56.56
+Example-wise F1         55.54
 Example-wise Jaccard    43.78
 Example-wise Precision  58.55
 Example-wise Recall     77.98
@@ -136,7 +136,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         55.28
+Example-wise F1         54.26
 Example-wise Jaccard    42.86
 Example-wise Precision  59.67
 Example-wise Recall     76.02
@@ -157,7 +157,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         54.41
+Example-wise F1         51.86
 Example-wise Jaccard    40.95
 Example-wise Precision  60.37
 Example-wise Recall     71.43
@@ -178,7 +178,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         53.44
+Example-wise F1         50.38
 Example-wise Jaccard    39.6
 Example-wise Precision  60.7
 Example-wise Recall     69.22
@@ -199,7 +199,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         54.83
+Example-wise F1         51.26
 Example-wise Jaccard    40.44
 Example-wise Precision  61.69
 Example-wise Recall     68.96
@@ -220,7 +220,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         54.43
+Example-wise F1         50.86
 Example-wise Jaccard    40.08
 Example-wise Precision  62.01
 Example-wise Recall     68.03
@@ -241,7 +241,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         54.3
+Example-wise F1         50.21
 Example-wise Jaccard    39.73
 Example-wise Precision  63.16
 Example-wise Recall     66.92
@@ -262,7 +262,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         52.45
+Example-wise F1         48.37
 Example-wise Jaccard    38.01
 Example-wise Precision  63.13
 Example-wise Recall     64.46
@@ -283,7 +283,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         50.7
+Example-wise F1         46.62
 Example-wise Jaccard    36.51
 Example-wise Precision  64.13
 Example-wise Recall     61.73
@@ -304,7 +304,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         51.21
+Example-wise F1         46.62
 Example-wise Jaccard    36.84
 Example-wise Precision  64.99
 Example-wise Recall     60.97
@@ -325,7 +325,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         50.04
+Example-wise F1         45.45
 Example-wise Jaccard    35.8
 Example-wise Precision  65.4
 Example-wise Recall     59.52
@@ -346,7 +346,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         47.98
+Example-wise F1         43.39
 Example-wise Jaccard    34.04
 Example-wise Precision  65.47
 Example-wise Recall     57.48
@@ -367,7 +367,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         47.05
+Example-wise F1         42.46
 Example-wise Jaccard    33.66
 Example-wise Precision  67.47
 Example-wise Recall     56.12
@@ -388,7 +388,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         46.01
+Example-wise F1         41.42
 Example-wise Jaccard    33.17
 Example-wise Precision  69.1
 Example-wise Recall     53.83
@@ -409,7 +409,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         43.85
+Example-wise F1         39.26
 Example-wise Jaccard    31.25
 Example-wise Precision  69.64
 Example-wise Recall     51.53

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm_sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm_sparse.txt
@@ -10,7 +10,7 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         43.85
+Example-wise F1         39.26
 Example-wise Jaccard    31.25
 Example-wise Precision  69.64
 Example-wise Recall     51.53

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm_sparse_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-gfm_sparse_incremental.txt
@@ -10,7 +10,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         57.15
+Example-wise F1         56.13
 Example-wise Jaccard    41.11
 Example-wise Precision  43.34
 Example-wise Recall     87.76
@@ -31,7 +31,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         60.83
+Example-wise F1         59.81
 Example-wise Jaccard    45.54
 Example-wise Precision  48.4
 Example-wise Recall     89.88
@@ -52,7 +52,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         62.06
+Example-wise F1         61.04
 Example-wise Jaccard    47.39
 Example-wise Precision  51.47
 Example-wise Recall     88.86
@@ -73,7 +73,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         60.03
+Example-wise F1         59.01
 Example-wise Jaccard    46.05
 Example-wise Precision  54.56
 Example-wise Recall     84.52
@@ -94,7 +94,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         58.03
+Example-wise F1         55.99
 Example-wise Jaccard    43.79
 Example-wise Precision  57.03
 Example-wise Recall     78.83
@@ -115,7 +115,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         56.56
+Example-wise F1         55.54
 Example-wise Jaccard    43.78
 Example-wise Precision  58.55
 Example-wise Recall     77.98
@@ -136,7 +136,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         55.28
+Example-wise F1         54.26
 Example-wise Jaccard    42.86
 Example-wise Precision  59.67
 Example-wise Recall     76.02
@@ -157,7 +157,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         54.41
+Example-wise F1         51.86
 Example-wise Jaccard    40.95
 Example-wise Precision  60.37
 Example-wise Recall     71.43
@@ -178,7 +178,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         53.44
+Example-wise F1         50.38
 Example-wise Jaccard    39.6
 Example-wise Precision  60.7
 Example-wise Recall     69.22
@@ -199,7 +199,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         54.83
+Example-wise F1         51.26
 Example-wise Jaccard    40.44
 Example-wise Precision  61.69
 Example-wise Recall     68.96
@@ -220,7 +220,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         54.43
+Example-wise F1         50.86
 Example-wise Jaccard    40.08
 Example-wise Precision  62.01
 Example-wise Recall     68.03
@@ -241,7 +241,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         54.3
+Example-wise F1         50.21
 Example-wise Jaccard    39.73
 Example-wise Precision  63.16
 Example-wise Recall     66.92
@@ -262,7 +262,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         52.45
+Example-wise F1         48.37
 Example-wise Jaccard    38.01
 Example-wise Precision  63.13
 Example-wise Recall     64.46
@@ -283,7 +283,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         50.7
+Example-wise F1         46.62
 Example-wise Jaccard    36.51
 Example-wise Precision  64.13
 Example-wise Recall     61.73
@@ -304,7 +304,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         51.21
+Example-wise F1         46.62
 Example-wise Jaccard    36.84
 Example-wise Precision  64.99
 Example-wise Recall     60.97
@@ -325,7 +325,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         50.04
+Example-wise F1         45.45
 Example-wise Jaccard    35.8
 Example-wise Precision  65.4
 Example-wise Recall     59.52
@@ -346,7 +346,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         47.98
+Example-wise F1         43.39
 Example-wise Jaccard    34.04
 Example-wise Precision  65.47
 Example-wise Recall     57.48
@@ -367,7 +367,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         47.05
+Example-wise F1         42.46
 Example-wise Jaccard    33.66
 Example-wise Precision  67.47
 Example-wise Recall     56.12
@@ -388,7 +388,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         46.01
+Example-wise F1         41.42
 Example-wise Jaccard    33.17
 Example-wise Precision  69.1
 Example-wise Recall     53.83
@@ -409,7 +409,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         43.85
+Example-wise F1         39.26
 Example-wise Jaccard    31.25
 Example-wise Precision  69.64
 Example-wise Recall     51.53

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_based-on-probabilities.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_based-on-probabilities.txt
@@ -10,7 +10,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         73.57
+Example-wise F1         59.8
 Example-wise Jaccard    51.36
 Example-wise Precision  71.94
 Example-wise Recall     61.31

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_incremental.txt
@@ -12,7 +12,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         53.1
+Example-wise F1         41.36
 Example-wise Jaccard    34.78
 Example-wise Precision  83.93
 Example-wise Recall     37.41
@@ -33,7 +33,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         64.2
+Example-wise F1         52.46
 Example-wise Jaccard    45.96
 Example-wise Precision  82.27
 Example-wise Recall     50.17
@@ -54,7 +54,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         66.97
+Example-wise F1         56.76
 Example-wise Jaccard    50
 Example-wise Precision  81.59
 Example-wise Recall     55.87
@@ -75,7 +75,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         67.26
+Example-wise F1         55.53
 Example-wise Jaccard    48.85
 Example-wise Precision  79.76
 Example-wise Recall     54.93
@@ -96,7 +96,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         69.61
+Example-wise F1         57.36
 Example-wise Jaccard    50.43
 Example-wise Precision  78.66
 Example-wise Recall     56.89
@@ -117,7 +117,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         69.95
+Example-wise F1         58.21
 Example-wise Jaccard    51.45
 Example-wise Precision  78.74
 Example-wise Recall     57.74
@@ -138,7 +138,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         69.76
+Example-wise F1         57.52
 Example-wise Jaccard    50.89
 Example-wise Precision  78.32
 Example-wise Recall     57.14
@@ -159,7 +159,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         68.47
+Example-wise F1         57.24
 Example-wise Jaccard    50.77
 Example-wise Precision  79.34
 Example-wise Recall     57.14
@@ -180,7 +180,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         68.59
+Example-wise F1         57.36
 Example-wise Jaccard    50.64
 Example-wise Precision  79
 Example-wise Recall     57.4
@@ -201,7 +201,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         69.15
+Example-wise F1         58.44
 Example-wise Jaccard    51.57
 Example-wise Precision  79.85
 Example-wise Recall     58.5
@@ -222,7 +222,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         69.64
+Example-wise F1         58.93
 Example-wise Jaccard    51.83
 Example-wise Precision  79.59
 Example-wise Recall     58.84
@@ -243,7 +243,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         68.28
+Example-wise F1         58.59
 Example-wise Jaccard    51.57
 Example-wise Precision  80.36
 Example-wise Recall     59.01
@@ -264,7 +264,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         67.74
+Example-wise F1         58.55
 Example-wise Jaccard    51.66
 Example-wise Precision  80.95
 Example-wise Recall     59.01
@@ -285,7 +285,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         67.52
+Example-wise F1         58.33
 Example-wise Jaccard    51.15
 Example-wise Precision  81.04
 Example-wise Recall     58.59
@@ -306,7 +306,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         67.23
+Example-wise F1         58.55
 Example-wise Jaccard    51.49
 Example-wise Precision  81.38
 Example-wise Recall     58.93
@@ -327,7 +327,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         68.06
+Example-wise F1         58.88
 Example-wise Jaccard    51.7
 Example-wise Precision  80.61
 Example-wise Recall     59.44
@@ -348,7 +348,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         67.33
+Example-wise F1         59.17
 Example-wise Jaccard    52
 Example-wise Precision  81.04
 Example-wise Recall     59.95
@@ -369,7 +369,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         68.15
+Example-wise F1         59.47
 Example-wise Jaccard    52.17
 Example-wise Precision  80.44
 Example-wise Recall     60.37
@@ -390,7 +390,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         68.06
+Example-wise F1         59.9
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.88
@@ -411,7 +411,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_incremental_based-on-probabilities.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_incremental_based-on-probabilities.txt
@@ -10,7 +10,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         72.57
+Example-wise F1         55.22
 Example-wise Jaccard    44.94
 Example-wise Precision  55.1
 Example-wise Recall     63.01
@@ -31,7 +31,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         72.93
+Example-wise F1         60.68
 Example-wise Jaccard    50.31
 Example-wise Precision  64.71
 Example-wise Recall     65.31
@@ -52,7 +52,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         72.31
+Example-wise F1         61.6
 Example-wise Jaccard    51.25
 Example-wise Precision  66.58
 Example-wise Recall     66.5
@@ -73,7 +73,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         70.41
+Example-wise F1         60.2
 Example-wise Jaccard    49.51
 Example-wise Precision  68.28
 Example-wise Recall     64.03
@@ -94,7 +94,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         70.66
+Example-wise F1         60.97
 Example-wise Jaccard    50.36
 Example-wise Precision  69.73
 Example-wise Recall     64.63
@@ -115,7 +115,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         70.97
+Example-wise F1         61.28
 Example-wise Jaccard    51.16
 Example-wise Precision  71.6
 Example-wise Recall     64.29
@@ -136,7 +136,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         71.29
+Example-wise F1         60.58
 Example-wise Jaccard    50.31
 Example-wise Precision  69.98
 Example-wise Recall     64.03
@@ -157,7 +157,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         72.69
+Example-wise F1         61.46
 Example-wise Jaccard    51.57
 Example-wise Precision  71.6
 Example-wise Recall     64.03
@@ -178,7 +178,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         70.99
+Example-wise F1         60.27
 Example-wise Jaccard    50.68
 Example-wise Precision  71.51
 Example-wise Recall     63.18
@@ -199,7 +199,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         70.7
+Example-wise F1         60.49
 Example-wise Jaccard    50.87
 Example-wise Precision  72.7
 Example-wise Recall     63.01
@@ -220,7 +220,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         70.7
+Example-wise F1         59.98
 Example-wise Jaccard    50.27
 Example-wise Precision  72.11
 Example-wise Recall     62.5
@@ -241,7 +241,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         71.26
+Example-wise F1         60.54
 Example-wise Jaccard    51.06
 Example-wise Precision  72.79
 Example-wise Recall     62.84
@@ -262,7 +262,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         72.23
+Example-wise F1         60.49
 Example-wise Jaccard    51.66
 Example-wise Precision  73.3
 Example-wise Recall     62.24
@@ -283,7 +283,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         72.82
+Example-wise F1         61.09
 Example-wise Jaccard    52.08
 Example-wise Precision  72.7
 Example-wise Recall     63.27
@@ -304,7 +304,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         73.79
+Example-wise F1         61.55
 Example-wise Jaccard    52.68
 Example-wise Precision  73.21
 Example-wise Recall     62.84
@@ -325,7 +325,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         72.48
+Example-wise F1         61.26
 Example-wise Jaccard    52.3
 Example-wise Precision  73.81
 Example-wise Recall     62.59
@@ -346,7 +346,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         72.59
+Example-wise F1         60.85
 Example-wise Jaccard    52.04
 Example-wise Precision  73.3
 Example-wise Recall     62.33
@@ -367,7 +367,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         72.81
+Example-wise F1         60.56
 Example-wise Jaccard    51.79
 Example-wise Precision  72.96
 Example-wise Recall     62.07
@@ -388,7 +388,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         72.47
+Example-wise F1         60.22
 Example-wise Jaccard    51.53
 Example-wise Precision  72.96
 Example-wise Recall     61.82
@@ -409,7 +409,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         73.57
+Example-wise F1         59.8
 Example-wise Jaccard    51.36
 Example-wise Precision  71.94
 Example-wise Recall     61.31

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_sparse.txt
@@ -12,7 +12,7 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_sparse_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/predictor-binary-label-wise_sparse_incremental.txt
@@ -12,7 +12,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         53.1
+Example-wise F1         41.36
 Example-wise Jaccard    34.78
 Example-wise Precision  83.93
 Example-wise Recall     37.41
@@ -33,7 +33,7 @@ INFO Predicting for 196 test examples using a model of size 100...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 100:
 
-Example-wise F1         64.2
+Example-wise F1         52.46
 Example-wise Jaccard    45.96
 Example-wise Precision  82.27
 Example-wise Recall     50.17
@@ -54,7 +54,7 @@ INFO Predicting for 196 test examples using a model of size 150...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 150:
 
-Example-wise F1         66.97
+Example-wise F1         56.76
 Example-wise Jaccard    50
 Example-wise Precision  81.59
 Example-wise Recall     55.87
@@ -75,7 +75,7 @@ INFO Predicting for 196 test examples using a model of size 200...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 200:
 
-Example-wise F1         67.26
+Example-wise F1         55.53
 Example-wise Jaccard    48.85
 Example-wise Precision  79.76
 Example-wise Recall     54.93
@@ -96,7 +96,7 @@ INFO Predicting for 196 test examples using a model of size 250...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 250:
 
-Example-wise F1         69.61
+Example-wise F1         57.36
 Example-wise Jaccard    50.43
 Example-wise Precision  78.66
 Example-wise Recall     56.89
@@ -117,7 +117,7 @@ INFO Predicting for 196 test examples using a model of size 300...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 300:
 
-Example-wise F1         69.95
+Example-wise F1         58.21
 Example-wise Jaccard    51.45
 Example-wise Precision  78.74
 Example-wise Recall     57.74
@@ -138,7 +138,7 @@ INFO Predicting for 196 test examples using a model of size 350...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 350:
 
-Example-wise F1         69.76
+Example-wise F1         57.52
 Example-wise Jaccard    50.89
 Example-wise Precision  78.32
 Example-wise Recall     57.14
@@ -159,7 +159,7 @@ INFO Predicting for 196 test examples using a model of size 400...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 400:
 
-Example-wise F1         68.47
+Example-wise F1         57.24
 Example-wise Jaccard    50.77
 Example-wise Precision  79.34
 Example-wise Recall     57.14
@@ -180,7 +180,7 @@ INFO Predicting for 196 test examples using a model of size 450...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 450:
 
-Example-wise F1         68.59
+Example-wise F1         57.36
 Example-wise Jaccard    50.64
 Example-wise Precision  79
 Example-wise Recall     57.4
@@ -201,7 +201,7 @@ INFO Predicting for 196 test examples using a model of size 500...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 500:
 
-Example-wise F1         69.15
+Example-wise F1         58.44
 Example-wise Jaccard    51.57
 Example-wise Precision  79.85
 Example-wise Recall     58.5
@@ -222,7 +222,7 @@ INFO Predicting for 196 test examples using a model of size 550...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 550:
 
-Example-wise F1         69.64
+Example-wise F1         58.93
 Example-wise Jaccard    51.83
 Example-wise Precision  79.59
 Example-wise Recall     58.84
@@ -243,7 +243,7 @@ INFO Predicting for 196 test examples using a model of size 600...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 600:
 
-Example-wise F1         68.28
+Example-wise F1         58.59
 Example-wise Jaccard    51.57
 Example-wise Precision  80.36
 Example-wise Recall     59.01
@@ -264,7 +264,7 @@ INFO Predicting for 196 test examples using a model of size 650...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 650:
 
-Example-wise F1         67.74
+Example-wise F1         58.55
 Example-wise Jaccard    51.66
 Example-wise Precision  80.95
 Example-wise Recall     59.01
@@ -285,7 +285,7 @@ INFO Predicting for 196 test examples using a model of size 700...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 700:
 
-Example-wise F1         67.52
+Example-wise F1         58.33
 Example-wise Jaccard    51.15
 Example-wise Precision  81.04
 Example-wise Recall     58.59
@@ -306,7 +306,7 @@ INFO Predicting for 196 test examples using a model of size 750...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 750:
 
-Example-wise F1         67.23
+Example-wise F1         58.55
 Example-wise Jaccard    51.49
 Example-wise Precision  81.38
 Example-wise Recall     58.93
@@ -327,7 +327,7 @@ INFO Predicting for 196 test examples using a model of size 800...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 800:
 
-Example-wise F1         68.06
+Example-wise F1         58.88
 Example-wise Jaccard    51.7
 Example-wise Precision  80.61
 Example-wise Recall     59.44
@@ -348,7 +348,7 @@ INFO Predicting for 196 test examples using a model of size 850...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 850:
 
-Example-wise F1         67.33
+Example-wise F1         59.17
 Example-wise Jaccard    52
 Example-wise Precision  81.04
 Example-wise Recall     59.95
@@ -369,7 +369,7 @@ INFO Predicting for 196 test examples using a model of size 900...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 900:
 
-Example-wise F1         68.15
+Example-wise F1         59.47
 Example-wise Jaccard    52.17
 Example-wise Precision  80.44
 Example-wise Recall     60.37
@@ -390,7 +390,7 @@ INFO Predicting for 196 test examples using a model of size 950...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 950:
 
-Example-wise F1         68.06
+Example-wise F1         59.9
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.88
@@ -411,7 +411,7 @@ INFO Predicting for 196 test examples using a model of size 1000...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 1000:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/pruning-irep.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/pruning-irep.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         75.05
+Example-wise F1         64.85
 Example-wise Jaccard    55.91
 Example-wise Precision  71.34
 Example-wise Recall     69.22

--- a/python/subprojects/testbed/tests/res/out/boomer/pruning-no.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/pruning-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.23
+Example-wise F1         59.56
 Example-wise Jaccard    52.59
 Example-wise Precision  80.7
 Example-wise Recall     60.37

--- a/python/subprojects/testbed/tests/res/out/boomer/rule-induction-top-down-beam-search.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/rule-induction-top-down-beam-search.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.48
+Example-wise F1         59.23
 Example-wise Jaccard    51.57
 Example-wise Precision  77.47
 Example-wise Recall     58.93

--- a/python/subprojects/testbed/tests/res/out/boomer/sequential-post-optimization.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/sequential-post-optimization.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.69
+Example-wise F1         55.94
 Example-wise Jaccard    48.68
 Example-wise Precision  77.89
 Example-wise Recall     55.44

--- a/python/subprojects/testbed/tests/res/out/boomer/statistics-sparse_label-format-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/statistics-sparse_label-format-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         26.52
+Example-wise F1         22.37
 Example-wise Jaccard    21.92
 Example-wise Precision  95.75
 Example-wise Recall     22.03
 Hamming Accuracy        98.51
 Hamming Loss             1.49
-Macro F1                15.25
+Macro F1                11.25
 Macro Jaccard            9.98
 Macro Precision         93.62
 Macro Recall            10.22

--- a/python/subprojects/testbed/tests/res/out/boomer/statistics-sparse_label-format-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/boomer/statistics-sparse_label-format-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         26.52
+Example-wise F1         22.37
 Example-wise Jaccard    21.92
 Example-wise Precision  95.75
 Example-wise Recall     22.03
 Hamming Accuracy        98.51
 Hamming Loss             1.49
-Macro F1                15.25
+Macro F1                11.25
 Macro Jaccard            9.98
 Macro Precision         93.62
 Macro Recall            10.22

--- a/python/subprojects/testbed/tests/res/out/seco/binary-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/binary-features-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         61.02
+Example-wise F1         49.99
 Example-wise Jaccard    36.58
 Example-wise Precision  49.85
 Example-wise Recall     56.26
 Hamming Accuracy        93.8
 Hamming Loss             6.2
-Macro F1                15.52
+Macro F1                13.63
 Macro Jaccard           10.15
 Macro Precision         84.99
 Macro Recall            15.84

--- a/python/subprojects/testbed/tests/res/out/seco/binary-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/binary-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         61.02
+Example-wise F1         49.99
 Example-wise Jaccard    36.58
 Example-wise Precision  49.85
 Example-wise Recall     56.26
 Hamming Accuracy        93.8
 Hamming Loss             6.2
-Macro F1                15.52
+Macro F1                13.63
 Macro Jaccard           10.15
 Macro Precision         84.99
 Macro Recall            15.84

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_cross-validation-predefined.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_cross-validation-predefined.txt
@@ -22,7 +22,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         74.98
+Example-wise F1         54.64
 Example-wise Jaccard    44.89
 Example-wise Precision  59.55
 Example-wise Recall     60.73
@@ -50,7 +50,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 2):
 
-Example-wise F1         76.39
+Example-wise F1         57.75
 Example-wise Jaccard    49.46
 Example-wise Precision  65.82
 Example-wise Recall     60.17
@@ -78,7 +78,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 3):
 
-Example-wise F1         65.17
+Example-wise F1         55.17
 Example-wise Jaccard    45.83
 Example-wise Precision  71.94
 Example-wise Recall     56.39
@@ -106,7 +106,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 4):
 
-Example-wise F1         73.22
+Example-wise F1         56.27
 Example-wise Jaccard    47.88
 Example-wise Precision  65.82
 Example-wise Recall     58.76
@@ -134,7 +134,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 5):
 
-Example-wise F1         67.72
+Example-wise F1         57.55
 Example-wise Jaccard    48.45
 Example-wise Precision  66.53
 Example-wise Recall     64.69
@@ -162,7 +162,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 6):
 
-Example-wise F1         72.88
+Example-wise F1         54.24
 Example-wise Jaccard    46.19
 Example-wise Precision  65.25
 Example-wise Recall     57.91
@@ -190,7 +190,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 7):
 
-Example-wise F1         66.95
+Example-wise F1         48.62
 Example-wise Jaccard    39.97
 Example-wise Precision  65.67
 Example-wise Recall     50.83
@@ -218,7 +218,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 8):
 
-Example-wise F1         71.24
+Example-wise F1         55.99
 Example-wise Jaccard    47.46
 Example-wise Precision  66.81
 Example-wise Recall     60.17
@@ -246,7 +246,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 9):
 
-Example-wise F1         69.61
+Example-wise F1         54.36
 Example-wise Jaccard    46.44
 Example-wise Precision  65.08
 Example-wise Recall     60.73
@@ -274,7 +274,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 10):
 
-Example-wise F1         64.41
+Example-wise F1         52.75
 Example-wise Jaccard    43.47
 Example-wise Precision  66.11
 Example-wise Recall     61.67
@@ -293,7 +293,7 @@ Subset Accuracy         15
 
 INFO Evaluation result for test data (Average across 10 folds):
 
-Example-wise F1         70.26  ±3.93
+Example-wise F1         54.73  ±2.51
 Example-wise Jaccard    46     ±2.61
 Example-wise Precision  65.86  ±2.82
 Example-wise Recall     59.21  ±3.50

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_cross-validation.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_cross-validation.txt
@@ -13,7 +13,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.63
+Example-wise F1         56.63
 Example-wise Jaccard    46.67
 Example-wise Precision  68.33
 Example-wise Recall     60.56
@@ -41,7 +41,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 2):
 
-Example-wise F1         71.6
+Example-wise F1         51.6
 Example-wise Jaccard    43.44
 Example-wise Precision  59.86
 Example-wise Recall     57.22
@@ -69,7 +69,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 3):
 
-Example-wise F1         68.94
+Example-wise F1         55.61
 Example-wise Jaccard    46.11
 Example-wise Precision  67.22
 Example-wise Recall     60
@@ -97,7 +97,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 4):
 
-Example-wise F1         70.85
+Example-wise F1         52.2
 Example-wise Jaccard    43.47
 Example-wise Precision  60.17
 Example-wise Recall     56.5
@@ -125,7 +125,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 5):
 
-Example-wise F1         70.32
+Example-wise F1         58.46
 Example-wise Jaccard    49.15
 Example-wise Precision  66.53
 Example-wise Recall     65.82
@@ -153,7 +153,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 6):
 
-Example-wise F1         68.62
+Example-wise F1         49.98
 Example-wise Jaccard    40.73
 Example-wise Precision  59.32
 Example-wise Recall     55.08
@@ -181,7 +181,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 7):
 
-Example-wise F1         70.27
+Example-wise F1         56.71
 Example-wise Jaccard    47.88
 Example-wise Precision  69.92
 Example-wise Recall     60.17
@@ -209,7 +209,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 8):
 
-Example-wise F1         74.01
+Example-wise F1         57.06
 Example-wise Jaccard    49.21
 Example-wise Precision  67.51
 Example-wise Recall     61.3
@@ -237,7 +237,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 9):
 
-Example-wise F1         74.41
+Example-wise F1         55.76
 Example-wise Jaccard    46.89
 Example-wise Precision  66.67
 Example-wise Recall     58.76
@@ -265,13 +265,13 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 10):
 
-Example-wise F1         72.77
+Example-wise F1         57.51
 Example-wise Jaccard    50
 Example-wise Precision  71.47
 Example-wise Recall     61.3
 Hamming Accuracy        77.68
 Hamming Loss            22.32
-Macro F1                69.42
+Macro F1                52.75
 Macro Jaccard           39.98
 Macro Precision         54.41
 Macro Recall            54.27
@@ -284,13 +284,13 @@ Subset Accuracy         28.81
 
 INFO Evaluation result for test data (Average across 10 folds):
 
-Example-wise F1         70.84  ±2.32
+Example-wise F1         55.15  ±2.71
 Example-wise Jaccard    46.36  ±2.84
 Example-wise Precision  65.7   ±4.13
 Example-wise Recall     59.67  ±2.87
 Hamming Accuracy        75.27  ±2.45
 Hamming Loss            24.73  ±2.45
-Macro F1                54.44  ±6.26
+Macro F1                52.78  ±3.78
 Macro Jaccard           39.31  ±3.89
 Macro Precision         67.41  ±6.53
 Macro Recall            57.25  ±4.20

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_incremental.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_incremental.txt
@@ -12,7 +12,7 @@ INFO Predicting for 196 test examples using a model of size 50...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 50:
 
-Example-wise F1         67.4
+Example-wise F1         52.09
 Example-wise Jaccard    43.17
 Example-wise Precision  65.23
 Example-wise Recall     56.46
@@ -33,7 +33,7 @@ INFO Predicting for 196 test examples using a model of size 62...
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data using a model of size 62:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_no-data-split.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_no-data-split.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for training data:
 
-Example-wise F1         74.34
+Example-wise F1         66.41
 Example-wise Jaccard    57.36
 Example-wise Precision  75.11
 Example-wise Recall     69.59

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_single-fold.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_single-fold.txt
@@ -13,7 +13,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.63
+Example-wise F1         56.63
 Example-wise Jaccard    46.67
 Example-wise Precision  68.33
 Example-wise Recall     60.56

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_train-test-predefined.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_train-test-predefined.txt
@@ -13,7 +13,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.41
+Example-wise F1         52.59
 Example-wise Jaccard    43.14
 Example-wise Precision  64.13
 Example-wise Recall     54.29

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_train-test.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_train-test.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/evaluation_training-data.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/evaluation_training-data.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for training data:
 
-Example-wise F1         72.41
+Example-wise F1         65.36
 Example-wise Jaccard    56.87
 Example-wise Precision  77.02
 Example-wise Recall     68.93
@@ -35,7 +35,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_binary-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_binary-features-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         61.02
+Example-wise F1         49.99
 Example-wise Jaccard    36.58
 Example-wise Precision  49.85
 Example-wise Recall     56.26
 Hamming Accuracy        93.8
 Hamming Loss             6.2
-Macro F1                15.52
+Macro F1                13.63
 Macro Jaccard           10.15
 Macro Precision         84.99
 Macro Recall            15.84

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_binary-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_binary-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         61.02
+Example-wise F1         49.99
 Example-wise Jaccard    36.58
 Example-wise Precision  49.85
 Example-wise Recall     56.26
 Hamming Accuracy        93.8
 Hamming Loss             6.2
-Macro F1                15.52
+Macro F1                13.63
 Macro Jaccard           10.15
 Macro Precision         84.99
 Macro Recall            15.84

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_nominal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_nominal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.34
+Example-wise F1         55.5
 Example-wise Jaccard    45.33
 Example-wise Precision  60.51
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_nominal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_nominal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.34
+Example-wise F1         55.5
 Example-wise Jaccard    45.33
 Example-wise Precision  60.51
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_numerical-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_numerical-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.74
+Example-wise F1         56.95
 Example-wise Jaccard    47.88
 Example-wise Precision  63.78
 Example-wise Recall     63.1

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_numerical-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-frequency_numerical-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.84
+Example-wise F1         56.56
 Example-wise Jaccard    46.98
 Example-wise Precision  63.29
 Example-wise Recall     61.99
 Hamming Accuracy        74.23
 Hamming Loss            25.77
-Macro F1                69.45
+Macro F1                52.79
 Macro Jaccard           38.87
 Macro Precision         52.53
 Macro Recall            57.85

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_binary-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_binary-features-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         61.02
+Example-wise F1         49.99
 Example-wise Jaccard    36.58
 Example-wise Precision  49.85
 Example-wise Recall     56.26
 Hamming Accuracy        93.8
 Hamming Loss             6.2
-Macro F1                15.52
+Macro F1                13.63
 Macro Jaccard           10.15
 Macro Precision         84.99
 Macro Recall            15.84

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_binary-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_binary-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         61.02
+Example-wise F1         49.99
 Example-wise Jaccard    36.58
 Example-wise Precision  49.85
 Example-wise Recall     56.26
 Hamming Accuracy        93.8
 Hamming Loss             6.2
-Macro F1                15.52
+Macro F1                13.63
 Macro Jaccard           10.15
 Macro Precision         84.99
 Macro Recall            15.84

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_nominal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_nominal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.34
+Example-wise F1         55.5
 Example-wise Jaccard    45.33
 Example-wise Precision  60.51
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_nominal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_nominal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.34
+Example-wise F1         55.5
 Example-wise Jaccard    45.33
 Example-wise Precision  60.51
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_numerical-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_numerical-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.48
+Example-wise F1         59.26
 Example-wise Jaccard    48.75
 Example-wise Precision  59.49
 Example-wise Recall     69.73

--- a/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_numerical-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-binning-equal-width_numerical-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.48
+Example-wise F1         59.26
 Example-wise Jaccard    48.75
 Example-wise Precision  59.49
 Example-wise Recall     69.73

--- a/python/subprojects/testbed/tests/res/out/seco/feature-sampling-no.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-sampling-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/feature-sampling-without-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/feature-sampling-without-replacement.txt
@@ -12,13 +12,13 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.79
+Example-wise F1         49.93
 Example-wise Jaccard    41.43
 Example-wise Precision  63.66
 Example-wise Recall     54.08
 Hamming Accuracy        72.19
 Hamming Loss            27.81
-Macro F1                66.06
+Macro F1                49.39
 Macro Jaccard           35.12
 Macro Precision         48.77
 Macro Recall            51.58

--- a/python/subprojects/testbed/tests/res/out/seco/heuristic_accuracy.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/heuristic_accuracy.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         28.66
+Example-wise F1         11.31
 Example-wise Jaccard     8.16
 Example-wise Precision  82.65
 Example-wise Recall      8.16

--- a/python/subprojects/testbed/tests/res/out/seco/heuristic_f-measure.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/heuristic_f-measure.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/heuristic_laplace.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/heuristic_laplace.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         65.74
+Example-wise F1         51.46
 Example-wise Jaccard    42.28
 Example-wise Precision  64.27
 Example-wise Recall     57.4

--- a/python/subprojects/testbed/tests/res/out/seco/heuristic_m-estimate.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/heuristic_m-estimate.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.25
+Example-wise F1         57.48
 Example-wise Jaccard    47.95
 Example-wise Precision  65.39
 Example-wise Recall     62.59

--- a/python/subprojects/testbed/tests/res/out/seco/heuristic_precision.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/heuristic_precision.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         65.89
+Example-wise F1         52.12
 Example-wise Jaccard    42.64
 Example-wise Precision  62.24
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/heuristic_recall.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/heuristic_recall.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         79.97
+Example-wise F1         37.11
 Example-wise Jaccard    30.44
 Example-wise Precision  37.5
 Example-wise Recall     38.78

--- a/python/subprojects/testbed/tests/res/out/seco/heuristic_wra.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/heuristic_wra.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.41
+Example-wise F1         53.61
 Example-wise Jaccard    44.23
 Example-wise Precision  64.89
 Example-wise Recall     58.42

--- a/python/subprojects/testbed/tests/res/out/seco/instance-sampling-no.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/instance-sampling-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         65.25
+Example-wise F1         50.45
 Example-wise Jaccard    40.83
 Example-wise Precision  61.14
 Example-wise Recall     58.59

--- a/python/subprojects/testbed/tests/res/out/seco/instance-sampling-stratified-example-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/instance-sampling-stratified-example-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.93
+Example-wise F1         54.58
 Example-wise Jaccard    45.14
 Example-wise Precision  62.87
 Example-wise Recall     58.76

--- a/python/subprojects/testbed/tests/res/out/seco/instance-sampling-stratified-label-wise.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/instance-sampling-stratified-label-wise.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/instance-sampling-with-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/instance-sampling-with-replacement.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.11
+Example-wise F1         53.78
 Example-wise Jaccard    43.94
 Example-wise Precision  57.22
 Example-wise Recall     60.54

--- a/python/subprojects/testbed/tests/res/out/seco/instance-sampling-without-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/instance-sampling-without-replacement.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.27
+Example-wise F1         52.94
 Example-wise Jaccard    44.28
 Example-wise Precision  63.36
 Example-wise Recall     58.76

--- a/python/subprojects/testbed/tests/res/out/seco/label-format-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/label-format-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/label-format-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/label-format-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/label-sampling-no.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/label-sampling-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/label-sampling-round-robin.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/label-sampling-round-robin.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.03
+Example-wise F1         53.74
 Example-wise Jaccard    44.84
 Example-wise Precision  66.16
 Example-wise Recall     59.1

--- a/python/subprojects/testbed/tests/res/out/seco/label-sampling-without-replacement.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/label-sampling-without-replacement.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.49
+Example-wise F1         50.63
 Example-wise Jaccard    42.6
 Example-wise Precision  62.53
 Example-wise Recall     56.38

--- a/python/subprojects/testbed/tests/res/out/seco/model-persistence_cross-validation.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/model-persistence_cross-validation.txt
@@ -11,7 +11,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.63
+Example-wise F1         56.63
 Example-wise Jaccard    46.67
 Example-wise Precision  68.33
 Example-wise Recall     60.56
@@ -37,7 +37,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 2):
 
-Example-wise F1         71.6
+Example-wise F1         51.6
 Example-wise Jaccard    43.44
 Example-wise Precision  59.86
 Example-wise Recall     57.22
@@ -63,7 +63,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 3):
 
-Example-wise F1         68.94
+Example-wise F1         55.61
 Example-wise Jaccard    46.11
 Example-wise Precision  67.22
 Example-wise Recall     60
@@ -89,7 +89,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 4):
 
-Example-wise F1         70.85
+Example-wise F1         52.2
 Example-wise Jaccard    43.47
 Example-wise Precision  60.17
 Example-wise Recall     56.5
@@ -115,7 +115,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 5):
 
-Example-wise F1         70.32
+Example-wise F1         58.46
 Example-wise Jaccard    49.15
 Example-wise Precision  66.53
 Example-wise Recall     65.82
@@ -141,7 +141,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 6):
 
-Example-wise F1         68.62
+Example-wise F1         49.98
 Example-wise Jaccard    40.73
 Example-wise Precision  59.32
 Example-wise Recall     55.08
@@ -167,7 +167,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 7):
 
-Example-wise F1         70.27
+Example-wise F1         56.71
 Example-wise Jaccard    47.88
 Example-wise Precision  69.92
 Example-wise Recall     60.17
@@ -193,7 +193,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 8):
 
-Example-wise F1         74.01
+Example-wise F1         57.06
 Example-wise Jaccard    49.21
 Example-wise Precision  67.51
 Example-wise Recall     61.3
@@ -219,7 +219,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 9):
 
-Example-wise F1         74.41
+Example-wise F1         55.76
 Example-wise Jaccard    46.89
 Example-wise Precision  66.67
 Example-wise Recall     58.76
@@ -245,13 +245,13 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 10):
 
-Example-wise F1         72.77
+Example-wise F1         57.51
 Example-wise Jaccard    50
 Example-wise Precision  71.47
 Example-wise Recall     61.3
 Hamming Accuracy        77.68
 Hamming Loss            22.32
-Macro F1                69.42
+Macro F1                52.75
 Macro Jaccard           39.98
 Macro Precision         54.41
 Macro Recall            54.27
@@ -264,13 +264,13 @@ Subset Accuracy         28.81
 
 INFO Evaluation result for test data (Average across 10 folds):
 
-Example-wise F1         70.84  ±2.32
+Example-wise F1         55.15  ±2.71
 Example-wise Jaccard    46.36  ±2.84
 Example-wise Precision  65.7   ±4.13
 Example-wise Recall     59.67  ±2.87
 Hamming Accuracy        75.27  ±2.45
 Hamming Loss            24.73  ±2.45
-Macro F1                54.44  ±6.26
+Macro F1                52.78  ±3.78
 Macro Jaccard           39.31  ±3.89
 Macro Precision         67.41  ±6.53
 Macro Recall            57.25  ±4.20

--- a/python/subprojects/testbed/tests/res/out/seco/model-persistence_single-fold.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/model-persistence_single-fold.txt
@@ -11,7 +11,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data (Fold 1):
 
-Example-wise F1         66.63
+Example-wise F1         56.63
 Example-wise Jaccard    46.67
 Example-wise Precision  68.33
 Example-wise Recall     60.56

--- a/python/subprojects/testbed/tests/res/out/seco/model-persistence_train-test.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/model-persistence_train-test.txt
@@ -10,7 +10,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/nominal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/nominal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.34
+Example-wise F1         55.5
 Example-wise Jaccard    45.33
 Example-wise Precision  60.51
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/seco/nominal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/nominal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         72.34
+Example-wise F1         55.5
 Example-wise Jaccard    45.33
 Example-wise Precision  60.51
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/seco/numeric-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/numeric-features-dense.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         47.29
+Example-wise F1         27.58
 Example-wise Jaccard    25.96
 Example-wise Precision  76.63
 Example-wise Recall     28.73
 Hamming Accuracy        98.23
 Hamming Loss             1.77
-Macro F1                17.54
+Macro F1                12.2
 Macro Jaccard           10.54
 Macro Precision         80.63
 Macro Recall            11.65

--- a/python/subprojects/testbed/tests/res/out/seco/numeric-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/numeric-features-sparse.txt
@@ -12,13 +12,13 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         44
+Example-wise F1         27.41
 Example-wise Jaccard    26.09
 Example-wise Precision  80.78
 Example-wise Recall     28.15
 Hamming Accuracy        98.31
 Hamming Loss             1.69
-Macro F1                14.7
+Macro F1                12.03
 Macro Jaccard           10.45
 Macro Precision         84.63
 Macro Recall            11.37

--- a/python/subprojects/testbed/tests/res/out/seco/ordinal-features-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/ordinal-features-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         71.75
+Example-wise F1         56.95
 Example-wise Jaccard    48.17
 Example-wise Precision  67.6
 Example-wise Recall     60.29

--- a/python/subprojects/testbed/tests/res/out/seco/ordinal-features-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/ordinal-features-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.69
+Example-wise F1         55.43
 Example-wise Jaccard    46.53
 Example-wise Precision  68.7
 Example-wise Recall     59.01

--- a/python/subprojects/testbed/tests/res/out/seco/partial-heads_kln-lift-function.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/partial-heads_kln-lift-function.txt
@@ -12,13 +12,13 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         68.31
+Example-wise F1         55.05
 Example-wise Jaccard    46.16
 Example-wise Precision  66.34
 Example-wise Recall     59.86
 Hamming Accuracy        74.49
 Hamming Loss            25.51
-Macro F1                69.33
+Macro F1                52.66
 Macro Jaccard           38.66
 Macro Precision         52.21
 Macro Recall            56.23

--- a/python/subprojects/testbed/tests/res/out/seco/partial-heads_no-lift-function.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/partial-heads_no-lift-function.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/partial-heads_peak-lift-function.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/partial-heads_peak-lift-function.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         73.45
+Example-wise F1         54.06
 Example-wise Jaccard    45.2
 Example-wise Precision  63.18
 Example-wise Recall     56.97

--- a/python/subprojects/testbed/tests/res/out/seco/prediction-format-dense.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/prediction-format-dense.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/prediction-format-sparse.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/prediction-format-sparse.txt
@@ -12,7 +12,7 @@ DEBUG A sparse matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_accuracy.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_accuracy.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_f-measure.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_f-measure.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.27
+Example-wise F1         54.45
 Example-wise Jaccard    45.4
 Example-wise Precision  62.45
 Example-wise Recall     60.63

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_laplace.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_laplace.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.5
+Example-wise F1         53.17
 Example-wise Jaccard    44.17
 Example-wise Precision  62.85
 Example-wise Recall     58.67

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_m-estimate.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_m-estimate.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.27
+Example-wise F1         54.45
 Example-wise Jaccard    45.4
 Example-wise Precision  62.45
 Example-wise Recall     60.63

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_precision.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_precision.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.72
+Example-wise F1         53.39
 Example-wise Jaccard    44.31
 Example-wise Precision  62.21
 Example-wise Recall     59.1

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_recall.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_recall.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.55
+Example-wise F1         56.29
 Example-wise Jaccard    46.89
 Example-wise Precision  62.79
 Example-wise Recall     63.35

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_wra.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-heuristic_wra.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.67
+Example-wise F1         54.88
 Example-wise Jaccard    45.65
 Example-wise Precision  62.7
 Example-wise Recall     61.14

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-irep.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-irep.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.27
+Example-wise F1         52.94
 Example-wise Jaccard    44.28
 Example-wise Precision  63.36
 Example-wise Recall     58.76

--- a/python/subprojects/testbed/tests/res/out/seco/pruning-no.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/pruning-no.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.05
+Example-wise F1         54.8
 Example-wise Jaccard    44.97
 Example-wise Precision  63.54
 Example-wise Recall     61.73

--- a/python/subprojects/testbed/tests/res/out/seco/rule-induction-top-down-beam-search.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/rule-induction-top-down-beam-search.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         67.68
+Example-wise F1         51.36
 Example-wise Jaccard    42.57
 Example-wise Precision  62.53
 Example-wise Recall     57.06

--- a/python/subprojects/testbed/tests/res/out/seco/sequential-post-optimization.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/sequential-post-optimization.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         70.25
+Example-wise F1         57.49
 Example-wise Jaccard    48.25
 Example-wise Precision  64.74
 Example-wise Recall     64.71

--- a/python/subprojects/testbed/tests/res/out/seco/single-label-heads.txt
+++ b/python/subprojects/testbed/tests/res/out/seco/single-label-heads.txt
@@ -12,7 +12,7 @@ DEBUG A dense matrix is used to store the predicted labels
 INFO Successfully predicted in <duration>
 INFO Evaluation result for test data:
 
-Example-wise F1         69.53
+Example-wise F1         53.72
 Example-wise Jaccard    44.55
 Example-wise Precision  63.06
 Example-wise Recall     59.18


### PR DESCRIPTION
Updates the dependency "scikit-learn" to version 1.4 or greater. Appearently, the library's implementation of the F1 metric has changed. For this reason, the expected output of the integration tests needed to be adjusted.