### PR TITLE
Use Github workflow runner "macos-13" for publishing packages

### DIFF
--- a/.github/workflows/template_publish_non_native.yml
+++ b/.github/workflows/template_publish_non_native.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           platforms: all
       - name: Build package
-        uses: pypa/cibuildwheel@v2.17
+        uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BEFORE_BUILD_LINUX: ./build --clean && SUBPROJECTS=${{ inputs.subproject }} TEST_SUPPORT=disabled GPU_SUPPORT=disabled
             ./build install

--- a/.github/workflows/template_publish_platform.yml
+++ b/.github/workflows/template_publish_platform.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build package
-        uses: pypa/cibuildwheel@v2.17
+        uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BEFORE_BUILD_LINUX: ./build --clean && SUBPROJECTS=${{ inputs.subproject }} TEST_SUPPORT=disabled GPU_SUPPORT=disabled
             ./build install


### PR DESCRIPTION
Fixes the CI workflow for publishing packages, which currently suffers from a broken MacOS build.