### PR TITLE
Fix MacOS build

### DIFF
--- a/.github/workflows/template_publish_platform.yml
+++ b/.github/workflows/template_publish_platform.yml
@@ -33,9 +33,7 @@ jobs:
           echo "Set version to $(cat VERSION)"
       - name: Install OpenMP
         if: matrix.os == 'macos-latest'
-        run: |
-          brew install libomp
-          brew link libomp --force
+        run: brew install libomp
       - name: Prepare MSVC
         if: matrix.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1
@@ -43,7 +41,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.17
         env:
           CIBW_BEFORE_BUILD_LINUX: ./build --clean && SUBPROJECTS=${{ inputs.subproject }} TEST_SUPPORT=disabled GPU_SUPPORT=disabled ./build install
-          CIBW_BEFORE_BUILD_MACOS: rm -rf venv && ./build --clean && SUBPROJECTS=${{ inputs.subproject }} TEST_SUPPORT=disabled GPU_SUPPORT=disabled ./build install
+          CIBW_BEFORE_BUILD_MACOS: rm -rf venv && ./build --clean && SUBPROJECTS=${{ inputs.subproject }} TEST_SUPPORT=disabled GPU_SUPPORT=disabled CPLUS_INCLUDE_PATH=/opt/homebrew/opt/libomp/include/ LIBRARY_PATH=/opt/homebrew/opt/libomp/lib/ ./build install
           CIBW_BEFORE_BUILD_WINDOWS: .\build.bat --clean && set SUBPROJECTS=${{ inputs.subproject }} && set TEST_SUPPORT=disabled && set GPU_SUPPORT=disabled && .\build.bat install
           CIBW_BUILD_FRONTEND: build
           CIBW_ARCHS: auto64

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -123,9 +123,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install OpenMP
-        run: |
-          brew install libomp
-          brew link libomp --force
+        run: brew install libomp
       - name: Install OpenCL
         run: brew install opencl-clhpp-headers
       - name: Prepare ccache
@@ -133,7 +131,7 @@ jobs:
         with:
           key: ${{ runner.os }}-test-build-ccache
       - name: Compile via Clang
-        run: TEST_SUPPORT=disabled CPLUS_INCLUDE_PATH=/usr/local/opt/opencl-clhpp-headers/include ./build compile
+        run: TEST_SUPPORT=disabled CPLUS_INCLUDE_PATH=/opt/homebrew/opt/libomp/include/:/opt/homebrew/opt/opencl-clhpp-headers/include/ LIBRARY_PATH=/opt/homebrew/opt/libomp/lib/ ./build compile
   windows_build:
     needs: changes
     if: ${{ needs.changes.outputs.cpp == 'true' }}


### PR DESCRIPTION
For MacOS builds conducted via CI, we install the dependency OpenMP using Homebrew. Since recently, creating symlinks to the dependency's include directory and library files via `brew link libomp --force` is not supported anymore. This results in the library not being found. To fix this, we now provide the paths to all relevant include directories and library files via the environment variables `CPLUS_INCLUDE_PATH` and `LIBRARY_PATH`.