### PR TITLE
Revert "Do not treat compiler warnings as errors."

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -1,4 +1,4 @@
-project('mlrl', meson_version : '>=1.1')
+project('mlrl', meson_version : '>=1.1', default_options : ['werror=true'])
 
 subprojects = get_option('subprojects')
 


### PR DESCRIPTION
This reverts commit 2396bdd96dfd8ddcef22c76558695026d8666ad8.